### PR TITLE
Fix loading text displayed when no volumes present

### DIFF
--- a/app/components/volumes/volumesController.js
+++ b/app/components/volumes/volumesController.js
@@ -54,7 +54,7 @@ function ($scope, $state, Volume, Messages) {
   function fetchVolumes() {
     $('#loadVolumesSpinner').show();
     Volume.query({}, function (d) {
-      $scope.volumes = d.Volumes;
+      $scope.volumes = d.Volumes || [];
       $('#loadVolumesSpinner').hide();
     }, function (e) {
       $('#loadVolumesSpinner').hide();


### PR DESCRIPTION
Volumes is undefined when no volumes are present. The loading text will remain until volumes is defined. Fix #368.