### PR TITLE
Add Linux ARM support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,10 @@ mv dist/* /tmp/portainer-build-win/portainer
 cd /tmp/portainer-build-win
 tar cvpfz portainer-${VERSION}-windows-amd64.tar.gz portainer
 
+grunt release-arm
+rm -rf /tmp/portainer-build-arm && mkdir -pv /tmp/portainer-build-arm/portainer
+mv dist/* /tmp/portainer-build-arm/portainer
+cd /tmp/portainer-build-arm
+tar cvpfz portainer-${VERSION}-linux-arm.tar.gz portainer
+
 exit 0

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -47,6 +47,18 @@ module.exports = function (grunt) {
         'recess:min',
         'copy'
     ]);
+    grunt.registerTask('release-arm', [
+        'clean:all',
+        'if:unixArmBinaryNotExist',
+        'html2js',
+        'uglify',
+        'clean:tmpl',
+        'jshint',
+        //'karma:unit',
+        'concat:index',
+        'recess:min',
+        'copy'
+    ]);
     grunt.registerTask('lint', ['jshint']);
     grunt.registerTask('test-watch', ['karma:watch']);
     grunt.registerTask('run', ['if:unixBinaryNotExist', 'build', 'shell:buildImage', 'shell:run']);
@@ -275,6 +287,14 @@ module.exports = function (grunt) {
                     'mv api/portainer dist/'
                 ].join(' && ')
             },
+            buildUnixArmBinary: {
+                command: [
+                    'docker run --rm -v $(pwd)/api:/src -e BUILD_GOOS="linux" -e BUILD_GOARCH="arm" centurylink/golang-builder-cross',
+                    'shasum api/portainer-linux-arm > portainer-checksum.txt',
+                    'mkdir -p dist',
+                    'mv api/portainer-linux-arm dist/portainer'
+                ].join(' && ')
+            },
             buildWindowsBinary: {
                 command: [
                     'docker run --rm -v $(pwd)/api:/src -e BUILD_GOOS="windows" -e BUILD_GOARCH="amd64" centurylink/golang-builder-cross',
@@ -314,6 +334,12 @@ module.exports = function (grunt) {
                   executable: 'dist/portainer'
               },
               ifFalse: ['shell:buildBinary']
+            },
+            unixArmBinaryNotExist: {
+              options: {
+                  executable: 'dist/portainer'
+              },
+              ifFalse: ['shell:buildUnixArmBinary']
             },
             windowsBinaryNotExist: {
               options: {


### PR DESCRIPTION
With this PR you can build a Linux ARM binary as well.

``` bash
grunt release-arm
export DOCKER_HOST=tcp://<ip-address-of-your-raspbery-pi>:2375
docker build -t portainer -f build/linux/Dockerfile .
docker run -d -p 9000:9000 -v /var/run/docker.sock:/var/run/docker.sock portainer
open http://<ip-address-of-your-raspbery-pi>:9000
```

![bildschirmfoto 2016-10-30 um 13 51 18](https://cloud.githubusercontent.com/assets/207759/19836679/1ca3283e-9ea8-11e6-81ec-81a7425943e7.png)

Would be great if you push the portainer/portainer:arm (or portainer/portainer:armhf) docker image as well.
