### PR TITLE
feat(images): initial aarch64/arm64 support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,13 @@ cd /tmp/portainer-build-arm
 tar cvpfz portainer-${VERSION}-linux-arm.tar.gz portainer
 cd -
 
+grunt release-arm64
+rm -rf /tmp/portainer-build-arm64 && mkdir -pv /tmp/portainer-build-arm64/portainer
+mv dist/* /tmp/portainer-build-arm64/portainer
+cd /tmp/portainer-build-arm64
+tar cvpfz portainer-${VERSION}-linux-arm64.tar.gz portainer
+cd -
+
 grunt release-macos
 rm -rf /tmp/portainer-build-darwin && mkdir -pv /tmp/portainer-build-darwin/portainer
 mv dist/* /tmp/portainer-build-darwin/portainer

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,6 +74,21 @@ module.exports = function (grunt) {
     'usemin',
     'clean:tmp'
   ]);
+  grunt.registerTask('release-arm64', [
+    'clean:app',
+    'if:unixArm64BinaryNotExist',
+    'html2js',
+    'useminPrepare',
+    'recess:build',
+    'concat',
+    'clean:tmpl',
+    'cssmin',
+    'uglify',
+    'copy',
+    'filerev',
+    'usemin',
+    'clean:tmp'
+  ]);
   grunt.registerTask('release-macos', [
     'clean:app',
     'if:darwinBinaryNotExist',
@@ -355,6 +370,14 @@ module.exports = function (grunt) {
           'mv api/cmd/portainer/portainer-linux-arm dist/portainer'
         ].join(' && ')
       },
+        buildUnixArm64Binary: {
+            command: [
+                'docker run --rm -v $(pwd)/api:/src -e BUILD_GOOS="linux" -e BUILD_GOARCH="arm64" portainer/golang-builder:cross-platform /src/cmd/portainer',
+                'shasum api/cmd/portainer/portainer-linux-arm64 > portainer-checksum.txt',
+                'mkdir -p dist',
+                'mv api/cmd/portainer/portainer-linux-arm64 dist/portainer'
+            ].join(' && ')
+        },
       buildDarwinBinary: {
         command: [
           'docker run --rm -v $(pwd)/api:/src -e BUILD_GOOS="darwin" -e BUILD_GOARCH="amd64" portainer/golang-builder:cross-platform /src/cmd/portainer',
@@ -415,6 +438,12 @@ module.exports = function (grunt) {
           executable: 'dist/portainer'
         },
         ifFalse: ['shell:buildUnixArmBinary']
+      },
+      unixArm64BinaryNotExist: {
+        options: {
+          executable: 'dist/portainer'
+        },
+        ifFalse: ['shell:buildUnixArm64Binary']
       },
       darwinBinaryNotExist: {
         options: {


### PR DESCRIPTION
Inspired by @StefanScherer on [PR#299](https://github.com/portainer/portainer/pull/299) I added aarch64 support using arm64 cross compiling flag and Go 1.7 and tested the result on a Pine64 cluster

![screenshot from 2017-01-01 18-51-42](https://cloud.githubusercontent.com/assets/4040180/21582418/bacf4774-d056-11e6-8343-13c004091c49.png)
