### PR TITLE
#476 fix(UX): Rename 'local' endpoint doesn't overwrite "unix://"

### DIFF
--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -19,8 +19,8 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Messages) {
     var TLSCACert = $scope.formValues.TLSCACert !== $scope.endpoint.TLSCACert ? $scope.formValues.TLSCACert : null;
     var TLSCert = $scope.formValues.TLSCert !== $scope.endpoint.TLSCert ? $scope.formValues.TLSCert : null;
     var TLSKey = $scope.formValues.TLSKey !== $scope.endpoint.TLSKey ? $scope.formValues.TLSKey : null;
-    var TYPE = $scope.endpointType;
-    EndpointService.updateEndpoint(ID, name, URL, TLS, TLSCACert, TLSCert, TLSKey, TYPE).then(function success(data) {
+    var type = $scope.endpointType;
+    EndpointService.updateEndpoint(ID, name, URL, TLS, TLSCACert, TLSCert, TLSKey, type).then(function success(data) {
       Messages.send("Endpoint updated", $scope.endpoint.Name);
       $state.go('endpoints');
     }, function error(err) {

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -19,7 +19,8 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Messages) {
     var TLSCACert = $scope.formValues.TLSCACert !== $scope.endpoint.TLSCACert ? $scope.formValues.TLSCACert : null;
     var TLSCert = $scope.formValues.TLSCert !== $scope.endpoint.TLSCert ? $scope.formValues.TLSCert : null;
     var TLSKey = $scope.formValues.TLSKey !== $scope.endpoint.TLSKey ? $scope.formValues.TLSKey : null;
-    EndpointService.updateEndpoint(ID, name, URL, TLS, TLSCACert, TLSCert, TLSKey).then(function success(data) {
+    var TYPE = $scope.endpointType;
+    EndpointService.updateEndpoint(ID, name, URL, TLS, TLSCACert, TLSCert, TLSKey, TYPE).then(function success(data) {
       Messages.send("Endpoint updated", $scope.endpoint.Name);
       $state.go('endpoints');
     }, function error(err) {

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -374,11 +374,11 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         endpoints: function() {
           return Endpoints.query({}).$promise;
         },
-        updateEndpoint: function(ID, name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile) {
+        updateEndpoint: function(ID, name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, TYPE) {
           var endpoint = {
             id: ID,
             Name: name,
-            URL: "tcp://" + URL,
+            URL: TYPE === 'local' ? ("unix://" + URL) : ("tcp://" + URL),
             TLS: TLS
           };
           var deferred = $q.defer();

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -374,11 +374,11 @@ angular.module('portainer.services', ['ngResource', 'ngSanitize'])
         endpoints: function() {
           return Endpoints.query({}).$promise;
         },
-        updateEndpoint: function(ID, name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, TYPE) {
+        updateEndpoint: function(ID, name, URL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, type) {
           var endpoint = {
             id: ID,
             Name: name,
-            URL: TYPE === 'local' ? ("unix://" + URL) : ("tcp://" + URL),
+            URL: type === 'local' ? ("unix://" + URL) : ("tcp://" + URL),
             TLS: TLS
           };
           var deferred = $q.defer();


### PR DESCRIPTION
This is a fix to the issue #476