### PR TITLE
Fix leaving a network in container view

### DIFF
--- a/app/components/container/containerController.js
+++ b/app/components/container/containerController.js
@@ -162,7 +162,7 @@ function ($scope, $state, $stateParams, $filter, Container, ContainerCommit, Ima
       } else {
         $('#loadingViewSpinner').hide();
         Messages.send("Container left network", $stateParams.id);
-        $state.go('network', {id: network.Id}, {reload: true});
+        $state.go('container', {id: $stateParams.id}, {reload: true});
       }
     }, function (e) {
       $('#loadingViewSpinner').hide();


### PR DESCRIPTION
- When clicking leave network you will now stay on the container page
- The page will be refreshed

Fix #336.
