### PR TITLE
#503 fix(container-stats): fix container stats timer not being proper…

### DIFF
--- a/app/components/stats/statsController.js
+++ b/app/components/stats/statsController.js
@@ -114,6 +114,12 @@ function (Settings, $scope, Messages, $timeout, Container, ContainerTop, $stateP
     });
     $scope.networkLegend = $sce.trustAsHtml(networkChart.generateLegend());
 
+    function setUpdateStatsTimeout() {
+      if(!destroyed) {
+        timeout = $timeout(updateStats, 5000);
+      }
+    }
+
     function updateStats() {
       Container.stats({id: $stateParams.id}, function (d) {
         var arr = Object.keys(d).map(function (key) {
@@ -129,15 +135,17 @@ function (Settings, $scope, Messages, $timeout, Container, ContainerTop, $stateP
         updateCpuChart(d);
         updateMemoryChart(d);
         updateNetworkChart(d);
-        timeout = $timeout(updateStats, 5000);
+        setUpdateStatsTimeout();
       }, function () {
         Messages.error('Unable to retrieve stats', {}, 'Is this container running?');
-        timeout = $timeout(updateStats, 5000);
+        setUpdateStatsTimeout();
       });
     }
 
+    var destroyed = false;
     var timeout;
     $scope.$on('$destroy', function () {
+      destroyed = true;
       $timeout.cancel(timeout);
     });
 


### PR DESCRIPTION
This PR fixes #503 by checking if stats controller has been destroyed before setting a new timeout.