### PR TITLE
#361 fix(templates): fixes an issue regarding template selection when paged

### DIFF
--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -121,7 +121,7 @@
       </rd-widget-header>
       <rd-widget-body classes="padding">
         <div class="template-list">
-          <div dir-paginate="tpl in templates | itemsPerPage: pagination_count" class="container-template hvr-underline-from-center" id="template_{{ $index }}" ng-click="selectTemplate($index)">
+          <div dir-paginate="tpl in templates | itemsPerPage: pagination_count" class="container-template hvr-underline-from-center" id="template_{{ tpl.index }}" ng-click="selectTemplate(tpl.index)">
             <img class="logo" ng-src="{{ tpl.logo }}" />
             <div class="title">{{ tpl.title }}</div>
             <div class="description">{{ tpl.description }}</div>

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -184,7 +184,10 @@ function ($scope, $q, $state, $filter, Config, Info, Container, ContainerHelper,
 
   function initTemplates() {
     Templates.get(function (data) {
-      $scope.templates = data;
+      $scope.templates = data.map(function(tpl,index){
+        tpl.index = index;
+        return tpl;
+      });
       $('#loadTemplatesSpinner').hide();
     }, function (e) {
       $('#loadTemplatesSpinner').hide();


### PR DESCRIPTION
`$index` was causing issues as it was only the index of the currently visible items.

I chose `index` instead of `id` to as to not cause headache down the line incase the Template objects actually get IDs.

Fixes #361 