### PR TITLE
feat(global): multi endpoint management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 bower_components
 dist
 portainer-checksum.txt
-api/cmd/portainer/portainer-*
+api/cmd/portainer/portainer*

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -20,9 +20,10 @@ type Store struct {
 }
 
 const (
-	databaseFileName   = "portainer.db"
-	userBucketName     = "users"
-	endpointBucketName = "endpoints"
+	databaseFileName         = "portainer.db"
+	userBucketName           = "users"
+	endpointBucketName       = "endpoints"
+	activeEndpointBucketName = "activeEndpoint"
 )
 
 // NewStore initializes a new Store and the associated services
@@ -51,6 +52,10 @@ func (store *Store) Open() error {
 			return err
 		}
 		_, err = tx.CreateBucketIfNotExists([]byte(endpointBucketName))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(activeEndpointBucketName))
 		if err != nil {
 			return err
 		}

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -1,8 +1,9 @@
 package bolt
 
 import (
-	"github.com/boltdb/bolt"
 	"time"
+
+	"github.com/boltdb/bolt"
 )
 
 // Store defines the implementation of portainer.DataStore using
@@ -46,6 +47,10 @@ func (store *Store) Open() error {
 	store.db = db
 	return db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists([]byte(userBucketName))
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists([]byte(endpointBucketName))
 		if err != nil {
 			return err
 		}

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -12,23 +12,27 @@ type Store struct {
 	Path string
 
 	// Services
-	UserService *UserService
+	UserService     *UserService
+	EndpointService *EndpointService
 
 	db *bolt.DB
 }
 
 const (
-	databaseFileName = "portainer.db"
-	userBucketName   = "users"
+	databaseFileName   = "portainer.db"
+	userBucketName     = "users"
+	endpointBucketName = "endpoints"
 )
 
 // NewStore initializes a new Store and the associated services
 func NewStore(storePath string) *Store {
 	store := &Store{
-		Path:        storePath,
-		UserService: &UserService{},
+		Path:            storePath,
+		UserService:     &UserService{},
+		EndpointService: &EndpointService{},
 	}
 	store.UserService.store = store
+	store.EndpointService.store = store
 	return store
 }
 

--- a/api/bolt/endpoint_service.go
+++ b/api/bolt/endpoint_service.go
@@ -1,0 +1,68 @@
+package bolt
+
+import (
+	"github.com/portainer/portainer"
+	"github.com/portainer/portainer/bolt/internal"
+
+	"github.com/boltdb/bolt"
+)
+
+// EndpointService represents a service for managing users.
+type EndpointService struct {
+	store *Store
+}
+
+// Endpoint returns an endpoint by ID.
+func (service *EndpointService) Endpoint(ID portainer.EndpointID) (*portainer.Endpoint, error) {
+	var data []byte
+	err := service.store.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(endpointBucketName))
+		value := bucket.Get([]byte(internal.Itob(int(ID))))
+		if value == nil {
+			return portainer.ErrEndpointNotFound
+		}
+
+		data = make([]byte, len(value))
+		copy(data, value)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var endpoint portainer.Endpoint
+	err = internal.UnmarshalEndpoint(data, &endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}
+
+// UpdateEndpoint saves an endpoint.
+func (service *EndpointService) UpdateEndpoint(endpoint *portainer.Endpoint) error {
+	data, err := internal.MarshalEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+
+	return service.store.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(endpointBucketName))
+		err = bucket.Put([]byte(internal.Itob(int(endpoint.ID))), data)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// DeleteEndpoint deletes an endpoint.
+func (service *EndpointService) DeleteEndpoint(ID portainer.EndpointID) error {
+	return service.store.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(endpointBucketName))
+		err := bucket.Delete([]byte(internal.Itob(int(ID))))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/api/bolt/internal/internal.go
+++ b/api/bolt/internal/internal.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"github.com/portainer/portainer"
 
+	"encoding/binary"
 	"encoding/json"
 )
 
@@ -14,4 +15,23 @@ func MarshalUser(user *portainer.User) ([]byte, error) {
 // UnmarshalUser decodes a user from a binary data.
 func UnmarshalUser(data []byte, user *portainer.User) error {
 	return json.Unmarshal(data, user)
+}
+
+// MarshalEndpoint encodes an endpoint to binary format.
+func MarshalEndpoint(endpoint *portainer.Endpoint) ([]byte, error) {
+	return json.Marshal(endpoint)
+}
+
+// UnmarshalEndpoint decodes an endpoint from a binary data.
+func UnmarshalEndpoint(data []byte, endpoint *portainer.Endpoint) error {
+	return json.Unmarshal(data, endpoint)
+}
+
+// Itob returns an 8-byte big endian representation of v.
+// This function is typically used for encoding integer IDs to byte slices
+// so that they can be used as BoltDB keys.
+func Itob(v int) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
 }

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -3,9 +3,10 @@ package cli
 import (
 	"github.com/portainer/portainer"
 
-	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Service implements the CLIService interface
@@ -27,7 +28,6 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		Addr:      kingpin.Flag("bind", "Address and port to serve Portainer").Default(":9000").Short('p').String(),
 		Assets:    kingpin.Flag("assets", "Path to the assets").Default(".").Short('a').String(),
 		Data:      kingpin.Flag("data", "Path to the folder where the data is stored").Default("/data").Short('d').String(),
-		Swarm:     kingpin.Flag("swarm", "Swarm cluster support").Default("false").Short('s').Bool(),
 		Templates: kingpin.Flag("templates", "URL to the templates (apps) definitions").Default("https://raw.githubusercontent.com/portainer/templates/master/templates.json").Short('t').String(),
 		TLSVerify: kingpin.Flag("tlsverify", "TLS support").Default("false").Bool(),
 		TLSCacert: kingpin.Flag("tlscacert", "Path to the CA").Default("/certs/ca.pem").String(),

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -21,12 +21,12 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	kingpin.Version(version)
 
 	flags := &portainer.CLIFlags{
+		Endpoint:  kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
+		Logo:      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
+		Labels:    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
 		Addr:      kingpin.Flag("bind", "Address and port to serve Portainer").Default(":9000").Short('p').String(),
 		Assets:    kingpin.Flag("assets", "Path to the assets").Default(".").Short('a').String(),
 		Data:      kingpin.Flag("data", "Path to the folder where the data is stored").Default("/data").Short('d').String(),
-		Endpoint:  kingpin.Flag("host", "Dockerd endpoint").Default("unix:///var/run/docker.sock").Short('H').String(),
-		Labels:    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
-		Logo:      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
 		Swarm:     kingpin.Flag("swarm", "Swarm cluster support").Default("false").Short('s').Bool(),
 		Templates: kingpin.Flag("templates", "URL to the templates (apps) definitions").Default("https://raw.githubusercontent.com/portainer/templates/master/templates.json").Short('t').String(),
 		TLSVerify: kingpin.Flag("tlsverify", "TLS support").Default("false").Bool(),
@@ -41,17 +41,19 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 
 // ValidateFlags validates the values of the flags.
 func (*Service) ValidateFlags(flags *portainer.CLIFlags) error {
-	if !strings.HasPrefix(*flags.Endpoint, "unix://") && !strings.HasPrefix(*flags.Endpoint, "tcp://") {
-		return errInvalidEnpointProtocol
-	}
+	if *flags.Endpoint != "" {
+		if !strings.HasPrefix(*flags.Endpoint, "unix://") && !strings.HasPrefix(*flags.Endpoint, "tcp://") {
+			return errInvalidEnpointProtocol
+		}
 
-	if strings.HasPrefix(*flags.Endpoint, "unix://") {
-		socketPath := strings.TrimPrefix(*flags.Endpoint, "unix://")
-		if _, err := os.Stat(socketPath); err != nil {
-			if os.IsNotExist(err) {
-				return errSocketNotFound
+		if strings.HasPrefix(*flags.Endpoint, "unix://") {
+			socketPath := strings.TrimPrefix(*flags.Endpoint, "unix://")
+			if _, err := os.Stat(socketPath); err != nil {
+				if os.IsNotExist(err) {
+					return errSocketNotFound
+				}
+				return err
 			}
-			return err
 		}
 	}
 

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -52,12 +52,14 @@ func main() {
 	var activeEndpoint *portainer.Endpoint
 	if *flags.Endpoint != "" {
 		activeEndpoint = &portainer.Endpoint{
+			Name:          "primary",
 			URL:           *flags.Endpoint,
 			TLS:           *flags.TLSVerify,
 			TLSCACertPath: *flags.TLSCacert,
 			TLSCertPath:   *flags.TLSCert,
 			TLSKeyPath:    *flags.TLSKey,
 		}
+		store.EndpointService.CreateEndpoint(activeEndpoint)
 	}
 
 	var server portainer.Server = &http.Server{

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -25,7 +25,6 @@ func main() {
 	}
 
 	settings := &portainer.Settings{
-		Swarm:        *flags.Swarm,
 		HiddenLabels: *flags.Labels,
 		Logo:         *flags.Logo,
 	}

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/portainer/portainer/bolt"
 	"github.com/portainer/portainer/cli"
 	"github.com/portainer/portainer/crypto"
+	"github.com/portainer/portainer/file"
 	"github.com/portainer/portainer/http"
 	"github.com/portainer/portainer/jwt"
 
@@ -41,6 +42,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	fileService, err := file.NewService(*flags.Data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	var cryptoService portainer.CryptoService = &crypto.Service{}
 
 	var activeEndpoint *portainer.Endpoint
@@ -63,6 +69,7 @@ func main() {
 		EndpointService: store.EndpointService,
 		CryptoService:   cryptoService,
 		JWTService:      jwtService,
+		FileService:     fileService,
 		ActiveEndpoint:  activeEndpoint,
 	}
 

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -43,23 +43,27 @@ func main() {
 
 	var cryptoService portainer.CryptoService = &crypto.Service{}
 
-	endpointConfiguration := &portainer.EndpointConfiguration{
-		Endpoint:      *flags.Endpoint,
-		TLS:           *flags.TLSVerify,
-		TLSCACertPath: *flags.TLSCacert,
-		TLSCertPath:   *flags.TLSCert,
-		TLSKeyPath:    *flags.TLSKey,
+	var activeEndpoint *portainer.Endpoint
+	if *flags.Endpoint != "" {
+		activeEndpoint = &portainer.Endpoint{
+			URL:           *flags.Endpoint,
+			TLS:           *flags.TLSVerify,
+			TLSCACertPath: *flags.TLSCacert,
+			TLSCertPath:   *flags.TLSCert,
+			TLSKeyPath:    *flags.TLSKey,
+		}
 	}
 
 	var server portainer.Server = &http.Server{
-		BindAddress:    *flags.Addr,
-		AssetsPath:     *flags.Assets,
-		Settings:       settings,
-		TemplatesURL:   *flags.Templates,
-		UserService:    store.UserService,
-		CryptoService:  cryptoService,
-		JWTService:     jwtService,
-		EndpointConfig: endpointConfiguration,
+		BindAddress:     *flags.Addr,
+		AssetsPath:      *flags.Assets,
+		Settings:        settings,
+		TemplatesURL:    *flags.Templates,
+		UserService:     store.UserService,
+		EndpointService: store.EndpointService,
+		CryptoService:   cryptoService,
+		JWTService:      jwtService,
+		ActiveEndpoint:  activeEndpoint,
 	}
 
 	log.Printf("Starting Portainer on %s", *flags.Addr)

--- a/api/errors.go
+++ b/api/errors.go
@@ -13,6 +13,7 @@ const (
 // Endpoint errors.
 const (
 	ErrEndpointNotFound = Error("Endpoint not found")
+	ErrNoActiveEndpoint = Error("Undefined Docker endpoint")
 )
 
 // Crypto errors.
@@ -24,6 +25,11 @@ const (
 const (
 	ErrSecretGeneration = Error("Unable to generate secret key")
 	ErrInvalidJWTToken  = Error("Invalid JWT token")
+)
+
+// File errors.
+const (
+	ErrUndefinedTLSFileType = Error("Undefined TLS file type")
 )
 
 // Error represents an application error.

--- a/api/errors.go
+++ b/api/errors.go
@@ -10,6 +10,11 @@ const (
 	ErrUserNotFound = Error("User not found")
 )
 
+// Endpoint errors.
+const (
+	ErrEndpointNotFound = Error("Endpoint not found")
+)
+
 // Crypto errors.
 const (
 	ErrCryptoHashFailure = Error("Unable to hash data")

--- a/api/file/file.go
+++ b/api/file/file.go
@@ -1,0 +1,125 @@
+package file
+
+import (
+	"strconv"
+
+	"github.com/portainer/portainer"
+
+	"io"
+	"os"
+	"path"
+)
+
+const (
+	// TLSStorePath represents the subfolder where TLS files are stored in the file store folder.
+	TLSStorePath = "tls"
+	// TLSCACertFile represents the name on disk for a TLS CA file.
+	TLSCACertFile = "ca.pem"
+	// TLSCertFile represents the name on disk for a TLS certificate file.
+	TLSCertFile = "cert.pem"
+	// TLSKeyFile represents the name on disk for a TLS key file.
+	TLSKeyFile = "key.pem"
+)
+
+// Service represents a service for managing files.
+type Service struct {
+	fileStorePath string
+}
+
+// NewService initializes a new service.
+func NewService(fileStorePath string) (*Service, error) {
+	service := &Service{
+		fileStorePath: fileStorePath,
+	}
+
+	err := service.createFolderInStoreIfNotExist(TLSStorePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+// StoreTLSFile creates a subfolder in the TLSStorePath and stores a new file with the content from r.
+func (service *Service) StoreTLSFile(endpointID portainer.EndpointID, fileType portainer.TLSFileType, r io.Reader) error {
+	ID := strconv.Itoa(int(endpointID))
+	endpointStorePath := path.Join(TLSStorePath, ID)
+	err := service.createFolderInStoreIfNotExist(endpointStorePath)
+	if err != nil {
+		return err
+	}
+
+	var fileName string
+	switch fileType {
+	case portainer.TLSFileCA:
+		fileName = TLSCACertFile
+	case portainer.TLSFileCert:
+		fileName = TLSCertFile
+	case portainer.TLSFileKey:
+		fileName = TLSKeyFile
+	default:
+		return portainer.ErrUndefinedTLSFileType
+	}
+
+	tlsFilePath := path.Join(endpointStorePath, fileName)
+	err = service.createFileInStore(tlsFilePath, r)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetPathForTLSFile returns the absolute path to a specific TLS file for an endpoint.
+func (service *Service) GetPathForTLSFile(endpointID portainer.EndpointID, fileType portainer.TLSFileType) (string, error) {
+	var fileName string
+	switch fileType {
+	case portainer.TLSFileCA:
+		fileName = TLSCACertFile
+	case portainer.TLSFileCert:
+		fileName = TLSCertFile
+	case portainer.TLSFileKey:
+		fileName = TLSKeyFile
+	default:
+		return "", portainer.ErrUndefinedTLSFileType
+	}
+	ID := strconv.Itoa(int(endpointID))
+	return path.Join(service.fileStorePath, TLSStorePath, ID, fileName), nil
+}
+
+// DeleteTLSFiles deletes a folder containing the TLS files for an endpoint.
+func (service *Service) DeleteTLSFiles(endpointID portainer.EndpointID) error {
+	ID := strconv.Itoa(int(endpointID))
+	endpointPath := path.Join(service.fileStorePath, TLSStorePath, ID)
+	err := os.RemoveAll(endpointPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createFolderInStoreIfNotExist creates a new folder in the file store if it doesn't exists on the file system.
+func (service *Service) createFolderInStoreIfNotExist(name string) error {
+	path := path.Join(service.fileStorePath, name)
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		os.Mkdir(path, 0600)
+	} else if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createFile creates a new file in the file store with the content from r.
+func (service *Service) createFileInStore(filePath string, r io.Reader) error {
+	path := path.Join(service.fileStorePath, filePath)
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, r)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/file/file.go
+++ b/api/file/file.go
@@ -112,7 +112,7 @@ func (service *Service) createFolderInStoreIfNotExist(name string) error {
 // createFile creates a new file in the file store with the content from r.
 func (service *Service) createFileInStore(filePath string, r io.Reader) error {
 	path := path.Join(service.fileStorePath, filePath)
-	out, err := os.Create(path)
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/api/http/auth_handler.go
+++ b/api/http/auth_handler.go
@@ -28,7 +28,7 @@ const (
 	ErrInvalidCredentials = portainer.Error("Invalid credentials")
 )
 
-// NewAuthHandler returns a new instance of DialHandler.
+// NewAuthHandler returns a new instance of AuthHandler.
 func NewAuthHandler() *AuthHandler {
 	h := &AuthHandler{
 		Router: mux.NewRouter(),

--- a/api/http/auth_handler.go
+++ b/api/http/auth_handler.go
@@ -32,7 +32,7 @@ const (
 func NewAuthHandler() *AuthHandler {
 	h := &AuthHandler{
 		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "authhandler", log.LstdFlags),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
 	}
 	h.HandleFunc("/auth", h.handlePostAuth)
 	return h

--- a/api/http/auth_handler.go
+++ b/api/http/auth_handler.go
@@ -32,7 +32,7 @@ const (
 func NewAuthHandler() *AuthHandler {
 	h := &AuthHandler{
 		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "", log.LstdFlags),
+		Logger: log.New(os.Stderr, "authhandler", log.LstdFlags),
 	}
 	h.HandleFunc("/auth", h.handlePostAuth)
 	return h

--- a/api/http/auth_handler.go
+++ b/api/http/auth_handler.go
@@ -4,11 +4,12 @@ import (
 	"github.com/portainer/portainer"
 
 	"encoding/json"
-	"github.com/asaskevich/govalidator"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/gorilla/mux"
 )
 
 // AuthHandler represents an HTTP API handler for managing authentication.
@@ -38,8 +39,8 @@ func NewAuthHandler() *AuthHandler {
 }
 
 func (handler *AuthHandler) handlePostAuth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		handleNotAllowed(w, []string{"POST"})
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
 		return
 	}
 

--- a/api/http/docker_handler.go
+++ b/api/http/docker_handler.go
@@ -26,7 +26,7 @@ type DockerHandler struct {
 func NewDockerHandler(middleWareService *middleWareService) *DockerHandler {
 	h := &DockerHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "dockerhandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.PathPrefix("/").Handler(middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/docker_handler.go
+++ b/api/http/docker_handler.go
@@ -3,7 +3,6 @@ package http
 import (
 	"github.com/portainer/portainer"
 
-	"github.com/gorilla/mux"
 	"io"
 	"log"
 	"net"
@@ -11,6 +10,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+
+	"github.com/gorilla/mux"
 )
 
 // DockerHandler represents an HTTP API handler for proxying requests to the Docker API.
@@ -20,11 +21,6 @@ type DockerHandler struct {
 	middleWareService *middleWareService
 	proxy             http.Handler
 }
-
-const (
-	// ErrNoActiveEndpoint defines an error raised when no active endpoint is defined.
-	ErrNoActiveEndpoint = portainer.Error("Undefined Docker endpoint")
-)
 
 // NewDockerHandler returns a new instance of DockerHandler.
 func NewDockerHandler(middleWareService *middleWareService) *DockerHandler {
@@ -43,7 +39,7 @@ func (handler *DockerHandler) proxyRequestsToDockerAPI(w http.ResponseWriter, r 
 	if handler.proxy != nil {
 		handler.proxy.ServeHTTP(w, r)
 	} else {
-		Error(w, ErrNoActiveEndpoint, http.StatusNotFound, handler.Logger)
+		Error(w, portainer.ErrNoActiveEndpoint, http.StatusNotFound, handler.Logger)
 	}
 }
 
@@ -80,6 +76,7 @@ func newHTTPSProxy(u *url.URL, endpoint *portainer.Endpoint) (http.Handler, erro
 	proxy := httputil.NewSingleHostReverseProxy(u)
 	config, err := createTLSConfiguration(endpoint.TLSCACertPath, endpoint.TLSCertPath, endpoint.TLSKeyPath)
 	if err != nil {
+		log.Printf("Shit happened here: %+v", endpoint)
 		return nil, err
 	}
 	proxy.Transport = &http.Transport{

--- a/api/http/docker_handler.go
+++ b/api/http/docker_handler.go
@@ -26,7 +26,7 @@ type DockerHandler struct {
 func NewDockerHandler(middleWareService *middleWareService) *DockerHandler {
 	h := &DockerHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "dockerhandler", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.PathPrefix("/").Handler(middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,6 @@ func newHTTPSProxy(u *url.URL, endpoint *portainer.Endpoint) (http.Handler, erro
 	proxy := httputil.NewSingleHostReverseProxy(u)
 	config, err := createTLSConfiguration(endpoint.TLSCACertPath, endpoint.TLSCertPath, endpoint.TLSKeyPath)
 	if err != nil {
-		log.Printf("Shit happened here: %+v", endpoint)
 		return nil, err
 	}
 	proxy.Transport = &http.Transport{

--- a/api/http/endpoint_handler.go
+++ b/api/http/endpoint_handler.go
@@ -3,10 +3,13 @@ package http
 import (
 	"github.com/portainer/portainer"
 
+	"encoding/json"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
+	"github.com/asaskevich/govalidator"
 	"github.com/gorilla/mux"
 )
 
@@ -15,6 +18,8 @@ type EndpointHandler struct {
 	*mux.Router
 	Logger            *log.Logger
 	EndpointService   portainer.EndpointService
+	FileService       portainer.FileService
+	server            *Server
 	middleWareService *middleWareService
 }
 
@@ -27,21 +32,249 @@ func NewEndpointHandler(middleWareService *middleWareService) *EndpointHandler {
 	}
 	h.Handle("/endpoints", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.handlePostEndpoints(w, r)
-	})))
+	}))).Methods(http.MethodPost)
+	h.Handle("/endpoints", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handleGetEndpoints(w, r)
+	}))).Methods(http.MethodGet)
 	h.Handle("/endpoints/{id}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.handleGetEndpoint(w, r)
-	}))).Methods("GET")
+	}))).Methods(http.MethodGet)
+	h.Handle("/endpoints/{id}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handlePutEndpoint(w, r)
+	}))).Methods(http.MethodPut)
+	h.Handle("/endpoints/{id}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handleDeleteEndpoint(w, r)
+	}))).Methods(http.MethodDelete)
+	h.Handle("/endpoints/{id}/active", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handlePostEndpoint(w, r)
+	}))).Methods(http.MethodPost)
 	return h
 }
 
+// handleGetEndpoints handles GET requests on /endpoints
+func (handler *EndpointHandler) handleGetEndpoints(w http.ResponseWriter, r *http.Request) {
+	endpoints, err := handler.EndpointService.Endpoints()
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+	encodeJSON(w, endpoints, handler.Logger)
+}
+
 // handlePostEndpoints handles POST requests on /endpoints
+// if the active URL parameter is specified, will also define the new endpoint as the active endpoint.
+// /endpoints(?active=true|false)
 func (handler *EndpointHandler) handlePostEndpoints(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		handleNotAllowed(w, []string{http.MethodPost})
+	var req postEndpointsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, ErrInvalidJSON, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	_, err := govalidator.ValidateStruct(req)
+	if err != nil {
+		Error(w, ErrInvalidRequestFormat, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	endpoint := &portainer.Endpoint{
+		Name: req.Name,
+		URL:  req.URL,
+		TLS:  req.TLS,
+	}
+
+	err = handler.EndpointService.CreateEndpoint(endpoint)
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	if req.TLS {
+		caCertPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileCA)
+		endpoint.TLSCACertPath = caCertPath
+		certPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileCert)
+		endpoint.TLSCertPath = certPath
+		keyPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileKey)
+		endpoint.TLSKeyPath = keyPath
+		err = handler.EndpointService.UpdateEndpoint(endpoint.ID, endpoint)
+		if err != nil {
+			Error(w, err, http.StatusInternalServerError, handler.Logger)
+			return
+		}
+	}
+
+	activeEndpointParameter := r.FormValue("active")
+	if activeEndpointParameter != "" {
+		active, err := strconv.ParseBool(activeEndpointParameter)
+		if err != nil {
+			Error(w, err, http.StatusBadRequest, handler.Logger)
+			return
+		}
+		if active == true {
+			err = handler.server.updateActiveEndpoint(endpoint)
+			if err != nil {
+				Error(w, err, http.StatusInternalServerError, handler.Logger)
+				return
+			}
+		}
+	}
+
+	encodeJSON(w, &postEndpointsResponse{ID: int(endpoint.ID)}, handler.Logger)
+}
+
+type postEndpointsRequest struct {
+	Name string `valid:"alphanum,required"`
+	URL  string `valid:"required"`
+	TLS  bool
+}
+
+type postEndpointsResponse struct {
+	ID int `json:"Id"`
+}
+
+// handleGetEndpoint handles GET requests on /endpoints/:id
+// GET /endpoints/0 returns active endpoint
+func (handler *EndpointHandler) handleGetEndpoint(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	endpointID, err := strconv.Atoi(id)
+	if err != nil {
+		Error(w, err, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	var endpoint *portainer.Endpoint
+	if id == "0" {
+		endpoint = handler.server.ActiveEndpoint
+		if endpoint == nil {
+			Error(w, portainer.ErrNoActiveEndpoint, http.StatusNotFound, handler.Logger)
+			return
+		}
+	} else {
+		endpoint, err = handler.EndpointService.Endpoint(portainer.EndpointID(endpointID))
+		if err == portainer.ErrEndpointNotFound {
+			Error(w, err, http.StatusNotFound, handler.Logger)
+			return
+		} else if err != nil {
+			Error(w, err, http.StatusInternalServerError, handler.Logger)
+			return
+		}
+	}
+
+	encodeJSON(w, endpoint, handler.Logger)
+}
+
+// handlePostEndpoint handles POST requests on /endpoints/:id/active
+func (handler *EndpointHandler) handlePostEndpoint(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	endpointID, err := strconv.Atoi(id)
+	if err != nil {
+		Error(w, err, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	endpoint, err := handler.EndpointService.Endpoint(portainer.EndpointID(endpointID))
+	if err == portainer.ErrEndpointNotFound {
+		Error(w, err, http.StatusNotFound, handler.Logger)
+		return
+	} else if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	err = handler.server.updateActiveEndpoint(endpoint)
+	if err != nil {
+		log.Print("The failz")
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
 		return
 	}
 }
 
-// handleGetEndpoint handles GET requests on /endpoints/:id
-func (handler *EndpointHandler) handleGetEndpoint(w http.ResponseWriter, r *http.Request) {
+// handlePutEndpoint handles PUT requests on /endpoints/:id
+func (handler *EndpointHandler) handlePutEndpoint(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	endpointID, err := strconv.Atoi(id)
+	if err != nil {
+		Error(w, err, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	var req putEndpointsRequest
+	if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		Error(w, ErrInvalidJSON, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	_, err = govalidator.ValidateStruct(req)
+	if err != nil {
+		Error(w, ErrInvalidRequestFormat, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	endpoint := &portainer.Endpoint{
+		ID:   portainer.EndpointID(endpointID),
+		Name: req.Name,
+		URL:  req.URL,
+		TLS:  req.TLS,
+	}
+
+	if req.TLS {
+		caCertPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileCA)
+		endpoint.TLSCACertPath = caCertPath
+		certPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileCert)
+		endpoint.TLSCertPath = certPath
+		keyPath, _ := handler.FileService.GetPathForTLSFile(endpoint.ID, portainer.TLSFileKey)
+		endpoint.TLSKeyPath = keyPath
+	}
+
+	err = handler.EndpointService.UpdateEndpoint(endpoint.ID, endpoint)
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+}
+
+type putEndpointsRequest struct {
+	Name string `valid:"alphanum,required"`
+	URL  string `valid:"required"`
+	TLS  bool
+}
+
+// handleDeleteEndpoint handles DELETE requests on /endpoints/:id
+func (handler *EndpointHandler) handleDeleteEndpoint(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	endpointID, err := strconv.Atoi(id)
+	if err != nil {
+		Error(w, err, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	endpoint, err := handler.EndpointService.Endpoint(portainer.EndpointID(endpointID))
+	if err == portainer.ErrEndpointNotFound {
+		Error(w, err, http.StatusNotFound, handler.Logger)
+		return
+	} else if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	err = handler.EndpointService.DeleteEndpoint(portainer.EndpointID(endpointID))
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	if endpoint.TLS {
+		err = handler.FileService.DeleteTLSFiles(portainer.EndpointID(endpointID))
+		if err != nil {
+			Error(w, err, http.StatusInternalServerError, handler.Logger)
+		}
+	}
 }

--- a/api/http/endpoint_handler.go
+++ b/api/http/endpoint_handler.go
@@ -116,11 +116,6 @@ func (handler *EndpointHandler) handlePostEndpoints(w http.ResponseWriter, r *ht
 				Error(w, err, http.StatusInternalServerError, handler.Logger)
 				return
 			}
-			err = handler.EndpointService.SetActive(endpoint)
-			if err != nil {
-				Error(w, err, http.StatusInternalServerError, handler.Logger)
-				return
-			}
 		}
 	}
 
@@ -201,11 +196,6 @@ func (handler *EndpointHandler) handlePostEndpoint(w http.ResponseWriter, r *htt
 	}
 
 	err = handler.server.updateActiveEndpoint(endpoint)
-	if err != nil {
-		Error(w, err, http.StatusInternalServerError, handler.Logger)
-		return
-	}
-	err = handler.EndpointService.SetActive(endpoint)
 	if err != nil {
 		Error(w, err, http.StatusInternalServerError, handler.Logger)
 	}

--- a/api/http/endpoint_handler.go
+++ b/api/http/endpoint_handler.go
@@ -27,7 +27,7 @@ type EndpointHandler struct {
 func NewEndpointHandler(middleWareService *middleWareService) *EndpointHandler {
 	h := &EndpointHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "endpointhandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/endpoints", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/endpoint_handler.go
+++ b/api/http/endpoint_handler.go
@@ -123,7 +123,7 @@ func (handler *EndpointHandler) handlePostEndpoints(w http.ResponseWriter, r *ht
 }
 
 type postEndpointsRequest struct {
-	Name string `valid:"alphanum,required"`
+	Name string `valid:"required"`
 	URL  string `valid:"required"`
 	TLS  bool
 }
@@ -254,7 +254,7 @@ func (handler *EndpointHandler) handlePutEndpoint(w http.ResponseWriter, r *http
 }
 
 type putEndpointsRequest struct {
-	Name string `valid:"alphanum,required"`
+	Name string `valid:"required"`
 	URL  string `valid:"required"`
 	TLS  bool
 }

--- a/api/http/endpoint_handler.go
+++ b/api/http/endpoint_handler.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"github.com/portainer/portainer"
+
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+)
+
+// EndpointHandler represents an HTTP API handler for managing Docker endpoints.
+type EndpointHandler struct {
+	*mux.Router
+	Logger            *log.Logger
+	EndpointService   portainer.EndpointService
+	middleWareService *middleWareService
+}
+
+// NewEndpointHandler returns a new instance of EndpointHandler.
+func NewEndpointHandler(middleWareService *middleWareService) *EndpointHandler {
+	h := &EndpointHandler{
+		Router:            mux.NewRouter(),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
+		middleWareService: middleWareService,
+	}
+	h.Handle("/endpoints", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handlePostEndpoints(w, r)
+	})))
+	h.Handle("/endpoints/{id}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handleGetEndpoint(w, r)
+	}))).Methods("GET")
+	return h
+}
+
+// handlePostEndpoints handles POST requests on /endpoints
+func (handler *EndpointHandler) handlePostEndpoints(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
+		return
+	}
+}
+
+// handleGetEndpoint handles GET requests on /endpoints/:id
+func (handler *EndpointHandler) handleGetEndpoint(w http.ResponseWriter, r *http.Request) {
+}

--- a/api/http/handler.go
+++ b/api/http/handler.go
@@ -18,6 +18,7 @@ type Handler struct {
 	TemplatesHandler *TemplatesHandler
 	DockerHandler    *DockerHandler
 	WebSocketHandler *WebSocketHandler
+	UploadHandler    *UploadHandler
 	FileHandler      http.Handler
 }
 
@@ -40,6 +41,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.SettingsHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/templates") {
 		http.StripPrefix("/api", h.TemplatesHandler).ServeHTTP(w, r)
+	} else if strings.HasPrefix(r.URL.Path, "/api/upload") {
+		http.StripPrefix("/api", h.UploadHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/websocket") {
 		http.StripPrefix("/api", h.WebSocketHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/docker") {

--- a/api/http/handler.go
+++ b/api/http/handler.go
@@ -13,6 +13,7 @@ import (
 type Handler struct {
 	AuthHandler      *AuthHandler
 	UserHandler      *UserHandler
+	EndpointHandler  *EndpointHandler
 	SettingsHandler  *SettingsHandler
 	TemplatesHandler *TemplatesHandler
 	DockerHandler    *DockerHandler
@@ -33,6 +34,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.AuthHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/users") {
 		http.StripPrefix("/api", h.UserHandler).ServeHTTP(w, r)
+	} else if strings.HasPrefix(r.URL.Path, "/api/endpoints") {
+		http.StripPrefix("/api", h.EndpointHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/settings") {
 		http.StripPrefix("/api", h.SettingsHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/templates") {

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -29,6 +29,10 @@ func (server *Server) updateActiveEndpoint(endpoint *portainer.Endpoint) error {
 		if err != nil {
 			return err
 		}
+		err = server.EndpointService.SetActive(endpoint)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -57,7 +57,7 @@ func (server *Server) Start() error {
 	endpointHandler.EndpointService = server.EndpointService
 	endpointHandler.FileService = server.FileService
 	endpointHandler.server = server
-	var uploadHandler = NewUploadHandler()
+	var uploadHandler = NewUploadHandler(middleWareService)
 	uploadHandler.FileService = server.FileService
 	var fileHandler = http.FileServer(http.Dir(server.AssetsPath))
 

--- a/api/http/settings_handler.go
+++ b/api/http/settings_handler.go
@@ -3,10 +3,11 @@ package http
 import (
 	"github.com/portainer/portainer"
 
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/gorilla/mux"
 )
 
 // SettingsHandler represents an HTTP API handler for managing settings.
@@ -30,8 +31,8 @@ func NewSettingsHandler(middleWareService *middleWareService) *SettingsHandler {
 
 // handleGetSettings handles GET requests on /settings
 func (handler *SettingsHandler) handleGetSettings(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		handleNotAllowed(w, []string{"GET"})
+	if r.Method != http.MethodGet {
+		handleNotAllowed(w, []string{http.MethodGet})
 		return
 	}
 

--- a/api/http/settings_handler.go
+++ b/api/http/settings_handler.go
@@ -22,7 +22,7 @@ type SettingsHandler struct {
 func NewSettingsHandler(middleWareService *middleWareService) *SettingsHandler {
 	h := &SettingsHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "settingshandler", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.HandleFunc("/settings", h.handleGetSettings)

--- a/api/http/settings_handler.go
+++ b/api/http/settings_handler.go
@@ -22,7 +22,7 @@ type SettingsHandler struct {
 func NewSettingsHandler(middleWareService *middleWareService) *SettingsHandler {
 	h := &SettingsHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "settingshandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.HandleFunc("/settings", h.handleGetSettings)

--- a/api/http/templates_handler.go
+++ b/api/http/templates_handler.go
@@ -2,11 +2,12 @@ package http
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/gorilla/mux"
 )
 
 // TemplatesHandler represents an HTTP API handler for managing templates.
@@ -32,8 +33,8 @@ func NewTemplatesHandler(middleWareService *middleWareService) *TemplatesHandler
 
 // handleGetTemplates handles GET requests on /templates
 func (handler *TemplatesHandler) handleGetTemplates(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		handleNotAllowed(w, []string{"GET"})
+	if r.Method != http.MethodGet {
+		handleNotAllowed(w, []string{http.MethodGet})
 		return
 	}
 

--- a/api/http/templates_handler.go
+++ b/api/http/templates_handler.go
@@ -22,7 +22,7 @@ type TemplatesHandler struct {
 func NewTemplatesHandler(middleWareService *middleWareService) *TemplatesHandler {
 	h := &TemplatesHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "templateshandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/templates", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/templates_handler.go
+++ b/api/http/templates_handler.go
@@ -22,7 +22,7 @@ type TemplatesHandler struct {
 func NewTemplatesHandler(middleWareService *middleWareService) *TemplatesHandler {
 	h := &TemplatesHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "templateshandler", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/templates", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/upload_handler.go
+++ b/api/http/upload_handler.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"github.com/portainer/portainer"
+
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// UploadHandler represents an HTTP API handler for managing file uploads.
+type UploadHandler struct {
+	*mux.Router
+	Logger      *log.Logger
+	FileService portainer.FileService
+}
+
+// NewUploadHandler returns a new instance of UploadHandler.
+func NewUploadHandler() *UploadHandler {
+	h := &UploadHandler{
+		Router: mux.NewRouter(),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
+	}
+	h.HandleFunc("/upload/tls/{endpointID}/{certificate:(ca|cert|key)}", h.handlePostUploadTLS)
+	return h
+}
+
+func (handler *UploadHandler) handlePostUploadTLS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
+		return
+	}
+
+	vars := mux.Vars(r)
+	endpointID := vars["endpointID"]
+	certificate := vars["certificate"]
+	ID, err := strconv.Atoi(endpointID)
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	file, _, err := r.FormFile("file")
+	defer file.Close()
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	var fileType portainer.TLSFileType
+	switch certificate {
+	case "ca":
+		fileType = portainer.TLSFileCA
+	case "cert":
+		fileType = portainer.TLSFileCert
+	case "key":
+		fileType = portainer.TLSFileKey
+	default:
+		Error(w, portainer.ErrUndefinedTLSFileType, http.StatusInternalServerError, handler.Logger)
+		return
+	}
+
+	err = handler.FileService.StoreTLSFile(portainer.EndpointID(ID), fileType, file)
+	if err != nil {
+		Error(w, err, http.StatusInternalServerError, handler.Logger)
+	}
+}

--- a/api/http/upload_handler.go
+++ b/api/http/upload_handler.go
@@ -14,17 +14,21 @@ import (
 // UploadHandler represents an HTTP API handler for managing file uploads.
 type UploadHandler struct {
 	*mux.Router
-	Logger      *log.Logger
-	FileService portainer.FileService
+	Logger            *log.Logger
+	FileService       portainer.FileService
+	middleWareService *middleWareService
 }
 
 // NewUploadHandler returns a new instance of UploadHandler.
-func NewUploadHandler() *UploadHandler {
+func NewUploadHandler(middleWareService *middleWareService) *UploadHandler {
 	h := &UploadHandler{
-		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "uploadhandler", log.LstdFlags),
+		Router:            mux.NewRouter(),
+		Logger:            log.New(os.Stderr, "uploadhandler", log.LstdFlags),
+		middleWareService: middleWareService,
 	}
-	h.HandleFunc("/upload/tls/{endpointID}/{certificate:(ca|cert|key)}", h.handlePostUploadTLS)
+	h.Handle("/upload/tls/{endpointID}/{certificate:(ca|cert|key)}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.handlePostUploadTLS(w, r)
+	})))
 	return h
 }
 

--- a/api/http/upload_handler.go
+++ b/api/http/upload_handler.go
@@ -22,7 +22,7 @@ type UploadHandler struct {
 func NewUploadHandler() *UploadHandler {
 	h := &UploadHandler{
 		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "", log.LstdFlags),
+		Logger: log.New(os.Stderr, "uploadhandler", log.LstdFlags),
 	}
 	h.HandleFunc("/upload/tls/{endpointID}/{certificate:(ca|cert|key)}", h.handlePostUploadTLS)
 	return h

--- a/api/http/upload_handler.go
+++ b/api/http/upload_handler.go
@@ -23,7 +23,7 @@ type UploadHandler struct {
 func NewUploadHandler(middleWareService *middleWareService) *UploadHandler {
 	h := &UploadHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "uploadhandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/upload/tls/{endpointID}/{certificate:(ca|cert|key)}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/user_handler.go
+++ b/api/http/user_handler.go
@@ -4,11 +4,12 @@ import (
 	"github.com/portainer/portainer"
 
 	"encoding/json"
-	"github.com/asaskevich/govalidator"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/gorilla/mux"
 )
 
 // UserHandler represents an HTTP API handler for managing users.
@@ -46,8 +47,8 @@ func NewUserHandler(middleWareService *middleWareService) *UserHandler {
 
 // handlePostUsers handles POST requests on /users
 func (handler *UserHandler) handlePostUsers(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		handleNotAllowed(w, []string{"POST"})
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
 		return
 	}
 
@@ -86,8 +87,8 @@ type postUsersRequest struct {
 
 // handlePostUserPasswd handles POST requests on /users/:username/passwd
 func (handler *UserHandler) handlePostUserPasswd(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		handleNotAllowed(w, []string{"POST"})
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
 		return
 	}
 
@@ -189,8 +190,8 @@ type putUserRequest struct {
 
 // handlePostAdminInit handles GET requests on /users/admin/check
 func (handler *UserHandler) handleGetAdminCheck(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		handleNotAllowed(w, []string{"GET"})
+	if r.Method != http.MethodGet {
+		handleNotAllowed(w, []string{http.MethodGet})
 		return
 	}
 
@@ -209,8 +210,8 @@ func (handler *UserHandler) handleGetAdminCheck(w http.ResponseWriter, r *http.R
 
 // handlePostAdminInit handles POST requests on /users/admin/init
 func (handler *UserHandler) handlePostAdminInit(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		handleNotAllowed(w, []string{"POST"})
+	if r.Method != http.MethodPost {
+		handleNotAllowed(w, []string{http.MethodPost})
 		return
 	}
 

--- a/api/http/user_handler.go
+++ b/api/http/user_handler.go
@@ -25,7 +25,7 @@ type UserHandler struct {
 func NewUserHandler(middleWareService *middleWareService) *UserHandler {
 	h := &UserHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "userhandler", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/users", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/user_handler.go
+++ b/api/http/user_handler.go
@@ -25,7 +25,7 @@ type UserHandler struct {
 func NewUserHandler(middleWareService *middleWareService) *UserHandler {
 	h := &UserHandler{
 		Router:            mux.NewRouter(),
-		Logger:            log.New(os.Stderr, "userhandler", log.LstdFlags),
+		Logger:            log.New(os.Stderr, "", log.LstdFlags),
 		middleWareService: middleWareService,
 	}
 	h.Handle("/users", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/http/user_handler.go
+++ b/api/http/user_handler.go
@@ -33,10 +33,10 @@ func NewUserHandler(middleWareService *middleWareService) *UserHandler {
 	})))
 	h.Handle("/users/{username}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.handleGetUser(w, r)
-	}))).Methods("GET")
+	}))).Methods(http.MethodGet)
 	h.Handle("/users/{username}", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.handlePutUser(w, r)
-	}))).Methods("PUT")
+	}))).Methods(http.MethodPut)
 	h.Handle("/users/{username}/passwd", middleWareService.addMiddleWares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.handlePostUserPasswd(w, r)
 	})))

--- a/api/http/websocket_handler.go
+++ b/api/http/websocket_handler.go
@@ -7,8 +7,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
-	"golang.org/x/net/websocket"
 	"io"
 	"log"
 	"net"
@@ -17,6 +15,9 @@ import (
 	"net/url"
 	"os"
 	"time"
+
+	"github.com/gorilla/mux"
+	"golang.org/x/net/websocket"
 )
 
 // WebSocketHandler represents an HTTP API handler for proxying requests to a web socket.
@@ -31,7 +32,7 @@ type WebSocketHandler struct {
 func NewWebSocketHandler() *WebSocketHandler {
 	h := &WebSocketHandler{
 		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "", log.LstdFlags),
+		Logger: log.New(os.Stderr, "websockethandler", log.LstdFlags),
 	}
 	h.Handle("/websocket/exec", websocket.Handler(h.webSocketDockerExec))
 	return h

--- a/api/http/websocket_handler.go
+++ b/api/http/websocket_handler.go
@@ -22,9 +22,9 @@ import (
 // WebSocketHandler represents an HTTP API handler for proxying requests to a web socket.
 type WebSocketHandler struct {
 	*mux.Router
-	Logger                *log.Logger
-	middleWareService     *middleWareService
-	endpointConfiguration *portainer.EndpointConfiguration
+	Logger            *log.Logger
+	middleWareService *middleWareService
+	endpoint          *portainer.Endpoint
 }
 
 // NewWebSocketHandler returns a new instance of WebSocketHandler.
@@ -42,7 +42,7 @@ func (handler *WebSocketHandler) webSocketDockerExec(ws *websocket.Conn) {
 	execID := qry.Get("id")
 
 	// Should not be managed here
-	endpoint, err := url.Parse(handler.endpointConfiguration.Endpoint)
+	endpoint, err := url.Parse(handler.endpoint.URL)
 	if err != nil {
 		log.Fatalf("Unable to parse endpoint URL: %s", err)
 		return
@@ -57,10 +57,10 @@ func (handler *WebSocketHandler) webSocketDockerExec(ws *websocket.Conn) {
 
 	// Should not be managed here
 	var tlsConfig *tls.Config
-	if handler.endpointConfiguration.TLS {
-		tlsConfig, err = createTLSConfiguration(handler.endpointConfiguration.TLSCACertPath,
-			handler.endpointConfiguration.TLSCertPath,
-			handler.endpointConfiguration.TLSKeyPath)
+	if handler.endpoint.TLS {
+		tlsConfig, err = createTLSConfiguration(handler.endpoint.TLSCACertPath,
+			handler.endpoint.TLSCertPath,
+			handler.endpoint.TLSKeyPath)
 		if err != nil {
 			log.Fatalf("Unable to create TLS configuration: %s", err)
 			return

--- a/api/http/websocket_handler.go
+++ b/api/http/websocket_handler.go
@@ -32,7 +32,7 @@ type WebSocketHandler struct {
 func NewWebSocketHandler() *WebSocketHandler {
 	h := &WebSocketHandler{
 		Router: mux.NewRouter(),
-		Logger: log.New(os.Stderr, "websockethandler", log.LstdFlags),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
 	}
 	h.Handle("/websocket/exec", websocket.Handler(h.webSocketDockerExec))
 	return h

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -19,7 +19,6 @@ type (
 		Endpoint  *string
 		Labels    *[]Pair
 		Logo      *string
-		Swarm     *bool
 		Templates *string
 		TLSVerify *bool
 		TLSCacert *string
@@ -29,7 +28,6 @@ type (
 
 	// Settings represents Portainer settings.
 	Settings struct {
-		Swarm        bool   `json:"swarm"`
 		HiddenLabels []Pair `json:"hiddenLabels"`
 		Logo         string `json:"logo"`
 	}
@@ -54,7 +52,6 @@ type (
 		ID            EndpointID `json:"Id"`
 		Name          string     `json:"Name"`
 		URL           string     `json:"URL"`
-		Swarm         bool       `json:"Swarm"`
 		TLS           bool       `json:"TLS"`
 		TLSCACertPath string     `json:"TLSCACert,omitempty"`
 		TLSCertPath   string     `json:"TLSCert,omitempty"`

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -95,6 +95,8 @@ type (
 		CreateEndpoint(endpoint *Endpoint) error
 		UpdateEndpoint(ID EndpointID, endpoint *Endpoint) error
 		DeleteEndpoint(ID EndpointID) error
+		GetActive() (*Endpoint, error)
+		SetActive(endpoint *Endpoint) error
 	}
 
 	// CryptoService represents a service for encrypting/hashing data.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -41,13 +41,19 @@ type (
 		Username string
 	}
 
-	// EndpointConfiguration represents the data required to connect to a Docker API endpoint.
-	EndpointConfiguration struct {
-		Endpoint      string
-		TLS           bool
-		TLSCACertPath string
-		TLSCertPath   string
-		TLSKeyPath    string
+	// EndpointID represents an endpoint identifier.
+	EndpointID int
+
+	// Endpoint represents a Docker endpoint with all the info required
+	// to connect to it.
+	Endpoint struct {
+		ID            EndpointID `json:"id"`
+		URL           string     `json:"url"`
+		Swarm         bool       `json:"swarm"`
+		TLS           bool       `json:"tls"`
+		TLSCACertPath string     `json:"tlscacert"`
+		TLSCertPath   string     `json:"tlscert"`
+		TLSKeyPath    string     `json:"tlskey"`
 	}
 
 	// CLIService represents a service for managing CLI.
@@ -71,6 +77,13 @@ type (
 	UserService interface {
 		User(username string) (*User, error)
 		UpdateUser(user *User) error
+	}
+
+	// EndpointService represents a service for managing endpoints.
+	EndpointService interface {
+		Endpoint(ID EndpointID) (*Endpoint, error)
+		UpdateEndpoint(endpoint *Endpoint) error
+		DeleteEndpoint(ID EndpointID) error
 	}
 
 	// CryptoService represents a service for encrypting/hashing data.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1,5 +1,9 @@
 package portainer
 
+import (
+	"io"
+)
+
 type (
 	// Pair defines a key/value string pair
 	Pair struct {
@@ -32,8 +36,8 @@ type (
 
 	// User represent a user account.
 	User struct {
-		Username string `json:"username"`
-		Password string `json:"password,omitempty"`
+		Username string `json:"Username"`
+		Password string `json:"Password,omitempty"`
 	}
 
 	// TokenData represents the data embedded in a JWT token.
@@ -47,14 +51,19 @@ type (
 	// Endpoint represents a Docker endpoint with all the info required
 	// to connect to it.
 	Endpoint struct {
-		ID            EndpointID `json:"id"`
-		URL           string     `json:"url"`
-		Swarm         bool       `json:"swarm"`
-		TLS           bool       `json:"tls"`
-		TLSCACertPath string     `json:"tlscacert"`
-		TLSCertPath   string     `json:"tlscert"`
-		TLSKeyPath    string     `json:"tlskey"`
+		ID            EndpointID `json:"Id"`
+		Name          string     `json:"Name"`
+		URL           string     `json:"URL"`
+		Swarm         bool       `json:"Swarm"`
+		TLS           bool       `json:"TLS"`
+		TLSCACertPath string     `json:"TLSCACert,omitempty"`
+		TLSCertPath   string     `json:"TLSCert,omitempty"`
+		TLSKeyPath    string     `json:"TLSKey,omitempty"`
 	}
+
+	// TLSFileType represents a type of TLS file required to connect to a Docker endpoint.
+	// It can be either a TLS CA file, a TLS certificate file or a TLS key file.
+	TLSFileType int
 
 	// CLIService represents a service for managing CLI.
 	CLIService interface {
@@ -82,7 +91,9 @@ type (
 	// EndpointService represents a service for managing endpoints.
 	EndpointService interface {
 		Endpoint(ID EndpointID) (*Endpoint, error)
-		UpdateEndpoint(endpoint *Endpoint) error
+		Endpoints() ([]Endpoint, error)
+		CreateEndpoint(endpoint *Endpoint) error
+		UpdateEndpoint(ID EndpointID, endpoint *Endpoint) error
 		DeleteEndpoint(ID EndpointID) error
 	}
 
@@ -97,9 +108,25 @@ type (
 		GenerateToken(data *TokenData) (string, error)
 		VerifyToken(token string) error
 	}
+
+	// FileService represents a service for managing files.
+	FileService interface {
+		StoreTLSFile(endpointID EndpointID, fileType TLSFileType, r io.Reader) error
+		GetPathForTLSFile(endpointID EndpointID, fileType TLSFileType) (string, error)
+		DeleteTLSFiles(endpointID EndpointID) error
+	}
 )
 
 const (
 	// APIVersion is the version number of portainer API.
 	APIVersion = "1.10.2"
+)
+
+const (
+	// TLSFileCA represents a TLS CA certificate file.
+	TLSFileCA TLSFileType = iota
+	// TLSFileCert represents a TLS certificate file.
+	TLSFileCert
+	// TLSFileKey represents a TLS key file.
+	TLSFileKey
 )

--- a/app/app.js
+++ b/app/app.js
@@ -5,6 +5,7 @@ angular.module('portainer', [
   'ui.select',
   'ngCookies',
   'ngSanitize',
+  'ngFileUpload',
   'angularUtils.directives.dirPagination',
   'LocalStorageModule',
   'angular-jwt',
@@ -19,6 +20,9 @@ angular.module('portainer', [
   'containers',
   'createContainer',
   'docker',
+  'endpoint',
+  'endpointInit',
+  'endpoints',
   'events',
   'images',
   'image',
@@ -268,6 +272,47 @@ angular.module('portainer', [
       },
       data: {
         requiresLogin: true
+      }
+    })
+    .state('endpoints', {
+      url: '/endpoints/',
+      views: {
+        "content": {
+          templateUrl: 'app/components/endpoints/endpoints.html',
+          controller: 'EndpointsController'
+        },
+        "sidebar": {
+          templateUrl: 'app/components/sidebar/sidebar.html',
+          controller: 'SidebarController'
+        }
+      },
+      data: {
+        requiresLogin: false
+      }
+    })
+    .state('endpoint', {
+      url: '^/endpoints/:id',
+      views: {
+        "content": {
+          templateUrl: 'app/components/endpoint/endpoint.html',
+          controller: 'EndpointController'
+        },
+        "sidebar": {
+          templateUrl: 'app/components/sidebar/sidebar.html',
+          controller: 'SidebarController'
+        }
+      },
+      data: {
+        requiresLogin: false
+      }
+    })
+    .state('endpointInit', {
+      url: '/init/endpoint',
+      views: {
+        "content": {
+          templateUrl: 'app/components/endpointInit/endpointInit.html',
+          controller: 'EndpointInitController'
+        }
       }
     })
     .state('events', {

--- a/app/app.js
+++ b/app/app.js
@@ -536,18 +536,19 @@ angular.module('portainer', [
     });
 
     $rootScope.$on("$stateChangeStart", function(event, toState, toParams, fromState, fromParams) {
-      if ((fromState.name === 'auth' || fromState.name === '') && Authentication.isAuthenticated()) {
+      if (toState.name !== 'endpointInit' && (fromState.name === 'auth' || fromState.name === '' || fromState.name === 'endpointInit') && Authentication.isAuthenticated()) {
         EndpointMode.determineEndpointMode();
       }
     });
   }])
   // This is your docker url that the api will use to make requests
   // You need to set this to the api endpoint without the port i.e. http://192.168.1.9
-  .constant('DOCKER_ENDPOINT', '/api/docker')
   .constant('DOCKER_PORT', '') // Docker port, leave as an empty string if no port is required.  If you have a port, prefix it with a ':' i.e. :4243
+  .constant('DOCKER_ENDPOINT', '/api/docker')
   .constant('CONFIG_ENDPOINT', '/api/settings')
   .constant('AUTH_ENDPOINT', '/api/auth')
   .constant('USERS_ENDPOINT', '/api/users')
+  .constant('ENDPOINTS_ENDPOINT', '/api/endpoints')
   .constant('TEMPLATES_ENDPOINT', '/api/templates')
   .constant('PAGINATION_MAX_ITEMS', 10)
   .constant('UI_VERSION', 'v1.10.2');

--- a/app/app.js
+++ b/app/app.js
@@ -287,7 +287,7 @@ angular.module('portainer', [
         }
       },
       data: {
-        requiresLogin: false
+        requiresLogin: true
       }
     })
     .state('endpoint', {
@@ -303,7 +303,7 @@ angular.module('portainer', [
         }
       },
       data: {
-        requiresLogin: false
+        requiresLogin: true
       }
     })
     .state('endpointInit', {
@@ -313,6 +313,9 @@ angular.module('portainer', [
           templateUrl: 'app/components/endpointInit/endpointInit.html',
           controller: 'EndpointInitController'
         }
+      },
+      data: {
+        requiresLogin: true
       }
     })
     .state('events', {

--- a/app/components/auth/auth.html
+++ b/app/components/auth/auth.html
@@ -1,11 +1,11 @@
-<div class="login-wrapper">
+<div class="page-wrapper">
   <!-- login box -->
-  <div class="container login-box">
+  <div class="container simple-box">
     <div class="col-md-6 col-md-offset-3 col-sm-6 col-sm-offset-3">
       <!-- login box logo -->
       <div class="row">
-        <img ng-if="logo" ng-src="{{ logo }}" class="login-logo">
-        <img ng-if="!logo" src="images/logo_alt.png" class="login-logo" alt="Portainer">
+        <img ng-if="logo" ng-src="{{ logo }}" class="simple-box-logo">
+        <img ng-if="!logo" src="images/logo_alt.png" class="simple-box-logo" alt="Portainer">
       </div>
       <!-- !login box logo -->
       <!-- init password panel -->

--- a/app/components/auth/authController.js
+++ b/app/components/auth/authController.js
@@ -1,6 +1,6 @@
 angular.module('auth', [])
-.controller('AuthenticationController', ['$scope', '$state', '$stateParams', '$window', '$timeout', '$sanitize', 'Config', 'Authentication', 'Users', 'Messages',
-function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Authentication, Users, Messages) {
+.controller('AuthenticationController', ['$scope', '$state', '$stateParams', '$window', '$timeout', '$sanitize', 'Config', 'Authentication', 'Users', 'Endpoints', 'Messages',
+function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Authentication, Users, Endpoints, Messages) {
 
   $scope.authData = {
     username: 'admin',
@@ -60,7 +60,15 @@ function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Au
     var password = $sanitize($scope.authData.password);
     Authentication.login(username, password)
     .then(function() {
-      $state.go('dashboard');
+      Endpoints.getActiveEndpoint({}, function (d) {
+        $state.go('dashboard');
+      }, function (e) {
+        if (e.status === 404) {
+          $state.go('endpointInit');
+        } else {
+          Messages.error("Failure", e, 'Unable to verify Docker endpoint existence');
+        }
+      });
     }, function() {
       $scope.authData.error = 'Invalid credentials';
     });

--- a/app/components/auth/authController.js
+++ b/app/components/auth/authController.js
@@ -1,6 +1,6 @@
 angular.module('auth', [])
-.controller('AuthenticationController', ['$scope', '$state', '$stateParams', '$window', '$timeout', '$sanitize', 'Config', 'Authentication', 'Users', 'Endpoints', 'Messages',
-function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Authentication, Users, Endpoints, Messages) {
+.controller('AuthenticationController', ['$scope', '$state', '$stateParams', '$window', '$timeout', '$sanitize', 'Config', 'Authentication', 'Users', 'EndpointService', 'Messages',
+function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Authentication, Users, EndpointService, Messages) {
 
   $scope.authData = {
     username: 'admin',
@@ -58,18 +58,17 @@ function ($scope, $state, $stateParams, $window, $timeout, $sanitize, Config, Au
     $scope.authenticationError = false;
     var username = $sanitize($scope.authData.username);
     var password = $sanitize($scope.authData.password);
-    Authentication.login(username, password)
-    .then(function() {
-      Endpoints.getActiveEndpoint({}, function (d) {
+    Authentication.login(username, password).then(function success() {
+      EndpointService.getActive().then(function success(data) {
         $state.go('dashboard');
-      }, function (e) {
-        if (e.status === 404) {
+      }, function error(err) {
+        if (err.status === 404) {
           $state.go('endpointInit');
         } else {
-          Messages.error("Failure", e, 'Unable to verify Docker endpoint existence');
+          Messages.error("Failure", err, 'Unable to verify Docker endpoint existence');
         }
       });
-    }, function() {
+    }, function error() {
       $scope.authData.error = 'Invalid credentials';
     });
   };

--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -150,7 +150,7 @@ function ($scope, Container, ContainerHelper, Info, Settings, Messages, Config) 
 
   Config.$promise.then(function (c) {
     $scope.containersToHideLabels = c.hiddenLabels;
-    if (c.swarm && $scope.endpointMode.provider === 'DOCKER_SWARM') {
+    if ($scope.endpointMode.provider === 'DOCKER_SWARM') {
       Info.get({}, function (d) {
         $scope.swarm_hosts = retrieveSwarmHostsInfo(d);
         update({all: Settings.displayAll ? 1 : 0});

--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -52,7 +52,6 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
   };
 
   Config.$promise.then(function (c) {
-    $scope.swarm = c.swarm;
     var containersToHideLabels = c.hiddenLabels;
 
     Volume.query({}, function (d) {
@@ -63,7 +62,7 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
 
     Network.query({}, function (d) {
       var networks = d;
-      if ($scope.swarm) {
+      if ($scope.endpointMode.provider === 'DOCKER_SWARM' || $scope.endpointMode.provider === 'DOCKER_SWARM_MODE') {
         networks = d.filter(function (network) {
           if (network.Scope === 'global') {
             return network;
@@ -211,7 +210,7 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
     var containerName = container;
     if (container && typeof container === 'object') {
       containerName = $filter('trimcontainername')(container.Names[0]);
-      if ($scope.swarm && $scope.endpointMode.provider === 'DOCKER_SWARM') {
+      if ($scope.endpointMode.provider === 'DOCKER_SWARM') {
         containerName = $filter('swarmcontainername')(container);
       }
     }

--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -80,7 +80,7 @@
                   <input type="text" class="form-control" ng-model="portBinding.containerPort" placeholder="e.g. 80">
                 </div>
                 <div class="input-group col-sm-1 input-group-sm">
-                  <select class="selectpicker form-control" ng-model="portBinding.protocol">
+                  <select class="form-control" ng-model="portBinding.protocol">
                     <option value="tcp">tcp</option>
                     <option value="udp">udp</option>
                   </select>
@@ -232,7 +232,7 @@
                     </div>
                     <div class="input-group col-sm-5 input-group-sm">
                       <span class="input-group-addon"><input type="checkbox" ng-model="volume.isPath" ng-click="resetVolumePath($index)">Path</span>
-                      <select class="selectpicker form-control" ng-model="volume.name" ng-if="!volume.isPath">
+                      <select class="form-control" ng-model="volume.name" ng-if="!volume.isPath">
                         <option selected disabled hidden value="">Select a volume</option>
                         <option ng-repeat="vol in availableVolumes" ng-value="vol.Name">{{ vol.Name|truncate:30}}</option>
                       </select>
@@ -267,7 +267,7 @@
               <div class="form-group">
                 <label for="container_network" class="col-sm-1 control-label text-left">Network</label>
                 <div class="col-sm-9">
-                  <select class="selectpicker form-control" ng-model="config.HostConfig.NetworkMode" id="container_network">
+                  <select class="form-control" ng-model="config.HostConfig.NetworkMode" id="container_network">
                     <option selected disabled hidden value="">Select a network</option>
                     <option ng-repeat="net in availableNetworks" ng-value="net.Name">{{ net.Name }}</option>
                   </select>
@@ -278,10 +278,10 @@
               <div class="form-group" ng-if="config.HostConfig.NetworkMode == 'container'">
                 <label for="container_network_container" class="col-sm-1 control-label text-left">Container</label>
                 <div class="col-sm-9">
-                  <select ng-if="endpointMode.provider !== 'DOCKER_SWARM'" ng-options="container|containername for container in runningContainers" class="selectpicker form-control" ng-model="formValues.NetworkContainer">
+                  <select ng-if="endpointMode.provider !== 'DOCKER_SWARM'" ng-options="container|containername for container in runningContainers" class="form-control" ng-model="formValues.NetworkContainer">
                     <option selected disabled hidden value="">Select a container</option>
                   </select>
-                  <select ng-if="endpointMode.provider === 'DOCKER_SWARM'" ng-options="container|swarmcontainername for container in runningContainers" class="selectpicker form-control" ng-model="formValues.NetworkContainer">
+                  <select ng-if="endpointMode.provider === 'DOCKER_SWARM'" ng-options="container|swarmcontainername for container in runningContainers" class="form-control" ng-model="formValues.NetworkContainer">
                     <option selected disabled hidden value="">Select a container</option>
                   </select>
                 </div>

--- a/app/components/createService/createservice.html
+++ b/app/components/createService/createservice.html
@@ -72,7 +72,7 @@
                   <input type="text" class="form-control" ng-model="portBinding.TargetPort" placeholder="e.g. 80">
                 </div>
                 <div class="input-group col-sm-1 input-group-sm">
-                  <select class="selectpicker form-control" ng-model="portBinding.Protocol">
+                  <select class="form-control" ng-model="portBinding.Protocol">
                     <option value="tcp">tcp</option>
                     <option value="udp">udp</option>
                   </select>
@@ -183,7 +183,7 @@
                     </div>
                     <div class="input-group col-sm-5 input-group-sm">
                       <span class="input-group-addon"><input type="checkbox" ng-model="volume.Bind">bind</span>
-                      <select class="selectpicker form-control" ng-model="volume.Source" ng-if="!volume.Bind">
+                      <select class="form-control" ng-model="volume.Source" ng-if="!volume.Bind">
                         <option selected disabled hidden value="">Select a volume</option>
                         <option ng-repeat="vol in availableVolumes" ng-value="vol.Name">{{ vol.Name|truncate:30}}</option>
                       </select>
@@ -213,7 +213,7 @@
               <div class="form-group">
                 <label for="container_network" class="col-sm-1 control-label text-left">Network</label>
                 <div class="col-sm-9">
-                  <select class="selectpicker form-control" ng-model="formValues.Network">
+                  <select class="form-control" ng-model="formValues.Network">
                     <option selected disabled hidden value="">Select a network</option>
                     <option ng-repeat="net in availableNetworks" ng-value="net.Name">{{ net.Name }}</option>
                   </select>
@@ -238,7 +238,7 @@
                           <i class="fa fa-minus" aria-hidden="true"></i>
                         </button>
                       </span>
-                      <select class="selectpicker form-control" ng-model="network.Name">
+                      <select class="form-control" ng-model="network.Name">
                         <option selected disabled hidden value="">Select a network</option>
                         <option ng-repeat="net in availableNetworks" ng-value="net.Name">{{ net.Name }}</option>
                       </select>

--- a/app/components/dashboard/dashboardController.js
+++ b/app/components/dashboard/dashboardController.js
@@ -87,7 +87,6 @@ function ($scope, $q, Config, Container, ContainerHelper, Image, Network, Volume
   }
 
   Config.$promise.then(function (c) {
-    $scope.swarm = c.swarm;
     fetchDashboardData(c.hiddenLabels);
   });
 }]);

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -16,7 +16,7 @@
           <div class="form-group">
             <label for="container_name" class="col-sm-2 control-label text-left">Name</label>
             <div class="col-sm-10">
-              <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+              <input type="text" class="form-control" id="container_name" ng-model="endpoint.Name" placeholder="e.g. docker-prod01">
             </div>
           </div>
           <!-- !name-input -->
@@ -24,12 +24,7 @@
           <div class="form-group">
             <label for="endpoint_url" class="col-sm-2 control-label text-left">Endpoint URL</label>
             <div class="col-sm-10">
-              <div class="input-group">
-                <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
-                <span class="input-group-btn">
-                  <button class="btn btn-info" type="button">Test</button>
-                </span>
-              </div>
+              <input type="text" class="form-control" id="endpoint_url" ng-model="endpoint.URL" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
             </div>
           </div>
           <!-- !endpoint-url-input -->
@@ -37,22 +32,22 @@
           <div class="form-group">
             <label for="tls" class="col-sm-2 control-label text-left">TLS</label>
             <div class="col-sm-10">
-              <input type="checkbox" name="tls" ng-model="formValues.TLS">
+              <input type="checkbox" name="tls" ng-model="endpoint.TLS">
             </div>
           </div>
           <!-- !tls-checkbox -->
           <!-- tls-certs -->
-          <div ng-if="formValues.TLS">
+          <div ng-if="endpoint.TLS">
             <!-- ca-input -->
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
-                <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
-                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
-                </span>
-                <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
-                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                <span style="margin-left: 5px;">
+                  <span ng-if="formValues.TLSCACert !== endpoint.TLSCACert">{{ formValues.TLSCACert.name }}</span>
+                  <i class="fa fa-check green-icon" ng-if="formValues.TLSCACert && formValues.TLSCACert === endpoint.TLSCACert" aria-hidden="true"></i>
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCACert" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
                 </span>
               </div>
             </div>
@@ -62,11 +57,11 @@
               <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
-                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
-                </span>
-                <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
-                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                <span style="margin-left: 5px;">
+                  <span ng-if="formValues.TLSCert !== endpoint.TLSCert">{{ formValues.TLSCert.name }}</span>
+                  <i class="fa fa-check green-icon" ng-if="formValues.TLSCert && formValues.TLSCert === endpoint.TLSCert" aria-hidden="true"></i>
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
                 </span>
               </div>
             </div>
@@ -75,30 +70,30 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS key</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                  <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
-                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
-                  </span>
-                  <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
-                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                  </span>
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                <span style="margin-left: 5px;">
+                  <span ng-if="formValues.TLSKey !== endpoint.TLSKey">{{ formValues.TLSKey.name }}</span>
+                  <i class="fa fa-check green-icon" ng-if="formValues.TLSKey && formValues.TLSKey === endpoint.TLSKey" aria-hidden="true"></i>
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                </span>
               </div>
             </div>
             <!-- !key-input -->
           </div>
           <!-- !tls-certs -->
+          <div class="form-group">
+            <div class="col-sm-12">
+              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!endpoint.Name || !endpoint.URL || (endpoint.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="updateEndpoint()">Update endpoint</button>
+              <a type="button" class="btn btn-default btn-sm" ui-sref="endpoints">Cancel</a>
+              <i id="updateEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
+              <span class="text-danger" ng-if="state.error" style="margin: 5px;">
+                <i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ state.error }}
+              </span>
+            </div>
+          </div>
         </form>
       </rd-widget-body>
     </rd-widget>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-lg-12 col-md-12 col-xs-12" style="text-align: center;">
-    <div>
-      <i id="updateEndpointSpinner" class="fa fa-cog fa-3x fa-spin" style="margin-bottom: 5px; display: none;"></i>
-    </div>
-    <button type="button" class="btn btn-default btn-lg" ng-click="create()">Update</button>
-    <a type="button" class="btn btn-default btn-lg" ui-sref="endpoints">Cancel</a>
   </div>
 </div>

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -1,0 +1,100 @@
+<rd-header>
+  <rd-header-title title="Endpoint details">
+    <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
+  </rd-header-title>
+  <rd-header-content>
+    <a ui-sref="endpoints">Endpoints</a> > <a ui-sref="endpoint({id: endpoint.Id})">{{ endpoint.Name }}</a>
+  </rd-header-content>
+</rd-header>
+
+<div class="row">
+  <div class="col-lg-12 col-md-12 col-xs-12">
+    <rd-widget>
+      <rd-widget-body>
+        <form class="form-horizontal">
+          <!-- name-input -->
+          <div class="form-group">
+            <label for="container_name" class="col-sm-2 control-label text-left">Name</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+            </div>
+          </div>
+          <!-- !name-input -->
+          <!-- endpoint-url-input -->
+          <div class="form-group">
+            <label for="endpoint_url" class="col-sm-2 control-label text-left">Endpoint URL</label>
+            <div class="col-sm-10">
+              <div class="input-group">
+                <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
+                <span class="input-group-btn">
+                  <button class="btn btn-info" type="button">Test</button>
+                </span>
+              </div>
+            </div>
+          </div>
+          <!-- !endpoint-url-input -->
+          <!-- tls-checkbox -->
+          <div class="form-group">
+            <label for="tls" class="col-sm-2 control-label text-left">TLS</label>
+            <div class="col-sm-10">
+              <input type="checkbox" name="tls" ng-model="formValues.TLS">
+            </div>
+          </div>
+          <!-- !tls-checkbox -->
+          <!-- tls-certs -->
+          <div ng-if="formValues.TLS">
+            <!-- ca-input -->
+            <div class="form-group">
+              <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
+              <div class="col-sm-10">
+                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                  <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
+                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
+                  </span>
+                  <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
+                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                  </span>
+              </div>
+            </div>
+            <!-- !ca-input -->
+            <!-- cert-input -->
+            <div class="form-group">
+              <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
+              <div class="col-sm-10">
+                <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
+                required
+                ngf-model-invalid="errorFile" />
+              </div>
+            </div>
+            <!-- !cert-input -->
+            <!-- key-input -->
+            <div class="form-group">
+              <label class="col-sm-2 control-label text-left">TLS key</label>
+              <div class="col-sm-10">
+                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                  <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
+                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
+                  </span>
+                  <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
+                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                  </span>
+              </div>
+            </div>
+            <!-- !key-input -->
+          </div>
+          <!-- !tls-certs -->
+        </form>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-12 col-md-12 col-xs-12" style="text-align: center;">
+    <div>
+      <i id="updateEndpointSpinner" class="fa fa-cog fa-3x fa-spin" style="margin-bottom: 5px; display: none;"></i>
+    </div>
+    <button type="button" class="btn btn-default btn-lg" ng-click="create()">Update</button>
+    <a type="button" class="btn btn-default btn-lg" ui-sref="endpoints">Cancel</a>
+  </div>
+</div>

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -24,12 +24,12 @@
           <div class="form-group">
             <label for="endpoint_url" class="col-sm-2 control-label text-left">Endpoint URL</label>
             <div class="col-sm-10">
-              <input type="text" class="form-control" id="endpoint_url" ng-model="endpoint.URL" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
+              <input ng-disabled="endpointType === 'local'" type="text" class="form-control" id="endpoint_url" ng-model="endpoint.URL" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
             </div>
           </div>
           <!-- !endpoint-url-input -->
           <!-- tls-checkbox -->
-          <div class="form-group">
+          <div class="form-group" ng-if="endpointType === 'remote'">
             <label for="tls" class="col-sm-2 control-label text-left">TLS</label>
             <div class="col-sm-10">
               <input type="checkbox" name="tls" ng-model="endpoint.TLS">

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -47,13 +47,13 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
-                  <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
-                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
-                  </span>
-                  <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
-                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                  </span>
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
+                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
+                </span>
+                <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
+                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                </span>
               </div>
             </div>
             <!-- !ca-input -->
@@ -61,9 +61,13 @@
             <div class="form-group">
               <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
-                <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
-                required
-                ngf-model-invalid="errorFile" />
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
+                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
+                </span>
+                <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
+                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                </span>
               </div>
             </div>
             <!-- !cert-input -->
@@ -71,7 +75,7 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS key</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
                   <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
                     <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
                   </span>

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -36,6 +36,11 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Messages) {
     EndpointService.endpoint($stateParams.id).then(function success(data) {
       $('#loadingViewSpinner').hide();
       $scope.endpoint = data;
+      if (data.URL.indexOf("unix://") === 0) {
+        $scope.endpointType = 'local';
+      } else {
+        $scope.endpointType = 'remote';
+      }
       $scope.endpoint.URL = $filter('stripprotocol')(data.URL);
       $scope.formValues.TLSCACert = data.TLSCACert;
       $scope.formValues.TLSCert = data.TLSCert;

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -1,8 +1,50 @@
 angular.module('endpoint', [])
-.controller('EndpointController', ['$scope', '$stateParams',
-function ($scope, $stateParams) {
-  $scope.endpoint = {
-    Id: 'test',
-    Name: 'endpoint_name'
+.controller('EndpointController', ['$scope', '$state', '$stateParams', '$filter', 'EndpointService', 'Messages',
+function ($scope, $state, $stateParams, $filter, EndpointService, Messages) {
+  $scope.state = {
+    error: '',
+    uploadInProgress: false
   };
+  $scope.formValues = {
+    TLSCACert: null,
+    TLSCert: null,
+    TLSKey: null
+  };
+
+  $scope.updateEndpoint = function() {
+    var ID = $scope.endpoint.Id;
+    var name = $scope.endpoint.Name;
+    var URL = $scope.endpoint.URL;
+    var TLS = $scope.endpoint.TLS;
+    var TLSCACert = $scope.formValues.TLSCACert !== $scope.endpoint.TLSCACert ? $scope.formValues.TLSCACert : null;
+    var TLSCert = $scope.formValues.TLSCert !== $scope.endpoint.TLSCert ? $scope.formValues.TLSCert : null;
+    var TLSKey = $scope.formValues.TLSKey !== $scope.endpoint.TLSKey ? $scope.formValues.TLSKey : null;
+    EndpointService.updateEndpoint(ID, name, URL, TLS, TLSCACert, TLSCert, TLSKey).then(function success(data) {
+      Messages.send("Endpoint updated", $scope.endpoint.Name);
+      $state.go('endpoints');
+    }, function error(err) {
+      $scope.state.error = err.msg;
+    }, function update(evt) {
+      if (evt.upload) {
+        $scope.state.uploadInProgress = evt.upload;
+      }
+    });
+  };
+
+  function getEndpoint(endpointID) {
+    $('#loadingViewSpinner').show();
+    EndpointService.endpoint($stateParams.id).then(function success(data) {
+      $('#loadingViewSpinner').hide();
+      $scope.endpoint = data;
+      $scope.endpoint.URL = $filter('stripprotocol')(data.URL);
+      $scope.formValues.TLSCACert = data.TLSCACert;
+      $scope.formValues.TLSCert = data.TLSCert;
+      $scope.formValues.TLSKey = data.TLSKey;
+    }, function error(err) {
+      $('#loadingViewSpinner').hide();
+      Messages.error("Failure", err, "Unable to retrieve endpoint details");
+    });
+  }
+
+  getEndpoint($stateParams.id);
 }]);

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -1,0 +1,8 @@
+angular.module('endpoint', [])
+.controller('EndpointController', ['$scope', '$stateParams',
+function ($scope, $stateParams) {
+  $scope.endpoint = {
+    Id: 'test',
+    Name: 'endpoint_name'
+  };
+}]);

--- a/app/components/endpointInit/endpointInit.html
+++ b/app/components/endpointInit/endpointInit.html
@@ -1,0 +1,133 @@
+<div class="page-wrapper">
+  <!-- login box -->
+  <div class="container simple-box">
+    <div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
+      <!-- login box logo -->
+      <div class="row">
+        <img ng-if="logo" ng-src="{{ logo }}" class="simple-box-logo">
+        <img ng-if="!logo" src="images/logo_alt.png" class="simple-box-logo" alt="Portainer">
+      </div>
+      <!-- !login box logo -->
+      <!-- init-endpoint panel -->
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <!-- init-endpoint form -->
+          <form class="form-horizontal" style="margin: 20px;" enctype="multipart/form-data" method="POST">
+            <!-- comment -->
+            <div class="form-group">
+              <p>Connect Portainer to a Docker engine or Swarm cluster endpoint.</p>
+            </div>
+            <!-- !comment input -->
+            <!-- endpoin-type radio -->
+            <div class="form-group">
+              <div class="radio">
+                <label><input type="radio" name="endpointType" value="local" ng-model="formValues.endpointType">Manage the Docker instance where Portainer is running</label>
+              </div>
+              <div class="radio">
+                <label><input type="radio" name="endpointType" value="remote" ng-model="formValues.endpointType">Manage a remote Docker instance</label>
+              </div>
+            </div>
+            <!-- endpoint-type radio -->
+            <!-- local-endpoint -->
+            <div ng-if="formValues.endpointType === 'local'" style="margin-top: 25px;">
+              <div class="form-group">
+                <div class="col-sm-12">
+                  <span class="small text-muted">Note: ensure that the Docker socket is bind mounted in the Portainer container at <code>/var/run/docker.sock</code></span>
+                </div>
+              </div>
+            </div>
+            <!-- !local-endpoint -->
+            <!-- remote-endpoint -->
+            <div ng-if="formValues.endpointType === 'remote'" style="margin-top: 25px;">
+              <!-- name-input -->
+              <div class="form-group">
+                <label for="container_name" class="col-sm-3 control-label text-left">Name</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+                </div>
+              </div>
+              <!-- !name-input -->
+              <!-- endpoint-url-input -->
+              <div class="form-group">
+                <label for="endpoint_url" class="col-sm-3 control-label text-left">Endpoint URL</label>
+                <div class="col-sm-9">
+                  <div class="input-group">
+                    <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
+                    <span class="input-group-btn">
+                      <button class="btn btn-info" type="button">Test</button>
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <!-- !endpoint-url-input -->
+              <!-- tls-checkbox -->
+              <div class="form-group">
+                <label for="tls" class="col-sm-3 control-label text-left">TLS</label>
+                <div class="col-sm-9">
+                  <input type="checkbox" name="tls" ng-model="formValues.TLS">
+                </div>
+              </div>
+              <!-- !tls-checkbox -->
+              <!-- tls-certs -->
+              <div ng-if="formValues.TLS">
+                <!-- ca-input -->
+                <div class="form-group">
+                  <label class="col-sm-3 control-label text-left">TLS CA certificate</label>
+                  <div class="col-sm-9">
+                      <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                      <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
+                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
+                      </span>
+                      <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
+                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                      </span>
+                  </div>
+                </div>
+                <!-- !ca-input -->
+                <!-- cert-input -->
+                <div class="form-group">
+                  <label for="tls_cert" class="col-sm-3 control-label text-left">TLS certificate</label>
+                  <div class="col-sm-9">
+                    <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
+                    required
+                    ngf-model-invalid="errorFile" />
+                  </div>
+                </div>
+                <!-- !cert-input -->
+                <!-- key-input -->
+                <div class="form-group">
+                  <label class="col-sm-3 control-label text-left">TLS key</label>
+                  <div class="col-sm-9">
+                      <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                      <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
+                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
+                      </span>
+                      <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
+                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                      </span>
+                  </div>
+                </div>
+                <!-- !key-input -->
+              </div>
+              <!-- !tls-certs -->
+            </div>
+            <!-- !remote-endpoint -->
+            <!-- create button -->
+            <div class="form-group" style="margin-top: 10px;">
+              <div class="col-sm-12 controls">
+                <p class="pull-left text-danger" ng-if="true" style="margin: 5px;">
+                  <i class="fa fa-exclamation-circle" aria-hidden="true"></i> Any error will be displayed here
+                </p>
+                <button type="submit" class="btn btn-primary pull-right" ng-click="createPrimaryEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
+              </div>
+            </div>
+            <!-- !create button -->
+          </form>
+          <!-- !init-endpoint form -->
+        </div>
+      </div>
+      <!-- !init-endpoint panel -->
+    </div>
+  </div>
+  <!-- !login box -->
+</div>

--- a/app/components/endpointInit/endpointInit.html
+++ b/app/components/endpointInit/endpointInit.html
@@ -74,7 +74,7 @@
                 <div class="form-group">
                   <label class="col-sm-3 control-label text-left">TLS CA certificate</label>
                   <div class="col-sm-9">
-                      <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
                       <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
                         <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
                       </span>
@@ -88,9 +88,13 @@
                 <div class="form-group">
                   <label for="tls_cert" class="col-sm-3 control-label text-left">TLS certificate</label>
                   <div class="col-sm-9">
-                    <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
-                    required
-                    ngf-model-invalid="errorFile" />
+                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                      <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
+                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
+                      </span>
+                      <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
+                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                      </span>
                   </div>
                 </div>
                 <!-- !cert-input -->
@@ -98,7 +102,7 @@
                 <div class="form-group">
                   <label class="col-sm-3 control-label text-left">TLS key</label>
                   <div class="col-sm-9">
-                      <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
                       <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
                         <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
                       </span>

--- a/app/components/endpointInit/endpointInit.html
+++ b/app/components/endpointInit/endpointInit.html
@@ -1,13 +1,13 @@
 <div class="page-wrapper">
-  <!-- login box -->
+  <!-- simple box -->
   <div class="container simple-box">
     <div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2">
-      <!-- login box logo -->
+      <!-- simple box logo -->
       <div class="row">
         <img ng-if="logo" ng-src="{{ logo }}" class="simple-box-logo">
         <img ng-if="!logo" src="images/logo_alt.png" class="simple-box-logo" alt="Portainer">
       </div>
-      <!-- !login box logo -->
+      <!-- !simple box logo -->
       <!-- init-endpoint panel -->
       <div class="panel panel-default">
         <div class="panel-body">
@@ -35,6 +35,16 @@
                   <span class="small text-muted">Note: ensure that the Docker socket is bind mounted in the Portainer container at <code>/var/run/docker.sock</code></span>
                 </div>
               </div>
+              <!-- connect button -->
+              <div class="form-group" style="margin-top: 10px;">
+                <div class="col-sm-12 controls">
+                  <p class="pull-left text-danger" ng-if="state.error" style="margin: 5px;">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ state.error }}
+                  </p>
+                  <button type="submit" class="btn btn-primary pull-right" ng-click="createLocalEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
+                </div>
+              </div>
+              <!-- !connect button -->
             </div>
             <!-- !local-endpoint -->
             <!-- remote-endpoint -->
@@ -43,7 +53,7 @@
               <div class="form-group">
                 <label for="container_name" class="col-sm-3 control-label text-left">Name</label>
                 <div class="col-sm-9">
-                  <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+                  <input type="text" class="form-control" id="container_name" ng-model="formValues.Name" placeholder="e.g. docker-prod01">
                 </div>
               </div>
               <!-- !name-input -->
@@ -51,12 +61,7 @@
               <div class="form-group">
                 <label for="endpoint_url" class="col-sm-3 control-label text-left">Endpoint URL</label>
                 <div class="col-sm-9">
-                  <div class="input-group">
-                    <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
-                    <span class="input-group-btn">
-                      <button class="btn btn-info" type="button">Test</button>
-                    </span>
-                  </div>
+                  <input type="text" class="form-control" id="endpoint_url" ng-model="formValues.URL" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
                 </div>
               </div>
               <!-- !endpoint-url-input -->
@@ -74,13 +79,12 @@
                 <div class="form-group">
                   <label class="col-sm-3 control-label text-left">TLS CA certificate</label>
                   <div class="col-sm-9">
-                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
-                      <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
-                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
-                      </span>
-                      <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
-                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                      </span>
+                    <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                    <span style="margin-left: 5px;">
+                      {{ formValues.TLSCACert.name }}
+                      <i class="fa fa-times red-icon" ng-if="!formValues.TLSCACert" aria-hidden="true"></i>
+                      <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                    </span>
                   </div>
                 </div>
                 <!-- !ca-input -->
@@ -88,13 +92,12 @@
                 <div class="form-group">
                   <label for="tls_cert" class="col-sm-3 control-label text-left">TLS certificate</label>
                   <div class="col-sm-9">
-                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                      <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
-                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
-                      </span>
-                      <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
-                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                      </span>
+                    <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                    <span style="margin-left: 5px;">
+                      {{ formValues.TLSCert.name }}
+                      <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                      <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                    </span>
                   </div>
                 </div>
                 <!-- !cert-input -->
@@ -102,30 +105,29 @@
                 <div class="form-group">
                   <label class="col-sm-3 control-label text-left">TLS key</label>
                   <div class="col-sm-9">
-                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                      <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
-                        <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
-                      </span>
-                      <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
-                        <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                      </span>
+                    <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                    <span style="margin-left: 5px;">
+                      {{ formValues.TLSKey.name }}
+                      <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                      <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                    </span>
                   </div>
                 </div>
                 <!-- !key-input -->
               </div>
               <!-- !tls-certs -->
+              <!-- connect button -->
+              <div class="form-group" style="margin-top: 10px;">
+                <div class="col-sm-12 controls">
+                  <p class="pull-left text-danger" ng-if="state.error" style="margin: 5px;">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ state.error }}
+                  </p>
+                  <button type="submit" class="btn btn-primary pull-right" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="createRemoteEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
+                </div>
+              </div>
+              <!-- !connect button -->
             </div>
             <!-- !remote-endpoint -->
-            <!-- create button -->
-            <div class="form-group" style="margin-top: 10px;">
-              <div class="col-sm-12 controls">
-                <p class="pull-left text-danger" ng-if="true" style="margin: 5px;">
-                  <i class="fa fa-exclamation-circle" aria-hidden="true"></i> Any error will be displayed here
-                </p>
-                <button type="submit" class="btn btn-primary pull-right" ng-click="createPrimaryEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
-              </div>
-            </div>
-            <!-- !create button -->
           </form>
           <!-- !init-endpoint form -->
         </div>
@@ -133,5 +135,5 @@
       <!-- !init-endpoint panel -->
     </div>
   </div>
-  <!-- !login box -->
+  <!-- !simple box -->
 </div>

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -38,6 +38,7 @@ function ($scope, $state, EndpointService, Messages) {
     EndpointService.createRemoteEndpoint(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, TLS ? false : true).then(function success(data) {
       $state.go('dashboard');
     }, function error(err) {
+      $scope.state.uploadInProgress = false;
       $scope.state.error = err.msg;
     }, function update(evt) {
       if (evt.upload) {

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -1,11 +1,48 @@
 angular.module('endpointInit', [])
-.controller('EndpointInitController', ['$scope',
-function ($scope) {
+.controller('EndpointInitController', ['$scope', '$state', 'EndpointService', 'Messages',
+function ($scope, $state, EndpointService, Messages) {
+  $scope.state = {
+    error: '',
+    uploadInProgress: false
+  };
   $scope.formValues = {
     endpointType: "remote",
+    Name: '',
+    URL: '',
     TLS: false,
     TLSCACert: null,
     TLSCert: null,
     TLSKey: null
+  };
+
+  $scope.createLocalEndpoint = function() {
+    $scope.state.error = '';
+    var name = "local";
+    var URL = "unix:///var/run/docker.sock";
+    var TLS = false;
+    EndpointService.createLocalEndpoint(name, URL, TLS, true).then(function success(data) {
+      $state.go('dashboard');
+    }, function error(err) {
+      $scope.state.error = 'Unable to create endpoint';
+    });
+  };
+
+  $scope.createRemoteEndpoint = function() {
+    $scope.state.error = '';
+    var name = $scope.formValues.Name;
+    var URL = "tcp://" + $scope.formValues.URL;
+    var TLS = $scope.formValues.TLS;
+    var TLSCAFile = $scope.formValues.TLSCACert;
+    var TLSCertFile = $scope.formValues.TLSCert;
+    var TLSKeyFile = $scope.formValues.TLSKey;
+    EndpointService.createRemoteEndpoint(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, TLS ? false : true).then(function success(data) {
+      $state.go('dashboard');
+    }, function error(err) {
+      $scope.state.error = err.msg;
+    }, function update(evt) {
+      if (evt.upload) {
+        $scope.state.uploadInProgress = evt.upload;
+      }
+    });
   };
 }]);

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -30,7 +30,7 @@ function ($scope, $state, EndpointService, Messages) {
   $scope.createRemoteEndpoint = function() {
     $scope.state.error = '';
     var name = $scope.formValues.Name;
-    var URL = "tcp://" + $scope.formValues.URL;
+    var URL = $scope.formValues.URL;
     var TLS = $scope.formValues.TLS;
     var TLSCAFile = $scope.formValues.TLSCACert;
     var TLSCertFile = $scope.formValues.TLSCert;

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -15,6 +15,14 @@ function ($scope, $state, EndpointService, Messages) {
     TLSKey: null
   };
 
+  EndpointService.getActive().then(function success(data) {
+    $state.go('dashboard');
+  }, function error(err) {
+    if (err.status !== 404) {
+      Messages.error("Failure", err, 'Unable to verify Docker endpoint existence');
+    }
+  });
+
   $scope.createLocalEndpoint = function() {
     $scope.state.error = '';
     var name = "local";

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -1,0 +1,11 @@
+angular.module('endpointInit', [])
+.controller('EndpointInitController', ['$scope',
+function ($scope) {
+  $scope.formValues = {
+    endpointType: "remote",
+    TLS: false,
+    TLSCACert: null,
+    TLSCert: null,
+    TLSKey: null
+  };
+}]);

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -1,6 +1,8 @@
 <rd-header>
   <rd-header-title title="Endpoints">
-    <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
+    <a data-toggle="tooltip" title="Refresh" ui-sref="endpoints" ui-sref-opts="{reload: true}">
+      <i class="fa fa-refresh" aria-hidden="true"></i>
+    </a>
   </rd-header-title>
   <rd-header-content>Endpoint management</rd-header-content>
 </rd-header>
@@ -16,7 +18,7 @@
           <div class="form-group">
             <label for="container_name" class="col-sm-2 control-label text-left">Name</label>
             <div class="col-sm-10">
-              <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+              <input type="text" class="form-control" id="container_name" ng-model="formValues.Name" placeholder="e.g. docker-prod01">
             </div>
           </div>
           <!-- !name-input -->
@@ -24,12 +26,7 @@
           <div class="form-group">
             <label for="endpoint_url" class="col-sm-2 control-label text-left">Endpoint URL</label>
             <div class="col-sm-10">
-              <div class="input-group">
-                <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
-                <span class="input-group-btn">
-                  <button class="btn btn-info" type="button">Test</button>
-                </span>
-              </div>
+              <input type="text" class="form-control" id="endpoint_url" ng-model="formValues.URL" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
             </div>
           </div>
           <!-- !endpoint-url-input -->
@@ -47,13 +44,12 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
-                  <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
-                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
-                  </span>
-                  <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
-                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                  </span>
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                <span style="margin-left: 5px;">
+                  {{ formValues.TLSCACert.name }}
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCACert" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                </span>
               </div>
             </div>
             <!-- !ca-input -->
@@ -62,11 +58,10 @@
               <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
-                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
-                </span>
-                <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
-                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                <span style="margin-left: 5px;">
+                  {{ formValues.TLSCert.name }}
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
                 </span>
               </div>
             </div>
@@ -76,11 +71,10 @@
               <label class="col-sm-2 control-label text-left">TLS key</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
-                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
-                </span>
-                <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
-                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                <span style="margin-left: 5px;">
+                  {{ formValues.TLSKey.name }}
+                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
                 </span>
               </div>
             </div>
@@ -89,8 +83,11 @@
           <!-- !tls-certs -->
           <div class="form-group">
             <div class="col-sm-12">
-              <button type="button" class="btn btn-primary btn-sm">Add endpoint</button>
+              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="addEndpoint()">Add endpoint</button>
               <i id="createEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
+              <span class="text-danger" ng-if="state.error" style="margin: 5px;">
+                <i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ state.error }}
+              </span>
             </div>
           </div>
         </form>
@@ -136,15 +133,22 @@
                   </a>
                 </th>
                 <th>
+                  <a ui-sref="endpoints" ng-click="order('TLS')">
+                    TLS
+                    <span ng-show="sortType == 'TLS' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
+                    <span ng-show="sortType == 'TLS' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
+                  </a>
                 </th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
               <tr dir-paginate="endpoint in (state.filteredEndpoints = (endpoints | filter:state.filter | orderBy:sortType:sortReverse | itemsPerPage: pagination_count))">
                 <td><input type="checkbox" ng-model="endpoint.Checked" ng-change="selectItem(endpoint)" /></td>
                 <td>{{ endpoint.Name }}</td>
-                <td>{{ endpoint.URL }}</td>
-                <td><a ui-sref="endpoint({id: 'test'})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a></td>
+                <td>{{ endpoint.URL | stripprotocol }}</td>
+                <td><i class="fa fa-shield" aria-hidden="true" ng-if="endpoint.TLS"></i></td>
+                <td><a ui-sref="endpoint({id: endpoint.Id})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a></td>
               </tr>
               <tr ng-if="!endpoints">
                 <td colspan="5" class="text-center text-muted">Loading...</td>
@@ -159,6 +163,6 @@
           </div>
         </div>
       </rd-widget-body>
-      <rd-widget>
-      </div>
-    </div>
+    <rd-widget>
+  </div>
+</div>

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -1,0 +1,160 @@
+<rd-header>
+  <rd-header-title title="Endpoints">
+    <i id="loadingViewSpinner" class="fa fa-cog fa-spin"></i>
+  </rd-header-title>
+  <rd-header-content>Endpoint management</rd-header-content>
+</rd-header>
+
+<div class="row">
+  <div class="col-lg-12 col-md-12 col-xs-12">
+    <rd-widget>
+      <rd-widget-header icon="fa-plus" title="Add a new endpoint">
+      </rd-widget-header>
+      <rd-widget-body>
+        <form class="form-horizontal">
+          <!-- name-input -->
+          <div class="form-group">
+            <label for="container_name" class="col-sm-2 control-label text-left">Name</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="container_name" placeholder="e.g. docker-prod01">
+            </div>
+          </div>
+          <!-- !name-input -->
+          <!-- endpoint-url-input -->
+          <div class="form-group">
+            <label for="endpoint_url" class="col-sm-2 control-label text-left">Endpoint URL</label>
+            <div class="col-sm-10">
+              <div class="input-group">
+                <input type="text" class="form-control" id="endpoint_url" placeholder="e.g. 10.0.0.10:2375 or mydocker.mydomain.com:2375">
+                <span class="input-group-btn">
+                  <button class="btn btn-info" type="button">Test</button>
+                </span>
+              </div>
+            </div>
+          </div>
+          <!-- !endpoint-url-input -->
+          <!-- tls-checkbox -->
+          <div class="form-group">
+            <label for="tls" class="col-sm-2 control-label text-left">TLS</label>
+            <div class="col-sm-10">
+              <input type="checkbox" name="tls" ng-model="formValues.TLS">
+            </div>
+          </div>
+          <!-- !tls-checkbox -->
+          <!-- tls-certs -->
+          <div ng-if="formValues.TLS">
+            <!-- ca-input -->
+            <div class="form-group">
+              <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
+              <div class="col-sm-10">
+                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                  <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
+                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
+                  </span>
+                  <span ng-if="!formValues.TLSCACert" style="margin-left: 5px;">
+                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                  </span>
+              </div>
+            </div>
+            <!-- !ca-input -->
+            <!-- cert-input -->
+            <div class="form-group">
+              <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
+              <div class="col-sm-10">
+                <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
+                required
+                ngf-model-invalid="errorFile" />
+              </div>
+            </div>
+            <!-- !cert-input -->
+            <!-- key-input -->
+            <div class="form-group">
+              <label class="col-sm-2 control-label text-left">TLS key</label>
+              <div class="col-sm-10">
+                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                  <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
+                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
+                  </span>
+                  <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
+                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                  </span>
+              </div>
+            </div>
+            <!-- !key-input -->
+          </div>
+          <!-- !tls-certs -->
+          <div class="form-group">
+            <div class="col-sm-12">
+              <button type="button" class="btn btn-default btn-sm">Add endpoint</button>
+              <i id="createEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
+            </div>
+          </div>
+        </form>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-12 col-md-12 col-xs-12">
+    <rd-widget>
+      <rd-widget-header icon="fa-plug" title="Endpoints">
+        <div class="pull-right">
+          <i id="loadEndpointsSpinner" class="fa fa-cog fa-2x fa-spin" style="margin-top: 5px;"></i>
+        </div>
+      </rd-widget-header>
+      <rd-widget-taskbar classes="col-lg-12">
+        <div class="pull-left">
+          <button type="button" class="btn btn-danger" ng-click="removeAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-trash space-right" aria-hidden="true"></i>Remove</button>
+        </div>
+        <div class="pull-right">
+          <input type="text" id="filter" ng-model="state.filter" placeholder="Filter..." class="form-control input-sm" />
+        </div>
+      </rd-widget-taskbar>
+      <rd-widget-body classes="no-padding">
+        <div class="table-responsive">
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th></th>
+                <th>
+                  <a ui-sref="endpoints" ng-click="order('Name')">
+                    Name
+                    <span ng-show="sortType == 'Name' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
+                    <span ng-show="sortType == 'Name' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
+                  </a>
+                </th>
+                <th>
+                  <a ui-sref="endpoints" ng-click="order('URL')">
+                    URL
+                    <span ng-show="sortType == 'URL' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
+                    <span ng-show="sortType == 'URL' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
+                  </a>
+                </th>
+                <th>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr dir-paginate="endpoint in (state.filteredEndpoints = (endpoints | filter:state.filter | orderBy:sortType:sortReverse | itemsPerPage: pagination_count))">
+                <td><input type="checkbox" ng-model="endpoint.Checked" ng-change="selectItem(endpoint)" /></td>
+                <td>{{ endpoint.Name }}</td>
+                <td>{{ endpoint.URL }}</td>
+                <td><a ui-sref="endpoint({id: 'test'})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a></td>
+              </tr>
+              <tr ng-if="!endpoints">
+                <td colspan="5" class="text-center text-muted">Loading...</td>
+              </tr>
+              <tr ng-if="endpoints.length == 0">
+                <td colspan="5" class="text-center text-muted">No endpoints available.</td>
+              </tr>
+            </tbody>
+          </table>
+          <div ng-if="endpoints" class="pull-left pagination-controls">
+            <dir-pagination-controls></dir-pagination-controls>
+          </div>
+        </div>
+      </rd-widget-body>
+      <rd-widget>
+      </div>
+    </div>

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -47,7 +47,7 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSCACert">Select file</button>
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
                   <span ng-if="formValues.TLSCACert" style="margin-left: 5px;">
                     <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCACert.name }}
                   </span>
@@ -61,9 +61,13 @@
             <div class="form-group">
               <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
-                <input type="file" ngf-select ng-model="formValues.TLSCert" name="tls_cert"
-                required
-                ngf-model-invalid="errorFile" />
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                <span ng-if="formValues.TLSCert" style="margin-left: 5px;">
+                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSCert.name }}
+                </span>
+                <span ng-if="!formValues.TLSCert" style="margin-left: 5px;">
+                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                </span>
               </div>
             </div>
             <!-- !cert-input -->
@@ -71,13 +75,13 @@
             <div class="form-group">
               <label class="col-sm-2 control-label text-left">TLS key</label>
               <div class="col-sm-10">
-                  <button class="btn btn-sm btn-default" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                  <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
-                    <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
-                  </span>
-                  <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
-                    <i class="fa fa-times red-icon" aria-hidden="true"></i>
-                  </span>
+                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                <span ng-if="formValues.TLSKey" style="margin-left: 5px;">
+                  <i class="fa fa-check green-icon" aria-hidden="true"></i> {{ formValues.TLSKey.name }}
+                </span>
+                <span ng-if="!formValues.TLSKey" style="margin-left: 5px;">
+                  <i class="fa fa-times red-icon" aria-hidden="true"></i>
+                </span>
               </div>
             </div>
             <!-- !key-input -->
@@ -85,7 +89,7 @@
           <!-- !tls-certs -->
           <div class="form-group">
             <div class="col-sm-12">
-              <button type="button" class="btn btn-default btn-sm">Add endpoint</button>
+              <button type="button" class="btn btn-primary btn-sm">Add endpoint</button>
               <i id="createEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
             </div>
           </div>

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -145,10 +145,17 @@
             <tbody>
               <tr dir-paginate="endpoint in (state.filteredEndpoints = (endpoints | filter:state.filter | orderBy:sortType:sortReverse | itemsPerPage: pagination_count))">
                 <td><input type="checkbox" ng-model="endpoint.Checked" ng-change="selectItem(endpoint)" /></td>
-                <td>{{ endpoint.Name }}</td>
+                <td><i class="fa fa-star" aria-hidden="true" ng-if="endpoint.Id === activeEndpoint.Id"></i> {{ endpoint.Name }}</td>
                 <td>{{ endpoint.URL | stripprotocol }}</td>
                 <td><i class="fa fa-shield" aria-hidden="true" ng-if="endpoint.TLS"></i></td>
-                <td><a ui-sref="endpoint({id: endpoint.Id})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a></td>
+                <td>
+                  <span ng-if="endpoint.Id !== activeEndpoint.Id">
+                    <a ui-sref="endpoint({id: endpoint.Id})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a>
+                  </span>
+                  <span class="small text-muted" ng-if="endpoint.Id === activeEndpoint.Id">
+                    <i class="fa fa-lock" aria-hidden="true"></i> You cannot edit the active endpoint
+                  </span>
+              </td>
               </tr>
               <tr ng-if="!endpoints">
                 <td colspan="5" class="text-center text-muted">Loading...</td>

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -44,6 +44,7 @@ function ($scope, $state, EndpointService, Settings, Messages) {
       Messages.send("Endpoint created", name);
       $state.reload();
     }, function error(err) {
+      $scope.state.uploadInProgress = false;
       $scope.state.error = err.msg;
     }, function update(evt) {
       if (evt.upload) {

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -1,31 +1,23 @@
 angular.module('endpoints', [])
-.controller('EndpointsController', ['$scope', 'Settings',
-function ($scope, Settings) {
-  $scope.state = {};
+.controller('EndpointsController', ['$scope', '$state', 'EndpointService', 'Settings', 'Messages',
+function ($scope, $state, EndpointService, Settings, Messages) {
+  $scope.state = {
+    error: '',
+    uploadInProgress: false,
+    selectedItemCount: 0,
+  };
   $scope.sortType = 'Name';
   $scope.sortReverse = true;
   $scope.pagination_count = Settings.pagination_count;
 
   $scope.formValues = {
+    Name: '',
+    URL: '',
+    TLS: false,
+    TLSCACert: null,
+    TLSCert: null,
+    TLSKey: null
   };
-
-  $scope.endpoints = [
-    {
-      Name: "docker-prod01",
-      URL: "23.239.34.54:3475",
-      Checked: false
-    },
-    {
-      Name: "docker-prod02",
-      URL: "23.239.34.55:3475",
-      Checked: false
-    },
-    {
-      Name: "docker-staging01",
-      URL: "dockerhost.mycustomdomain.com:2375",
-      Checked: false
-    }
-  ];
 
   $scope.order = function(sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;
@@ -39,4 +31,63 @@ function ($scope, Settings) {
       $scope.state.selectedItemCount--;
     }
   };
+
+  $scope.addEndpoint = function() {
+    $scope.state.error = '';
+    var name = $scope.formValues.Name;
+    var URL = "tcp://" + $scope.formValues.URL;
+    var TLS = $scope.formValues.TLS;
+    var TLSCAFile = $scope.formValues.TLSCACert;
+    var TLSCertFile = $scope.formValues.TLSCert;
+    var TLSKeyFile = $scope.formValues.TLSKey;
+    EndpointService.createRemoteEndpoint(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, false).then(function success(data) {
+      Messages.send("Endpoint created", name);
+      $state.go('endpoints', {}, {reload: true});
+    }, function error(err) {
+      $scope.state.error = err.msg;
+    }, function update(evt) {
+      if (evt.upload) {
+        $scope.state.uploadInProgress = evt.upload;
+      }
+    });
+  };
+
+  $scope.removeAction = function () {
+    $('#loadEndpointsSpinner').show();
+    var counter = 0;
+    var complete = function () {
+      counter = counter - 1;
+      if (counter === 0) {
+        $('#loadEndpointsSpinner').hide();
+      }
+    };
+    angular.forEach($scope.endpoints, function (endpoint) {
+      if (endpoint.Checked) {
+        counter = counter + 1;
+        EndpointService.deleteEndpoint(endpoint.Id).then(function success(data) {
+          Messages.send("Endpoint deleted", endpoint.Name);
+          var index = $scope.endpoints.indexOf(endpoint);
+          $scope.endpoints.splice(index, 1);
+          complete();
+        }, function error(err) {
+          Messages.error("Failure", err, 'Unable to remove endpoint');
+          complete();
+        });
+      }
+    });
+  };
+
+  function fetchEndpoints() {
+    $('#loadEndpointsSpinner').show();
+    EndpointService.endpoints().then(function success(data) {
+      $scope.endpoints = data;
+      $('#loadEndpointsSpinner').hide();
+    }, function error(err) {
+      $('#loadEndpointsSpinner').hide();
+      Messages.error("Failure", err, "Unable to retrieve endpoints");
+      $scope.networks = [];
+    });
+  }
+
+  fetchEndpoints();
 }]);

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -1,0 +1,42 @@
+angular.module('endpoints', [])
+.controller('EndpointsController', ['$scope', 'Settings',
+function ($scope, Settings) {
+  $scope.state = {};
+  $scope.sortType = 'Name';
+  $scope.sortReverse = true;
+  $scope.pagination_count = Settings.pagination_count;
+
+  $scope.formValues = {
+  };
+
+  $scope.endpoints = [
+    {
+      Name: "docker-prod01",
+      URL: "23.239.34.54:3475",
+      Checked: false
+    },
+    {
+      Name: "docker-prod02",
+      URL: "23.239.34.55:3475",
+      Checked: false
+    },
+    {
+      Name: "docker-staging01",
+      URL: "dockerhost.mycustomdomain.com:2375",
+      Checked: false
+    }
+  ];
+
+  $scope.order = function(sortType) {
+    $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;
+    $scope.sortType = sortType;
+  };
+
+  $scope.selectItem = function (item) {
+    if (item.Checked) {
+      $scope.state.selectedItemCount++;
+    } else {
+      $scope.state.selectedItemCount--;
+    }
+  };
+}]);

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -4,7 +4,7 @@ function ($scope, $state, EndpointService, Settings, Messages) {
   $scope.state = {
     error: '',
     uploadInProgress: false,
-    selectedItemCount: 0,
+    selectedItemCount: 0
   };
   $scope.sortType = 'Name';
   $scope.sortReverse = true;
@@ -42,7 +42,7 @@ function ($scope, $state, EndpointService, Settings, Messages) {
     var TLSKeyFile = $scope.formValues.TLSKey;
     EndpointService.createRemoteEndpoint(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, false).then(function success(data) {
       Messages.send("Endpoint created", name);
-      $state.go('endpoints', {}, {reload: true});
+      $state.reload();
     }, function error(err) {
       $scope.state.error = err.msg;
     }, function update(evt) {
@@ -85,7 +85,7 @@ function ($scope, $state, EndpointService, Settings, Messages) {
     }, function error(err) {
       $('#loadEndpointsSpinner').hide();
       Messages.error("Failure", err, "Unable to retrieve endpoints");
-      $scope.networks = [];
+      $scope.endpoints = [];
     });
   }
 

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -35,7 +35,7 @@ function ($scope, $state, EndpointService, Settings, Messages) {
   $scope.addEndpoint = function() {
     $scope.state.error = '';
     var name = $scope.formValues.Name;
-    var URL = "tcp://" + $scope.formValues.URL;
+    var URL = $scope.formValues.URL;
     var TLS = $scope.formValues.TLS;
     var TLSCAFile = $scope.formValues.TLSCACert;
     var TLSCertFile = $scope.formValues.TLSCert;
@@ -81,7 +81,13 @@ function ($scope, $state, EndpointService, Settings, Messages) {
     $('#loadEndpointsSpinner').show();
     EndpointService.endpoints().then(function success(data) {
       $scope.endpoints = data;
-      $('#loadEndpointsSpinner').hide();
+      EndpointService.getActive().then(function success(data) {
+        $scope.activeEndpoint = data;
+        $('#loadEndpointsSpinner').hide();
+      }, function error(err) {
+        $('#loadEndpointsSpinner').hide();
+        Messages.error("Failure", err, "Unable to retrieve active endpoint");
+      });
     }, function error(err) {
       $('#loadEndpointsSpinner').hide();
       Messages.error("Failure", err, "Unable to retrieve endpoints");

--- a/app/components/images/imagesController.js
+++ b/app/components/images/imagesController.js
@@ -38,7 +38,7 @@ function ($scope, $state, Config, Image, ImageHelper, Messages, Settings) {
           Messages.error('Error', {}, detail.error);
         } else {
           $('#pullImageSpinner').hide();
-          $state.go('images', {}, {reload: true});
+          $state.reload();
         }
     }, function (e) {
       $('#pullImageSpinner').hide();

--- a/app/components/networks/networksController.js
+++ b/app/components/networks/networksController.js
@@ -13,7 +13,7 @@ function ($scope, $state, Network, Config, Messages, Settings) {
 
   function prepareNetworkConfiguration() {
     var config = angular.copy($scope.config);
-    if ($scope.swarm) {
+    if ($scope.endpointMode.provider === 'DOCKER_SWARM' || $scope.endpointMode.provider === 'DOCKER_SWARM_MODE') {
       config.Driver = 'overlay';
       // Force IPAM Driver to 'default', should not be required.
       // See: https://github.com/docker/docker/issues/25735
@@ -97,7 +97,6 @@ function ($scope, $state, Network, Config, Messages, Settings) {
   }
 
   Config.$promise.then(function (c) {
-    $scope.swarm = c.swarm;
     fetchNetworks();
   });
 }]);

--- a/app/components/networks/networksController.js
+++ b/app/components/networks/networksController.js
@@ -34,7 +34,7 @@ function ($scope, $state, Network, Config, Messages, Settings) {
       } else {
         Messages.send("Network created", d.Id);
         $('#createNetworkSpinner').hide();
-        $state.go('networks', {}, {reload: true});
+        $state.reload();
       }
     }, function (e) {
       $('#createNetworkSpinner').hide();

--- a/app/components/services/servicesController.js
+++ b/app/components/services/servicesController.js
@@ -14,7 +14,7 @@ function ($scope, $stateParams, $state, Service, ServiceHelper, Messages, Settin
     Service.update({ id: service.Id, version: service.Version }, config, function (data) {
       $('#loadServicesSpinner').hide();
       Messages.send("Service successfully scaled", "New replica count: " + service.Replicas);
-      $state.go('services', {}, {reload: true});
+      $state.reload();
     }, function (e) {
       $('#loadServicesSpinner').hide();
       service.Scale = false;

--- a/app/components/settings/settingsController.js
+++ b/app/components/settings/settingsController.js
@@ -16,7 +16,7 @@ function ($scope, $state, $sanitize, Users, Messages) {
         var newPassword = $sanitize($scope.formValues.newPassword);
         Users.update({ username: $scope.username, password: newPassword }, function (d) {
           Messages.send("Success", "Password successfully updated");
-          $state.go('settings', {}, {reload: true});
+          $state.reload();
         }, function (e) {
           Messages.error("Failure", e, "Unable to update password");
         });

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -8,7 +8,7 @@
         <span class="menu-icon glyphicon glyphicon-transfer"></span>
       </a>
     </li>
-    <li class="sidebar-title"><span>NAVIGATION</span></li>
+    <li class="sidebar-title"><span>ENDPOINT_NAME</span></li>
     <li class="sidebar-list">
       <a ui-sref="dashboard">Dashboard <span class="menu-icon fa fa-tachometer"></span></a>
     </li>
@@ -39,8 +39,12 @@
     <li class="sidebar-list" ng-if="endpointMode.provider === 'DOCKER_STANDALONE'">
       <a ui-sref="docker">Docker <span class="menu-icon fa fa-th"></span></a>
     </li>
+    <li class="sidebar-title"><span>SETTINGS</span></li>
     <li class="sidebar-list">
-      <a ui-sref="settings">Settings <span class="menu-icon fa fa-wrench"></span></a>
+      <a ui-sref="settings">General <span class="menu-icon fa fa-wrench"></span></a>
+    </li>
+    <li class="sidebar-list">
+      <a ui-sref="endpoints">Endpoints <span class="menu-icon fa fa-plug"></span></a>
     </li>
   </ul>
   <div class="sidebar-footer">

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -8,7 +8,11 @@
         <span class="menu-icon glyphicon glyphicon-transfer"></span>
       </a>
     </li>
-    <li class="sidebar-title"><span>ENDPOINT_NAME</span></li>
+    <li class="sidebar-title" ng-if="endpoints">
+      <select class="select-endpoint form-control" ng-options="endpoint.Name for endpoint in endpoints" ng-model="activeEndpoint" ng-change="switchEndpoint(activeEndpoint)">
+      </select>
+    </li>
+    <li class="sidebar-title"><span>Endpoint</span></li>
     <li class="sidebar-list">
       <a ui-sref="dashboard">Dashboard <span class="menu-icon fa fa-tachometer"></span></a>
     </li>

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -8,11 +8,14 @@
         <span class="menu-icon glyphicon glyphicon-transfer"></span>
       </a>
     </li>
-    <li class="sidebar-title" ng-if="endpoints">
+    <li class="sidebar-title">
+      <span>Active endpoint</span>
+    </li>
+    <li class="sidebar-title">
       <select class="select-endpoint form-control" ng-options="endpoint.Name for endpoint in endpoints" ng-model="activeEndpoint" ng-change="switchEndpoint(activeEndpoint)">
       </select>
     </li>
-    <li class="sidebar-title"><span>Endpoint</span></li>
+    <li class="sidebar-title"><span>Endpoint actions</span></li>
     <li class="sidebar-list">
       <a ui-sref="dashboard">Dashboard <span class="menu-icon fa fa-tachometer"></span></a>
     </li>
@@ -43,9 +46,9 @@
     <li class="sidebar-list" ng-if="endpointMode.provider === 'DOCKER_STANDALONE'">
       <a ui-sref="docker">Docker <span class="menu-icon fa fa-th"></span></a>
     </li>
-    <li class="sidebar-title"><span>SETTINGS</span></li>
+    <li class="sidebar-title"><span>Portainer settings</span></li>
     <li class="sidebar-list">
-      <a ui-sref="settings">General <span class="menu-icon fa fa-wrench"></span></a>
+      <a ui-sref="settings">Password <span class="menu-icon fa fa-lock"></span></a>
     </li>
     <li class="sidebar-list">
       <a ui-sref="endpoints">Endpoints <span class="menu-icon fa fa-plug"></span></a>

--- a/app/components/sidebar/sidebarController.js
+++ b/app/components/sidebar/sidebarController.js
@@ -1,10 +1,37 @@
 angular.module('sidebar', [])
-.controller('SidebarController', ['$scope', 'Settings', 'Config', 'Info',
-function ($scope, Settings, Config, Info) {
+.controller('SidebarController', ['$scope', '$state', 'Settings', 'Config', 'EndpointService', 'Messages',
+function ($scope, $state, Settings, Config, EndpointService, Messages) {
 
   Config.$promise.then(function (c) {
     $scope.logo = c.logo;
   });
 
   $scope.uiVersion = Settings.uiVersion;
+
+  $scope.switchEndpoint = function(endpoint) {
+    EndpointService.setActive(endpoint.Id).then(function success(data) {
+      $state.reload();
+    }, function error(err) {
+      Messages.error("Failure", err, "Unable to switch to new endpoint");
+    });
+  };
+
+  function fetchEndpoints() {
+    EndpointService.endpoints().then(function success(data) {
+      $scope.endpoints = data;
+      EndpointService.getActive().then(function success(data) {
+        angular.forEach($scope.endpoints, function (endpoint) {
+          if (endpoint.Id === data.Id) {
+            $scope.activeEndpoint = endpoint;
+          }
+        });
+      }, function error(err) {
+        Messages.error("Failure", err, "Unable to retrieve active endpoint");
+      });
+    }, function error(err) {
+      $scope.endpoints = [];
+    });
+  }
+
+  fetchEndpoints();
 }]);

--- a/app/components/sidebar/sidebarController.js
+++ b/app/components/sidebar/sidebarController.js
@@ -1,6 +1,6 @@
 angular.module('sidebar', [])
-.controller('SidebarController', ['$scope', '$state', 'Settings', 'Config', 'EndpointService', 'Messages',
-function ($scope, $state, Settings, Config, EndpointService, Messages) {
+.controller('SidebarController', ['$scope', '$state', 'Settings', 'Config', 'EndpointService', 'EndpointMode', 'Messages',
+function ($scope, $state, Settings, Config, EndpointService, EndpointMode, Messages) {
 
   Config.$promise.then(function (c) {
     $scope.logo = c.logo;
@@ -10,6 +10,7 @@ function ($scope, $state, Settings, Config, EndpointService, Messages) {
 
   $scope.switchEndpoint = function(endpoint) {
     EndpointService.setActive(endpoint.Id).then(function success(data) {
+      EndpointMode.determineEndpointMode();
       $state.reload();
     }, function error(err) {
       Messages.error("Failure", err, "Unable to switch to new endpoint");

--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -32,7 +32,7 @@
             </div>
             <label for="container_network" class="col-sm-2 control-label text-right">Network</label>
             <div class="col-sm-4">
-              <select class="selectpicker form-control" ng-options="net.Name for net in availableNetworks" ng-model="formValues.network">
+              <select class="form-control" ng-options="net.Name for net in availableNetworks" ng-model="formValues.network">
                 <option disabled hidden value="">Select a network</option>
               </select>
             </div>
@@ -41,10 +41,10 @@
           <div ng-repeat="var in state.selectedTemplate.env" ng-if="!var.set" class="form-group">
             <label for="field_{{ $index }}" class="col-sm-2 control-label text-left">{{ var.label }}</label>
             <div class="col-sm-10">
-              <select ng-if="endpointMode.provider !== 'DOCKER_SWARM' && var.type === 'container'" ng-options="container|containername for container in runningContainers" class="selectpicker form-control" ng-model="var.value">
+              <select ng-if="endpointMode.provider !== 'DOCKER_SWARM' && var.type === 'container'" ng-options="container|containername for container in runningContainers" class="form-control" ng-model="var.value">
                 <option selected disabled hidden value="">Select a container</option>
               </select>
-              <select ng-if="endpointMode.provider === 'DOCKER_SWARM' && var.type === 'container'" ng-options="container|swarmcontainername for container in runningContainers" class="selectpicker form-control" ng-model="var.value">
+              <select ng-if="endpointMode.provider === 'DOCKER_SWARM' && var.type === 'container'" ng-options="container|swarmcontainername for container in runningContainers" class="form-control" ng-model="var.value">
                 <option selected disabled hidden value="">Select a container</option>
               </select>
               <input ng-if="!var.type || !var.type === 'container'" type="text" class="form-control" ng-model="var.value" id="field_{{ $index }}">
@@ -79,7 +79,7 @@
                   <input type="text" class="form-control" ng-model="portBinding.containerPort" placeholder="e.g. 80">
                 </div>
                 <div class="input-group col-sm-1 input-group-sm">
-                  <select class="selectpicker form-control" ng-model="portBinding.protocol">
+                  <select class="form-control" ng-model="portBinding.protocol">
                     <option value="tcp">tcp</option>
                     <option value="udp">udp</option>
                   </select>

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -115,7 +115,7 @@ function ($scope, $q, $state, $filter, $anchorScroll, Config, Info, Container, C
         if (v.value || v.set) {
           var val;
           if (v.type && v.type === 'container') {
-            if ($scope.swarm && $scope.formValues.network.Scope === 'global') {
+            if ($scope.endpointMode.provider === 'DOCKER_SWARM' && $scope.formValues.network.Scope === 'global') {
               val = $filter('swarmcontainername')(v.value);
             } else {
               var container = v.value;
@@ -203,11 +203,10 @@ function ($scope, $q, $state, $filter, $anchorScroll, Config, Info, Container, C
   }
 
   Config.$promise.then(function (c) {
-    $scope.swarm = c.swarm;
     var containersToHideLabels = c.hiddenLabels;
     Network.query({}, function (d) {
       var networks = d;
-      if ($scope.swarm) {
+      if ($scope.endpointMode.provider === 'DOCKER_SWARM' || $scope.endpointMode.provider === 'DOCKER_SWARM_MODE') {
         networks = d.filter(function (network) {
           if (network.Scope === 'global') {
             return network;

--- a/app/shared/filters.js
+++ b/app/shared/filters.js
@@ -106,6 +106,12 @@ angular.module('portainer.filters', [])
     return 'Stopped';
   };
 })
+.filter('stripprotocol', function() {
+  'use strict';
+  return function (url) {
+    return url.replace(/.*?:\/\//g, '');
+  };
+})
 .filter('getstatelabel', function () {
   'use strict';
   return function (state) {

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -189,12 +189,12 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         'use strict';
         // http://docs.docker.com/reference/api/docker_remote_api_<%= remoteApiVersion %>/#2-5-networks
         return $resource(Settings.url + '/volumes/:name/:action', {name: '@name'}, {
-            query: {method: 'GET'},
-            get: {method: 'GET'},
-            create: {method: 'POST', params: {action: 'create'}, transformResponse: genericHandler},
-            remove: {
-              method: 'DELETE', transformResponse: genericHandler
-            }
+          query: {method: 'GET'},
+          get: {method: 'GET'},
+          create: {method: 'POST', params: {action: 'create'}, transformResponse: genericHandler},
+          remove: {
+            method: 'DELETE', transformResponse: genericHandler
+          }
         });
     }])
     .factory('Config', ['$resource', 'CONFIG_ENDPOINT', function ConfigFactory($resource, CONFIG_ENDPOINT) {
@@ -233,11 +233,23 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
       'use strict';
       return $resource(USERS_ENDPOINT + '/:username/:action', {}, {
         create: { method: 'POST' },
-        get: {method: 'GET', params: { username: '@username' } },
+        get: { method: 'GET', params: { username: '@username' } },
         update: { method: 'PUT', params: { username: '@username' } },
         checkPassword: { method: 'POST', params: { username: '@username', action: 'passwd' } },
-        checkAdminUser: {method: 'GET', params: { username: 'admin', action: 'check' }},
-        initAdminUser: {method: 'POST', params: { username: 'admin', action: 'init' }}
+        checkAdminUser: { method: 'GET', params: { username: 'admin', action: 'check' } },
+        initAdminUser: { method: 'POST', params: { username: 'admin', action: 'init' } }
+      });
+    }])
+    .factory('Endpoints', ['$resource', 'ENDPOINTS_ENDPOINT', function EndpointsFactory($resource, ENDPOINTS_ENDPOINT) {
+      'use strict';
+      return $resource(ENDPOINTS_ENDPOINT + '/:id/:action', {}, {
+        create: { method: 'POST' },
+        query: { method: 'GET', isArray: true },
+        get: { method: 'GET', params: { id: '@id' } },
+        update: { method: 'PUT', params: { id: '@id' } },
+        remove: { method: 'DELETE', params: { id: '@id'} },
+        getActiveEndpoint: { method: 'GET', params: { id: '0' } },
+        setActiveEndpoint: { method: 'POST', params: { id: '@id', action: 'active' } }
       });
     }])
     .factory('EndpointMode', ['$rootScope', 'Info', function EndpointMode($rootScope, Info) {
@@ -301,6 +313,122 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         isAuthenticated: function() {
           var jwt = localStorageService.get('JWT');
           return jwt && !jwtHelper.isTokenExpired(jwt);
+        }
+      };
+    }])
+    .factory('FileUploadService', ['$q', 'Upload', function FileUploadFactory($q, Upload) {
+      'use strict';
+      function uploadFile(url, file) {
+        var deferred = $q.defer();
+        Upload.upload({
+          url: url,
+          data: { file: file }
+        }).then(function success(data) {
+          deferred.resolve(data);
+        }, function error(e) {
+          deferred.reject(e);
+        }, function progress(evt) {
+        });
+        return deferred.promise;
+      }
+      return {
+        uploadTLSFilesForEndpoint: function(endpointID, TLSCAFile, TLSCertFile, TLSKeyFile) {
+          var deferred = $q.defer();
+          var queue = [];
+
+          if (TLSCAFile !== null) {
+            var uploadTLSCA = uploadFile('api/upload/tls/' + endpointID + '/ca', TLSCAFile);
+            queue.push(uploadTLSCA);
+          }
+          if (TLSCertFile !== null) {
+            var uploadTLSCert = uploadFile('api/upload/tls/' + endpointID + '/cert', TLSCertFile);
+            queue.push(uploadTLSCert);
+          }
+          if (TLSKeyFile !== null) {
+            var uploadTLSKey = uploadFile('api/upload/tls/' + endpointID + '/key', TLSKeyFile);
+            queue.push(uploadTLSKey);
+          }
+          $q.all(queue).then(function (data) {
+            deferred.resolve(data);
+          }, function (err) {
+            deferred.reject(err);
+          }, function update(evt) {
+            deferred.notify(evt);
+          });
+          return deferred.promise;
+        }
+      };
+    }])
+    .factory('EndpointService', ['$q', '$timeout', 'Endpoints', 'FileUploadService', function EndpointServiceFactory($q, $timeout, Endpoints, FileUploadService) {
+      'use strict';
+      return {
+        endpoint: function(endpointID) {
+          return Endpoints.get({id: endpointID}).$promise;
+        },
+        endpoints: function() {
+          return Endpoints.query({}).$promise;
+        },
+        updateEndpoint: function(ID, name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile) {
+          var endpoint = {
+            id: ID,
+            Name: name,
+            URL: URL,
+            TLS: TLS
+          };
+          var deferred = $q.defer();
+          Endpoints.update({}, endpoint, function success(data) {
+            FileUploadService.uploadTLSFilesForEndpoint(ID, TLSCAFile, TLSCertFile, TLSKeyFile).then(function success(data) {
+              deferred.notify({upload: false});
+              deferred.resolve(data);
+            }, function error(err) {
+              deferred.notify({upload: false});
+              deferred.reject({msg: 'Unable to upload TLS certs', err: err});
+            });
+          }, function error(err) {
+            deferred.reject({msg: 'Unable to update endpoint', err: err});
+          });
+          return deferred.promise;
+        },
+        deleteEndpoint: function(endpointID) {
+          return Endpoints.remove({id: endpointID}).$promise;
+        },
+        createLocalEndpoint: function(name, URL, TLS, active) {
+          var endpoint = {
+            Name: "local",
+            URL: "unix:///var/run/docker.sock",
+            TLS: false
+          };
+          return Endpoints.create({active: active}, endpoint).$promise;
+        },
+        createRemoteEndpoint: function(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, active) {
+          var endpoint = {
+            Name: name,
+            URL: URL,
+            TLS: TLS
+          };
+          var deferred = $q.defer();
+          Endpoints.create({active: active}, endpoint, function success(data) {
+            var endpointID = data.Id;
+            if (TLS) {
+              deferred.notify({upload: true});
+              FileUploadService.uploadTLSFilesForEndpoint(endpointID, TLSCAFile, TLSCertFile, TLSKeyFile).then(function success(data) {
+                deferred.notify({upload: false});
+                Endpoints.setActiveEndpoint({}, {id: endpointID}, function success(data) {
+                  deferred.resolve(data);
+                }, function error(err) {
+                  deferred.reject({msg: 'Unable to create endpoint', err: err});
+                });
+              }, function error(err) {
+                deferred.notify({upload: false});
+                deferred.reject({msg: 'Unable to upload TLS certs', err: err});
+              });
+            } else {
+              deferred.resolve(data);
+            }
+          }, function error(err) {
+            deferred.reject({msg: 'Unable to create endpoint', err: err});
+          });
+          return deferred.promise;
         }
       };
     }])

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -409,7 +409,7 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         createRemoteEndpoint: function(name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, active) {
           var endpoint = {
             Name: name,
-            URL: URL,
+            URL: 'tcp://' + URL,
             TLS: TLS
           };
           var deferred = $q.defer();
@@ -419,11 +419,13 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
               deferred.notify({upload: true});
               FileUploadService.uploadTLSFilesForEndpoint(endpointID, TLSCAFile, TLSCertFile, TLSKeyFile).then(function success(data) {
                 deferred.notify({upload: false});
-                Endpoints.setActiveEndpoint({}, {id: endpointID}, function success(data) {
-                  deferred.resolve(data);
-                }, function error(err) {
-                  deferred.reject({msg: 'Unable to create endpoint', err: err});
-                });
+                if (active) {
+                  Endpoints.setActiveEndpoint({}, {id: endpointID}, function success(data) {
+                    deferred.resolve(data);
+                  }, function error(err) {
+                    deferred.reject({msg: 'Unable to create endpoint', err: err});
+                  });
+                }
               }, function error(err) {
                 deferred.notify({upload: false});
                 deferred.reject({msg: 'Unable to upload TLS certs', err: err});

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -240,18 +240,6 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         initAdminUser: { method: 'POST', params: { username: 'admin', action: 'init' } }
       });
     }])
-    .factory('Endpoints', ['$resource', 'ENDPOINTS_ENDPOINT', function EndpointsFactory($resource, ENDPOINTS_ENDPOINT) {
-      'use strict';
-      return $resource(ENDPOINTS_ENDPOINT + '/:id/:action', {}, {
-        create: { method: 'POST' },
-        query: { method: 'GET', isArray: true },
-        get: { method: 'GET', params: { id: '@id' } },
-        update: { method: 'PUT', params: { id: '@id' } },
-        remove: { method: 'DELETE', params: { id: '@id'} },
-        getActiveEndpoint: { method: 'GET', params: { id: '0' } },
-        setActiveEndpoint: { method: 'POST', params: { id: '@id', action: 'active' } }
-      });
-    }])
     .factory('EndpointMode', ['$rootScope', 'Info', function EndpointMode($rootScope, Info) {
       'use strict';
       return {
@@ -359,9 +347,27 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         }
       };
     }])
+    .factory('Endpoints', ['$resource', 'ENDPOINTS_ENDPOINT', function EndpointsFactory($resource, ENDPOINTS_ENDPOINT) {
+      'use strict';
+      return $resource(ENDPOINTS_ENDPOINT + '/:id/:action', {}, {
+        create: { method: 'POST' },
+        query: { method: 'GET', isArray: true },
+        get: { method: 'GET', params: { id: '@id' } },
+        update: { method: 'PUT', params: { id: '@id' } },
+        remove: { method: 'DELETE', params: { id: '@id'} },
+        getActiveEndpoint: { method: 'GET', params: { id: '0' } },
+        setActiveEndpoint: { method: 'POST', params: { id: '@id', action: 'active' } }
+      });
+    }])
     .factory('EndpointService', ['$q', '$timeout', 'Endpoints', 'FileUploadService', function EndpointServiceFactory($q, $timeout, Endpoints, FileUploadService) {
       'use strict';
       return {
+        getActive: function() {
+          return Endpoints.getActiveEndpoint().$promise;
+        },
+        setActive: function(endpointID) {
+          return Endpoints.setActiveEndpoint({id: endpointID}).$promise;
+        },
         endpoint: function(endpointID) {
           return Endpoints.get({id: endpointID}).$promise;
         },

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -378,7 +378,7 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
           var endpoint = {
             id: ID,
             Name: name,
-            URL: URL,
+            URL: "tcp://" + URL,
             TLS: TLS
           };
           var deferred = $q.defer();
@@ -425,6 +425,8 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
                   }, function error(err) {
                     deferred.reject({msg: 'Unable to create endpoint', err: err});
                   });
+                } else {
+                  deferred.resolve(data);
                 }
               }, function error(err) {
                 deferred.notify({upload: false});

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -212,7 +212,7 @@ input[type="radio"] {
   margin-bottom: 5px;
 }
 
-.login-wrapper {
+.page-wrapper {
   margin-top: 25px;
   height: 100%;
   width: 100%;
@@ -220,15 +220,15 @@ input[type="radio"] {
   align-items: center;
 }
 
-.login-box {
+.simple-box {
   margin-bottom: 80px;
 }
 
-.login-box > div:first-child {
+.simple-box > div:first-child {
   padding-bottom: 10px;
 }
 
-.login-logo {
+.simple-box-logo {
   display: block;
   margin: auto;
   position: relative;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -257,3 +257,8 @@ input[type="radio"] {
 .user-box {
   margin-right: 25px;
 }
+
+.select-endpoint {
+  width: 80%;
+  margin: 0 auto;
+}

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,8 @@
     "rdash-ui": "1.0.*",
     "moment": "~2.14.1",
     "xterm.js": "~2.0.1",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "ng-file-upload": "~12.2.13"
   },
   "resolutions": {
     "angular": "1.5.5"

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -198,6 +198,7 @@ module.exports = function (grunt) {
                     'bower_components/angular-ui-router/release/angular-ui-router.min.js',
                     'bower_components/angular-resource/angular-resource.min.js',
                     'bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js',
+                    'bower_components/ng-file-upload/ng-file-upload.min.js',
                     'bower_components/angular-utils-pagination/dirPagination.js',
                     'bower_components/angular-ui-select/dist/select.min.js'],
                 dest: '<%= distdir %>/js/angular.js'

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 </head>
 
 <body ng-controller="MainController">
-  <div id="page-wrapper" ng-class="{open: toggle && $state.current.name !== 'auth', nopadding: $state.current.name === 'auth'}" ng-cloak>
+  <div id="page-wrapper" ng-class="{open: toggle && $state.current.name !== 'auth' && $state.current.name !== 'endpointInit', nopadding: $state.current.name === 'auth' || $state.current.name === 'endpointInit'}" ng-cloak>
 
     <div id="sideview" ui-view="sidebar"></div>
 


### PR DESCRIPTION
Another big one ! 

This one brings mutliple endpoint management from within one Portainer instance.

You can now start Portainer **without** any endpoint specified on the CLI and it will ask you to define the primary endpoint after authentication.

In this endpoint initialization view, you'll be able to either:

*  *manage the local Docker engine* using the socket bind mount, this will create a new endpoint called `local`
* *define a remote endpoint* by specifying the name of the endpoint, the URL of the endpoint and the TLS configuration if required.

When specifying TLS configuration, you'll be able to upload the SSL certificates inside Portainer data volume. These will be stored inside the `/data/tls/<ENDPOINT_ID>/` folder (assuming `/data` as the default data folder) using file permissions 0600. 

After creating the default endpoint, you'll see a new dropdown below the Portainer logo in the sidebar, this will allow you to switch the currently active endpoint.

A new section 'Endpoints' is introduced in the sidebar, from here you'll be able to manage endpoints (list, create, edit).

When restarting Portainer, it will automatically re-use the last active endpoint (assuming you provided the same path to the data).

You still have the ability to use the `-H` flag on the CLI but beware as it's now only used to initialize the primary endpoint (when no endpoints are defined). If you restart Portainer and there is already defined endpoints, the `-H` flag will be ignored. When creating a new endpoint using the CLI, it will create the endpoint using the data from the CLI and the name `primary`.

Endpoint mode is now automatically determined when connecting to an endpoint (e.g. when you connect to a host in Swarm mode, Portainer will automatically adjust the UI to support Swarm mode) closing #279

Close #101 