### PR TITLE
feat(templates): add support for the template registry field

### DIFF
--- a/app/components/container/containerController.js
+++ b/app/components/container/containerController.js
@@ -77,7 +77,7 @@ function ($scope, $state, $stateParams, $filter, Container, ContainerCommit, Ima
     $('#createImageSpinner').show();
     var image = _.toLower($scope.config.Image);
     var registry = _.toLower($scope.config.Registry);
-    var imageConfig = ImageHelper.createImageConfig(image, registry);
+    var imageConfig = ImageHelper.createImageConfigForCommit(image, registry);
     ContainerCommit.commit({id: $stateParams.id, tag: imageConfig.tag, repo: imageConfig.repo}, function (d) {
       $('#createImageSpinner').hide();
       update();

--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -1,6 +1,6 @@
 angular.module('createContainer', [])
-.controller('CreateContainerController', ['$scope', '$state', '$stateParams', '$filter', 'Config', 'Info', 'Container', 'ContainerHelper', 'Image', 'Volume', 'Network', 'Messages',
-function ($scope, $state, $stateParams, $filter, Config, Info, Container, ContainerHelper, Image, Volume, Network, Messages) {
+.controller('CreateContainerController', ['$scope', '$state', '$stateParams', '$filter', 'Config', 'Info', 'Container', 'ContainerHelper', 'Image', 'ImageHelper', 'Volume', 'Network', 'Messages',
+function ($scope, $state, $stateParams, $filter, Config, Info, Container, ContainerHelper, Image, ImageHelper, Volume, Network, Messages) {
 
   $scope.formValues = {
     alwaysPull: true,
@@ -143,23 +143,10 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
     });
   }
 
-  function createImageConfig(imageName, registry) {
-    var imageNameAndTag = imageName.split(':');
-    var image = imageNameAndTag[0];
-    if (registry) {
-      image = registry + '/' + imageNameAndTag[0];
-    }
-    var imageConfig = {
-      fromImage: image,
-      tag: imageNameAndTag[1] ? imageNameAndTag[1] : 'latest'
-    };
-    return imageConfig;
-  }
-
   function prepareImageConfig(config) {
     var image = _.toLower(config.Image);
     var registry = $scope.formValues.Registry;
-    var imageConfig = createImageConfig(image, registry);
+    var imageConfig = ImageHelper.createImageConfigForContainer(image, registry);
     config.Image = imageConfig.fromImage + ':' + imageConfig.tag;
     $scope.imageConfig = imageConfig;
   }

--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -69,8 +69,8 @@ function ($scope, $state, Service, Volume, Network, ImageHelper, Messages) {
   };
 
   function prepareImageConfig(config, input) {
-    var imageConfig = ImageHelper.createImageConfig(input.Image, input.Registry);
-    config.TaskTemplate.ContainerSpec.Image = imageConfig.repo + ':' + imageConfig.tag;
+    var imageConfig = ImageHelper.createImageConfigForContainer(input.Image, input.Registry);
+    config.TaskTemplate.ContainerSpec.Image = imageConfig.fromImage + ':' + imageConfig.tag;
   }
 
   function preparePortsConfig(config, input) {

--- a/app/components/image/imageController.js
+++ b/app/components/image/imageController.js
@@ -23,7 +23,7 @@ function ($scope, $stateParams, $state, Image, ImageHelper, Messages) {
     $('#loadingViewSpinner').show();
     var image = _.toLower($scope.config.Image);
     var registry = _.toLower($scope.config.Registry);
-    var imageConfig = ImageHelper.createImageConfig(image, registry);
+    var imageConfig = ImageHelper.createImageConfigForCommit(image, registry);
     Image.tag({id: $stateParams.id, tag: imageConfig.tag, repo: imageConfig.repo}, function (d) {
       Messages.send('Image successfully tagged');
       $('#loadingViewSpinner').hide();

--- a/app/components/images/imagesController.js
+++ b/app/components/images/imagesController.js
@@ -1,6 +1,6 @@
 angular.module('images', [])
-.controller('ImagesController', ['$scope', '$state', 'Config', 'Image', 'Messages', 'Settings',
-function ($scope, $state, Config, Image, Messages, Settings) {
+.controller('ImagesController', ['$scope', '$state', 'Config', 'Image', 'ImageHelper', 'Messages', 'Settings',
+function ($scope, $state, Config, Image, ImageHelper, Messages, Settings) {
   $scope.state = {};
   $scope.sortType = 'RepoTags';
   $scope.sortReverse = true;
@@ -25,24 +25,11 @@ function ($scope, $state, Config, Image, Messages, Settings) {
     }
   };
 
-  function createImageConfig(imageName, registry) {
-    var imageNameAndTag = imageName.split(':');
-    var image = imageNameAndTag[0];
-    if (registry) {
-      image = registry + '/' + imageNameAndTag[0];
-    }
-    var imageConfig = {
-      fromImage: image,
-      tag: imageNameAndTag[1] ? imageNameAndTag[1] : 'latest'
-    };
-    return imageConfig;
-  }
-
   $scope.pullImage = function() {
     $('#pullImageSpinner').show();
     var image = _.toLower($scope.config.Image);
     var registry = _.toLower($scope.config.Registry);
-    var imageConfig = createImageConfig(image, registry);
+    var imageConfig = ImageHelper.createImageConfigForContainer(image, registry);
     Image.create(imageConfig, function (data) {
         var err = data.length > 0 && data[data.length - 1].hasOwnProperty('error');
         if (err) {

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -1,6 +1,6 @@
 angular.module('templates', [])
-.controller('TemplatesController', ['$scope', '$q', '$state', '$filter', 'Config', 'Info', 'Container', 'ContainerHelper', 'Image', 'Volume', 'Network', 'Templates', 'TemplateHelper', 'Messages', 'Settings',
-function ($scope, $q, $state, $filter, Config, Info, Container, ContainerHelper, Image, Volume, Network, Templates, TemplateHelper, Messages, Settings) {
+.controller('TemplatesController', ['$scope', '$q', '$state', '$filter', 'Config', 'Info', 'Container', 'ContainerHelper', 'Image', 'ImageHelper', 'Volume', 'Network', 'Templates', 'TemplateHelper', 'Messages', 'Settings',
+function ($scope, $q, $state, $filter, Config, Info, Container, ContainerHelper, Image, ImageHelper, Volume, Network, Templates, TemplateHelper, Messages, Settings) {
   $scope.state = {
     selectedTemplate: null,
     showAdvancedOptions: false
@@ -129,7 +129,16 @@ function ($scope, $q, $state, $filter, Config, Info, Container, ContainerHelper,
       });
     }
     preparePortBindings(containerConfig, $scope.formValues.ports);
+    prepareImageConfig(containerConfig, template);
     return containerConfig;
+  }
+
+  function prepareImageConfig(config, template) {
+    var image = _.toLower(template.image);
+    var registry = template.registry;
+    var imageConfig = ImageHelper.createImageConfigForContainer(image, registry);
+    config.Image = imageConfig.fromImage + ':' + imageConfig.tag;
+    $scope.imageConfig = imageConfig;
   }
 
   function prepareVolumeQueries(template, containerConfig) {
@@ -158,13 +167,9 @@ function ($scope, $q, $state, $filter, Config, Info, Container, ContainerHelper,
     $('#createContainerSpinner').show();
     var template = $scope.state.selectedTemplate;
     var containerConfig = createConfigFromTemplate(template);
-    var imageConfig = {
-      fromImage: template.image.split(':')[0],
-      tag: template.image.split(':')[1] ? template.image.split(':')[1] : 'latest'
-    };
     var createVolumeQueries = prepareVolumeQueries(template, containerConfig);
     $q.all(createVolumeQueries).then(function (d) {
-      pullImageAndCreateContainer(imageConfig, containerConfig);
+      pullImageAndCreateContainer($scope.imageConfig, containerConfig);
     });
   };
 

--- a/app/shared/helpers.js
+++ b/app/shared/helpers.js
@@ -2,7 +2,7 @@ angular.module('portainer.helpers', [])
 .factory('ImageHelper', [function ImageHelperFactory() {
   'use strict';
   return {
-    createImageConfig: function(imageName, registry) {
+    createImageConfigForCommit: function(imageName, registry) {
       var imageNameAndTag = imageName.split(':');
       var image = imageNameAndTag[0];
       if (registry) {
@@ -10,6 +10,18 @@ angular.module('portainer.helpers', [])
       }
       var imageConfig = {
         repo: image,
+        tag: imageNameAndTag[1] ? imageNameAndTag[1] : 'latest'
+      };
+      return imageConfig;
+    },
+    createImageConfigForContainer: function (imageName, registry) {
+      var imageNameAndTag = imageName.split(':');
+      var image = imageNameAndTag[0];
+      if (registry) {
+        image = registry + '/' + imageNameAndTag[0];
+      }
+      var imageConfig = {
+        fromImage: image,
         tag: imageNameAndTag[1] ? imageNameAndTag[1] : 'latest'
       };
       return imageConfig;


### PR DESCRIPTION
This PR brings support for the field `registry` in any template definition. This field is optional and if not defined, portainer will pull the template image from the Dockerhub.

Documentation of the templates must be updated.

Close #311 
