### PR TITLE
Use microsoft base images

### DIFF
--- a/build/windows/microsoftservercore/Dockerfile
+++ b/build/windows/microsoftservercore/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:windowsservercore
+FROM microsoft/windowsservercore
 
 COPY dist /
 

--- a/build/windows/nanoserver/Dockerfile
+++ b/build/windows/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:nanoserver
+FROM microsoft/nanoserver
 
 COPY dist /
 


### PR DESCRIPTION
The Windows docker images could be much smaller if the standard base images are used to COPY all files into it.
