### PR TITLE
#182 feat(containers): support container already pause message

### DIFF
--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -77,6 +77,19 @@ function ($scope, $filter, Container, ContainerHelper, Info, Settings, Messages,
             complete();
           });
         }
+        else if (action === Container.pause) {
+          action({id: c.Id}, function (d) {
+            if (d.message) {
+              Messages.send("Container is already paused", c.Id);
+            } else {
+              Messages.send("Container " + msg, c.Id);
+            }
+            complete();
+          }, function (e) {
+            Messages.error("Failure", e, 'Unable to pause container');
+            complete();
+          });
+        }
         else {
           action({id: c.Id}, function (d) {
             Messages.send("Container " + msg, c.Id);


### PR DESCRIPTION
Hello this is my first contribution for this awesome project.

This PR contains

* displaying "Container is already paused" message when `Container.pause` triggered on paused containers

Thanks

Close #182 