### PR TITLE
feat: add clickable url in breadcrumbs

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -3,7 +3,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Containers > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a>
+    <a ui-sref="containers">Containers</a> > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a>
   </rd-header-content>
 </rd-header>
 

--- a/app/components/containerConsole/containerConsole.html
+++ b/app/components/containerConsole/containerConsole.html
@@ -3,7 +3,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content ng-if="state.loaded">
-    Containers > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Console
+    <a ui-sref="containers">Containers</a> > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Console
   </rd-header-content>
 </rd-header>
 

--- a/app/components/containerLogs/containerlogs.html
+++ b/app/components/containerLogs/containerlogs.html
@@ -3,7 +3,7 @@
       <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Containers > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Logs
+    <a ui-sref="containers">Containers</a> > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Logs
   </rd-header-content>
 </rd-header>
 

--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Create container"></rd-header-title>
   <rd-header-content>
-    Containers > Add container
+    <a ui-sref="containers">Containers</a> > Add container
   </rd-header-content>
 </rd-header>
 

--- a/app/components/createNetwork/createnetwork.html
+++ b/app/components/createNetwork/createnetwork.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Create network"></rd-header-title>
   <rd-header-content>
-    Networks > Add network
+    <a ui-sref="networks">Networks</a> > Add network
   </rd-header-content>
 </rd-header>
 

--- a/app/components/createService/createservice.html
+++ b/app/components/createService/createservice.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Create service"></rd-header-title>
   <rd-header-content>
-    Services > Add service
+    <a ui-sref="services">Services</a> > Add service
   </rd-header-content>
 </rd-header>
 

--- a/app/components/createVolume/createvolume.html
+++ b/app/components/createVolume/createvolume.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Create volume"></rd-header-title>
   <rd-header-content>
-    Volumes > Add volume
+    <a ui-sref="volumes">Volumes</a> > Add volume
   </rd-header-content>
 </rd-header>
 

--- a/app/components/image/image.html
+++ b/app/components/image/image.html
@@ -3,7 +3,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Images > <a ui-sref="image({id: image.Id})">{{ image.Id }}</a>
+    <a ui-sref="images">Images</a> > <a ui-sref="image({id: image.Id})">{{ image.Id }}</a>
   </rd-header-content>
 </rd-header>
 

--- a/app/components/network/network.html
+++ b/app/components/network/network.html
@@ -3,7 +3,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Networks > <a ui-sref="network({id: network.Id})">{{ network.Name }}</a>
+    <a ui-sref="networks">Networks</a> > <a ui-sref="network({id: network.Id})">{{ network.Name }}</a>
   </rd-header-content>
 </rd-header>
 

--- a/app/components/service/service.html
+++ b/app/components/service/service.html
@@ -6,7 +6,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Services > <a ui-sref="service({id: service.Id})">{{ service.Name }}</a>
+    <a ui-sref="services">Services</a> > <a ui-sref="service({id: service.Id})">{{ service.Name }}</a>
   </rd-header-content>
 </rd-header>
 

--- a/app/components/stats/stats.html
+++ b/app/components/stats/stats.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Container stats"></rd-header-title>
   <rd-header-content>
-    Containers > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Stats
+    <a ui-sref="containers">Containers</a> > <a ui-sref="container({id: container.Id})">{{ container.Name|trimcontainername }}</a> > Stats
   </rd-header-content>
 </rd-header>
 

--- a/app/components/task/task.html
+++ b/app/components/task/task.html
@@ -3,7 +3,7 @@
     <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
   </rd-header-title>
   <rd-header-content>
-    Services > <a ui-sref="service({id: task.ServiceID})">{{ serviceName }}</a> > {{ task.ID }}
+    <a ui-sref="services">Services</a> > <a ui-sref="service({id: task.ServiceID})">{{ serviceName }}</a> > {{ task.ID }}
   </rd-header-content>
 </rd-header>
 


### PR DESCRIPTION
- change the first item in breadcrumbs to a clickable url

When playing around with portainer I found that that I was missing the ability to click on the first item in the breadcrumbs to navigate to it. More so, because the last item often is clickable, it felt weird without it.
