### PR TITLE
feat(endpoints): add the ability to define endpoints from an external…

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -19,7 +19,7 @@ const (
 	errSocketNotFound          = portainer.Error("Unable to locate Unix socket")
 	errEndpointsFileNotFound   = portainer.Error("Unable to locate external endpoints file")
 	errInvalidSyncInterval     = portainer.Error("Invalid synchronization interval")
-	errEndpointExcludeExternal = portainer.Error("Cannot use the -H mutually with --external-endpoints")
+	errEndpointExcludeExternal = portainer.Error("Cannot use the -H flag mutually with --external-endpoints")
 )
 
 // ParseFlags parse the CLI flags and return a portainer.Flags struct

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/portainer/portainer"
 
 	"os"
@@ -15,6 +17,8 @@ type Service struct{}
 const (
 	errInvalidEnpointProtocol = portainer.Error("Invalid endpoint protocol: Portainer only supports unix:// or tcp://")
 	errSocketNotFound         = portainer.Error("Unable to locate Unix socket")
+	errEndpointsFileNotFound  = portainer.Error("Unable to locate external endpoints file")
+	errInvalidSyncInterval    = portainer.Error("Invalid synchronization interval")
 )
 
 // ParseFlags parse the CLI flags and return a portainer.Flags struct
@@ -22,18 +26,20 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	kingpin.Version(version)
 
 	flags := &portainer.CLIFlags{
-		Endpoint:  kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
-		Logo:      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
-		Labels:    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
-		Addr:      kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
-		Assets:    kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
-		Data:      kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
-		Templates: kingpin.Flag("templates", "URL to the templates (apps) definitions").Default(defaultTemplatesURL).Short('t').String(),
-		NoAuth:    kingpin.Flag("no-auth", "Disable authentication").Default(defaultNoAuth).Bool(),
-		TLSVerify: kingpin.Flag("tlsverify", "TLS support").Default(defaultTLSVerify).Bool(),
-		TLSCacert: kingpin.Flag("tlscacert", "Path to the CA").Default(defaultTLSCACertPath).String(),
-		TLSCert:   kingpin.Flag("tlscert", "Path to the TLS certificate file").Default(defaultTLSCertPath).String(),
-		TLSKey:    kingpin.Flag("tlskey", "Path to the TLS key").Default(defaultTLSKeyPath).String(),
+		Endpoint:          kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
+		Logo:              kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
+		ExternalEndpoints: kingpin.Flag("external-endpoints", "Path to a file defining available endpoints").String(),
+		SyncInterval:      kingpin.Flag("sync-interval", "Duration between each synchronization via the external endpoints source").Default(defaultSyncInterval).String(),
+		Labels:            pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
+		Addr:              kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
+		Assets:            kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
+		Data:              kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
+		Templates:         kingpin.Flag("templates", "URL to the templates (apps) definitions").Default(defaultTemplatesURL).Short('t').String(),
+		NoAuth:            kingpin.Flag("no-auth", "Disable authentication").Default(defaultNoAuth).Bool(),
+		TLSVerify:         kingpin.Flag("tlsverify", "TLS support").Default(defaultTLSVerify).Bool(),
+		TLSCacert:         kingpin.Flag("tlscacert", "Path to the CA").Default(defaultTLSCACertPath).String(),
+		TLSCert:           kingpin.Flag("tlscert", "Path to the TLS certificate file").Default(defaultTLSCertPath).String(),
+		TLSKey:            kingpin.Flag("tlskey", "Path to the TLS key").Default(defaultTLSKeyPath).String(),
 	}
 
 	kingpin.Parse()
@@ -55,6 +61,22 @@ func (*Service) ValidateFlags(flags *portainer.CLIFlags) error {
 				}
 				return err
 			}
+		}
+	}
+
+	if *flags.ExternalEndpoints != "" {
+		if _, err := os.Stat(*flags.ExternalEndpoints); err != nil {
+			if os.IsNotExist(err) {
+				return errEndpointsFileNotFound
+			}
+			return err
+		}
+	}
+
+	if *flags.SyncInterval != defaultSyncInterval {
+		_, err := time.ParseDuration(*flags.SyncInterval)
+		if err != nil {
+			return errInvalidSyncInterval
 		}
 	}
 

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -12,4 +12,5 @@ const (
 	defaultTLSCACertPath   = "/certs/ca.pem"
 	defaultTLSCertPath     = "/certs/cert.pem"
 	defaultTLSKeyPath      = "/certs/key.pem"
+	defaultSyncInterval    = "60s"
 )

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -10,4 +10,5 @@ const (
 	defaultTLSCACertPath   = "C:\\certs\\ca.pem"
 	defaultTLSCertPath     = "C:\\certs\\cert.pem"
 	defaultTLSKeyPath      = "C:\\certs\\key.pem"
+	defaultSyncInterval    = "60s"
 )

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/portainer/portainer"
 	"github.com/portainer/portainer/bolt"
 	"github.com/portainer/portainer/cli"
+	"github.com/portainer/portainer/cron"
 	"github.com/portainer/portainer/crypto"
 	"github.com/portainer/portainer/file"
 	"github.com/portainer/portainer/http"
@@ -22,12 +23,6 @@ func main() {
 	err = cli.ValidateFlags(flags)
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	settings := &portainer.Settings{
-		HiddenLabels:   *flags.Labels,
-		Logo:           *flags.Logo,
-		Authentication: !*flags.NoAuth,
 	}
 
 	fileService, err := file.NewService(*flags.Data, "")
@@ -52,6 +47,25 @@ func main() {
 
 	var cryptoService portainer.CryptoService = &crypto.Service{}
 
+	var endpointWatcher portainer.EndpointWatcher
+	authorizeEndpointMgmt := true
+	if *flags.ExternalEndpoints != "" {
+		log.Println("Using external endpoint definition. Disabling endpoint management via API.")
+		authorizeEndpointMgmt = false
+		endpointWatcher = cron.NewWatcher(store.EndpointService, *flags.SyncInterval)
+		err = endpointWatcher.WatchEndpointFile(*flags.ExternalEndpoints)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	settings := &portainer.Settings{
+		HiddenLabels:       *flags.Labels,
+		Logo:               *flags.Logo,
+		Authentication:     !*flags.NoAuth,
+		EndpointManagement: authorizeEndpointMgmt,
+	}
+
 	// Initialize the active endpoint from the CLI only if there is no
 	// active endpoint defined yet.
 	var activeEndpoint *portainer.Endpoint
@@ -74,19 +88,36 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+	if *flags.ExternalEndpoints != "" {
+		activeEndpoint, err = store.EndpointService.GetActive()
+		if err == portainer.ErrEndpointNotFound {
+			var endpoints []portainer.Endpoint
+			endpoints, err = store.EndpointService.Endpoints()
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = store.EndpointService.SetActive(&endpoints[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else if err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	var server portainer.Server = &http.Server{
-		BindAddress:     *flags.Addr,
-		AssetsPath:      *flags.Assets,
-		Settings:        settings,
-		TemplatesURL:    *flags.Templates,
-		AuthDisabled:    *flags.NoAuth,
-		UserService:     store.UserService,
-		EndpointService: store.EndpointService,
-		CryptoService:   cryptoService,
-		JWTService:      jwtService,
-		FileService:     fileService,
-		ActiveEndpoint:  activeEndpoint,
+		BindAddress:        *flags.Addr,
+		AssetsPath:         *flags.Assets,
+		Settings:           settings,
+		TemplatesURL:       *flags.Templates,
+		AuthDisabled:       *flags.NoAuth,
+		EndpointManagement: authorizeEndpointMgmt,
+		UserService:        store.UserService,
+		EndpointService:    store.EndpointService,
+		CryptoService:      cryptoService,
+		JWTService:         jwtService,
+		FileService:        fileService,
+		ActiveEndpoint:     activeEndpoint,
 	}
 
 	log.Printf("Starting Portainer on %s", *flags.Addr)

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -13,7 +13,7 @@ import (
 	"log"
 )
 
-func main() {
+func initCLI() *portainer.CLIFlags {
 	var cli portainer.CLIService = &cli.Service{}
 	flags, err := cli.ParseFlags(portainer.APIVersion)
 	if err != nil {
@@ -24,54 +24,80 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	return flags
+}
 
-	fileService, err := file.NewService(*flags.Data, "")
+func initFileService(dataStorePath string) portainer.FileService {
+	fileService, err := file.NewService(dataStorePath, "")
 	if err != nil {
 		log.Fatal(err)
 	}
+	return fileService
+}
 
-	var store = bolt.NewStore(*flags.Data)
-	err = store.Open()
+func initStore(dataStorePath string) *bolt.Store {
+	var store = bolt.NewStore(dataStorePath)
+	err := store.Open()
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer store.Close()
+	return store
+}
 
-	var jwtService portainer.JWTService
-	if !*flags.NoAuth {
-		jwtService, err = jwt.NewService()
+func initJWTService(authenticationEnabled bool) portainer.JWTService {
+	if authenticationEnabled {
+		jwtService, err := jwt.NewService()
 		if err != nil {
 			log.Fatal(err)
 		}
+		return jwtService
 	}
+	return nil
+}
 
-	var cryptoService portainer.CryptoService = &crypto.Service{}
+func initCryptoService() portainer.CryptoService {
+	return &crypto.Service{}
+}
 
-	var endpointWatcher portainer.EndpointWatcher
+func initEndpointWatcher(endpointService portainer.EndpointService, externalEnpointFile string, syncInterval string) bool {
 	authorizeEndpointMgmt := true
-	if *flags.ExternalEndpoints != "" {
-		log.Println("Using external endpoint definition. Disabling endpoint management via API.")
+	if externalEnpointFile != "" {
 		authorizeEndpointMgmt = false
-		endpointWatcher = cron.NewWatcher(store.EndpointService, *flags.SyncInterval)
-		err = endpointWatcher.WatchEndpointFile(*flags.ExternalEndpoints)
+		log.Println("Using external endpoint definition. Endpoint management via the API will be disabled.")
+		endpointWatcher := cron.NewWatcher(endpointService, syncInterval)
+		err := endpointWatcher.WatchEndpointFile(externalEnpointFile)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
+	return authorizeEndpointMgmt
+}
 
-	settings := &portainer.Settings{
+func initSettings(authorizeEndpointMgmt bool, flags *portainer.CLIFlags) *portainer.Settings {
+	return &portainer.Settings{
 		HiddenLabels:       *flags.Labels,
 		Logo:               *flags.Logo,
 		Authentication:     !*flags.NoAuth,
 		EndpointManagement: authorizeEndpointMgmt,
 	}
+}
 
-	// Initialize the active endpoint from the CLI only if there is no
-	// active endpoint defined yet.
-	var activeEndpoint *portainer.Endpoint
-	if *flags.Endpoint != "" {
-		activeEndpoint, err = store.EndpointService.GetActive()
-		if err == portainer.ErrEndpointNotFound {
+func initActiveEndpointFromFirstEndpointInDatabase(endpointService portainer.EndpointService) {
+
+}
+
+func retrieveFirstEndpointFromDatabase(endpointService portainer.EndpointService) *portainer.Endpoint {
+	endpoints, err := endpointService.Endpoints()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &endpoints[0]
+}
+
+func initActiveEndpoint(endpointService portainer.EndpointService, flags *portainer.CLIFlags) *portainer.Endpoint {
+	activeEndpoint, err := endpointService.GetActive()
+	if err == portainer.ErrEndpointNotFound {
+		if *flags.Endpoint != "" {
 			activeEndpoint = &portainer.Endpoint{
 				Name:          "primary",
 				URL:           *flags.Endpoint,
@@ -80,30 +106,36 @@ func main() {
 				TLSCertPath:   *flags.TLSCert,
 				TLSKeyPath:    *flags.TLSKey,
 			}
-			err = store.EndpointService.CreateEndpoint(activeEndpoint)
+			err = endpointService.CreateEndpoint(activeEndpoint)
 			if err != nil {
 				log.Fatal(err)
 			}
-		} else if err != nil {
-			log.Fatal(err)
+		} else if *flags.ExternalEndpoints != "" {
+			activeEndpoint = retrieveFirstEndpointFromDatabase(endpointService)
 		}
+	} else if err != nil {
+		log.Fatal(err)
 	}
-	if *flags.ExternalEndpoints != "" {
-		activeEndpoint, err = store.EndpointService.GetActive()
-		if err == portainer.ErrEndpointNotFound {
-			var endpoints []portainer.Endpoint
-			endpoints, err = store.EndpointService.Endpoints()
-			if err != nil {
-				log.Fatal(err)
-			}
-			err = store.EndpointService.SetActive(&endpoints[0])
-			if err != nil {
-				log.Fatal(err)
-			}
-		} else if err != nil {
-			log.Fatal(err)
-		}
-	}
+	return activeEndpoint
+}
+
+func main() {
+	flags := initCLI()
+
+	fileService := initFileService(*flags.Data)
+
+	store := initStore(*flags.Data)
+	defer store.Close()
+
+	jwtService := initJWTService(!*flags.NoAuth)
+
+	cryptoService := initCryptoService()
+
+	authorizeEndpointMgmt := initEndpointWatcher(store.EndpointService, *flags.ExternalEndpoints, *flags.SyncInterval)
+
+	settings := initSettings(authorizeEndpointMgmt, flags)
+
+	activeEndpoint := initActiveEndpoint(store.EndpointService, flags)
 
 	var server portainer.Server = &http.Server{
 		BindAddress:        *flags.Addr,
@@ -121,7 +153,7 @@ func main() {
 	}
 
 	log.Printf("Starting Portainer on %s", *flags.Addr)
-	err = server.Start()
+	err := server.Start()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/cron/endpoint_sync.go
+++ b/api/cron/endpoint_sync.go
@@ -1,0 +1,166 @@
+package cron
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/portainer/portainer"
+)
+
+type (
+	endpointSyncJob struct {
+		logger           *log.Logger
+		endpointService  portainer.EndpointService
+		endpointFilePath string
+	}
+
+	synchronization struct {
+		endpointsToCreate []*portainer.Endpoint
+		endpointsToUpdate []*portainer.Endpoint
+		endpointsToDelete []*portainer.Endpoint
+	}
+)
+
+const (
+	// ErrEmptyEndpointArray is an error raised when the external endpoint source array is empty.
+	ErrEmptyEndpointArray = portainer.Error("External endpoint source is empty")
+)
+
+func newEndpointSyncJob(endpointFilePath string, endpointService portainer.EndpointService) endpointSyncJob {
+	return endpointSyncJob{
+		logger:           log.New(os.Stderr, "", log.LstdFlags),
+		endpointService:  endpointService,
+		endpointFilePath: endpointFilePath,
+	}
+}
+
+func endpointSyncError(err error, logger *log.Logger) bool {
+	if err != nil {
+		logger.Printf("Endpoint synchronization error: %s", err)
+		return true
+	}
+	return false
+}
+
+func isValidEndpoint(endpoint *portainer.Endpoint) bool {
+	if endpoint.Name != "" && endpoint.URL != "" {
+		return true
+	}
+	return false
+}
+
+func endpointExists(endpoint *portainer.Endpoint, endpoints []portainer.Endpoint) int {
+	for idx, v := range endpoints {
+		if endpoint.Name == v.Name && isValidEndpoint(&v) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func mergeEndpointIfRequired(original, updated *portainer.Endpoint) *portainer.Endpoint {
+	var endpoint *portainer.Endpoint
+	if original.URL != updated.URL || original.TLS != updated.TLS {
+		endpoint = original
+		endpoint.URL = updated.URL
+		if updated.TLS {
+			endpoint.TLS = true
+			endpoint.TLSCACertPath = updated.TLSCACertPath
+			endpoint.TLSCertPath = updated.TLSCertPath
+			endpoint.TLSKeyPath = updated.TLSKeyPath
+		} else {
+			endpoint.TLS = false
+			endpoint.TLSCACertPath = ""
+			endpoint.TLSCertPath = ""
+			endpoint.TLSKeyPath = ""
+		}
+	}
+	return endpoint
+}
+
+func (sync synchronization) requireSync() bool {
+	if len(sync.endpointsToCreate) != 0 || len(sync.endpointsToUpdate) != 0 || len(sync.endpointsToDelete) != 0 {
+		return true
+	}
+	return false
+}
+
+// TMP: endpointSyncJob method to access logger, should be generic
+func (job endpointSyncJob) prepareSyncData(storedEndpoints, fileEndpoints []portainer.Endpoint) *synchronization {
+	endpointsToCreate := make([]*portainer.Endpoint, 0)
+	endpointsToUpdate := make([]*portainer.Endpoint, 0)
+	endpointsToDelete := make([]*portainer.Endpoint, 0)
+
+	for idx := range storedEndpoints {
+		fidx := endpointExists(&storedEndpoints[idx], fileEndpoints)
+		if fidx != -1 {
+			endpoint := mergeEndpointIfRequired(&storedEndpoints[idx], &fileEndpoints[fidx])
+			if endpoint != nil {
+				job.logger.Printf("New definition for a stored endpoint found in file, updating database. [name: %v] [url: %v]\n", endpoint.Name, endpoint.URL)
+				endpointsToUpdate = append(endpointsToUpdate, endpoint)
+			} else {
+				job.logger.Printf("No change detected for a stored endpoint. [name: %v] [url: %v]\n", storedEndpoints[idx].Name, storedEndpoints[idx].URL)
+			}
+		} else {
+			job.logger.Printf("Stored endpoint not found in file (definition might be invalid), removing from database. [name: %v] [url: %v]", storedEndpoints[idx].Name, storedEndpoints[idx].URL)
+			endpointsToDelete = append(endpointsToDelete, &storedEndpoints[idx])
+		}
+	}
+
+	for idx, endpoint := range fileEndpoints {
+		if endpoint.Name == "" || endpoint.URL == "" {
+			job.logger.Printf("Invalid file endpoint definition, skipping. [name: %v] [url: %v]", endpoint.Name, endpoint.URL)
+			continue
+		}
+		sidx := endpointExists(&fileEndpoints[idx], storedEndpoints)
+		if sidx == -1 {
+			job.logger.Printf("File endpoint not found in database, adding to database. [name: %v] [url: %v]", fileEndpoints[idx].Name, fileEndpoints[idx].URL)
+			endpointsToCreate = append(endpointsToCreate, &fileEndpoints[idx])
+		}
+	}
+
+	return &synchronization{
+		endpointsToCreate: endpointsToCreate,
+		endpointsToUpdate: endpointsToUpdate,
+		endpointsToDelete: endpointsToDelete,
+	}
+}
+
+func (job endpointSyncJob) Sync() error {
+	data, err := ioutil.ReadFile(job.endpointFilePath)
+	if endpointSyncError(err, job.logger) {
+		return err
+	}
+
+	var fileEndpoints []portainer.Endpoint
+	err = json.Unmarshal(data, &fileEndpoints)
+	if endpointSyncError(err, job.logger) {
+		return err
+	}
+
+	if len(fileEndpoints) == 0 {
+		return ErrEmptyEndpointArray
+	}
+
+	storedEndpoints, err := job.endpointService.Endpoints()
+	if endpointSyncError(err, job.logger) {
+		return err
+	}
+
+	sync := job.prepareSyncData(storedEndpoints, fileEndpoints)
+	if sync.requireSync() {
+		err = job.endpointService.Synchronize(sync.endpointsToCreate, sync.endpointsToUpdate, sync.endpointsToDelete)
+		if endpointSyncError(err, job.logger) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (job endpointSyncJob) Run() {
+	job.logger.Printf("Endpoint synchronization job started")
+	err := job.Sync()
+	endpointSyncError(err, job.logger)
+}

--- a/api/cron/endpoint_sync.go
+++ b/api/cron/endpoint_sync.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/portainer/portainer"
 )
@@ -46,6 +47,9 @@ func endpointSyncError(err error, logger *log.Logger) bool {
 
 func isValidEndpoint(endpoint *portainer.Endpoint) bool {
 	if endpoint.Name != "" && endpoint.URL != "" {
+		if !strings.HasPrefix(endpoint.URL, "unix://") && !strings.HasPrefix(endpoint.URL, "tcp://") {
+			return false
+		}
 		return true
 	}
 	return false
@@ -155,12 +159,13 @@ func (job endpointSyncJob) Sync() error {
 		if endpointSyncError(err, job.logger) {
 			return err
 		}
+		job.logger.Printf("Endpoint synchronization ended. [created: %v] [updated: %v] [deleted: %v]", len(sync.endpointsToCreate), len(sync.endpointsToUpdate), len(sync.endpointsToDelete))
 	}
 	return nil
 }
 
 func (job endpointSyncJob) Run() {
-	job.logger.Printf("Endpoint synchronization job started")
+	job.logger.Println("Endpoint synchronization job started.")
 	err := job.Sync()
 	endpointSyncError(err, job.logger)
 }

--- a/api/cron/watcher.go
+++ b/api/cron/watcher.go
@@ -1,0 +1,34 @@
+package cron
+
+import (
+	"github.com/portainer/portainer"
+	"github.com/robfig/cron"
+)
+
+// Watcher represents a service for managing crons.
+type Watcher struct {
+	Cron            *cron.Cron
+	EndpointService portainer.EndpointService
+	syncInterval    string
+}
+
+// NewWatcher initializes a new service.
+func NewWatcher(endpointService portainer.EndpointService, syncInterval string) *Watcher {
+	return &Watcher{
+		Cron:            cron.New(),
+		EndpointService: endpointService,
+		syncInterval:    syncInterval,
+	}
+}
+
+// WatchEndpointFile starts a cron job to synchronize the endpoints from a file
+func (watcher *Watcher) WatchEndpointFile(endpointFilePath string) error {
+	job := newEndpointSyncJob(endpointFilePath, watcher.EndpointService)
+	err := job.Sync()
+	if err != nil {
+		return err
+	}
+	watcher.Cron.AddJob("@every "+watcher.syncInterval, job)
+	watcher.Cron.Start()
+	return nil
+}

--- a/api/cron/watcher.go
+++ b/api/cron/watcher.go
@@ -24,11 +24,17 @@ func NewWatcher(endpointService portainer.EndpointService, syncInterval string) 
 // WatchEndpointFile starts a cron job to synchronize the endpoints from a file
 func (watcher *Watcher) WatchEndpointFile(endpointFilePath string) error {
 	job := newEndpointSyncJob(endpointFilePath, watcher.EndpointService)
+
 	err := job.Sync()
 	if err != nil {
 		return err
 	}
-	watcher.Cron.AddJob("@every "+watcher.syncInterval, job)
+
+	err = watcher.Cron.AddJob("@every "+watcher.syncInterval, job)
+	if err != nil {
+		return err
+	}
+
 	watcher.Cron.Start()
 	return nil
 }

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -8,18 +8,19 @@ import (
 
 // Server implements the portainer.Server interface
 type Server struct {
-	BindAddress     string
-	AssetsPath      string
-	AuthDisabled    bool
-	UserService     portainer.UserService
-	EndpointService portainer.EndpointService
-	CryptoService   portainer.CryptoService
-	JWTService      portainer.JWTService
-	FileService     portainer.FileService
-	Settings        *portainer.Settings
-	TemplatesURL    string
-	ActiveEndpoint  *portainer.Endpoint
-	Handler         *Handler
+	BindAddress        string
+	AssetsPath         string
+	AuthDisabled       bool
+	EndpointManagement bool
+	UserService        portainer.UserService
+	EndpointService    portainer.EndpointService
+	CryptoService      portainer.CryptoService
+	JWTService         portainer.JWTService
+	FileService        portainer.FileService
+	Settings           *portainer.Settings
+	TemplatesURL       string
+	ActiveEndpoint     *portainer.Endpoint
+	Handler            *Handler
 }
 
 func (server *Server) updateActiveEndpoint(endpoint *portainer.Endpoint) error {
@@ -61,6 +62,7 @@ func (server *Server) Start() error {
 	var websocketHandler = NewWebSocketHandler()
 	// EndpointHandler requires a reference to the server to be able to update the active endpoint.
 	var endpointHandler = NewEndpointHandler(middleWareService)
+	endpointHandler.authorizeEndpointManagement = server.EndpointManagement
 	endpointHandler.EndpointService = server.EndpointService
 	endpointHandler.FileService = server.FileService
 	endpointHandler.server = server

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -13,25 +13,28 @@ type (
 
 	// CLIFlags represents the available flags on the CLI.
 	CLIFlags struct {
-		Addr      *string
-		Assets    *string
-		Data      *string
-		Endpoint  *string
-		Labels    *[]Pair
-		Logo      *string
-		Templates *string
-		NoAuth    *bool
-		TLSVerify *bool
-		TLSCacert *string
-		TLSCert   *string
-		TLSKey    *string
+		Addr              *string
+		Assets            *string
+		Data              *string
+		ExternalEndpoints *string
+		SyncInterval      *string
+		Endpoint          *string
+		Labels            *[]Pair
+		Logo              *string
+		Templates         *string
+		NoAuth            *bool
+		TLSVerify         *bool
+		TLSCacert         *string
+		TLSCert           *string
+		TLSKey            *string
 	}
 
 	// Settings represents Portainer settings.
 	Settings struct {
-		HiddenLabels   []Pair `json:"hiddenLabels"`
-		Logo           string `json:"logo"`
-		Authentication bool   `json:"authentication"`
+		HiddenLabels       []Pair `json:"hiddenLabels"`
+		Logo               string `json:"logo"`
+		Authentication     bool   `json:"authentication"`
+		EndpointManagement bool   `json:"endpointManagement"`
 	}
 
 	// User represent a user account.
@@ -97,6 +100,7 @@ type (
 		GetActive() (*Endpoint, error)
 		SetActive(endpoint *Endpoint) error
 		DeleteActive() error
+		Synchronize(toCreate, toUpdate, toDelete []*Endpoint) error
 	}
 
 	// CryptoService represents a service for encrypting/hashing data.
@@ -116,6 +120,11 @@ type (
 		StoreTLSFile(endpointID EndpointID, fileType TLSFileType, r io.Reader) error
 		GetPathForTLSFile(endpointID EndpointID, fileType TLSFileType) (string, error)
 		DeleteTLSFiles(endpointID EndpointID) error
+	}
+
+	// EndpointWatcher represents a service to synchronize the endpoints via an external source.
+	EndpointWatcher interface {
+		WatchEndpointFile(endpointFilePath string) error
 	}
 )
 

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -1,6 +1,11 @@
 angular.module('endpoint', [])
 .controller('EndpointController', ['$scope', '$state', '$stateParams', '$filter', 'EndpointService', 'Messages',
 function ($scope, $state, $stateParams, $filter, EndpointService, Messages) {
+
+  if (!$scope.applicationState.application.endpointManagement) {
+    $state.go('endpoints');
+  }
+
   $scope.state = {
     error: '',
     uploadInProgress: false

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -8,7 +8,19 @@
   <rd-header-content>Endpoint management</rd-header-content>
 </rd-header>
 
-<div class="row">
+<div class="row" ng-if="!applicationState.application.endpointManagement">
+  <div class="col-lg-12 col-md-12 col-xs-12">
+    <rd-widget>
+      <rd-widget-header icon="fa-exclamation-triangle" title="Endpoint management is not available">
+      </rd-widget-header>
+      <rd-widget-body>
+        <span class="small text-muted">Portainer has been started using the <code>--external-endpoints</code> flag. Endpoint management via the UI is disabled.</span>
+      </rd-wigdet-body>
+    </rd-widget>
+  </div>
+</div>
+
+<div class="row" ng-if="applicationState.application.endpointManagement">
   <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
       <rd-widget-header icon="fa-plus" title="Add a new endpoint">
@@ -113,7 +125,7 @@
         </div>
       </rd-widget-header>
       <rd-widget-taskbar classes="col-lg-12">
-        <div class="pull-left">
+        <div class="pull-left" ng-if="applicationState.application.endpointManagement">
           <button type="button" class="btn btn-danger" ng-click="removeAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-trash space-right" aria-hidden="true"></i>Remove</button>
         </div>
         <div class="pull-right">
@@ -125,7 +137,7 @@
           <table class="table table-hover">
             <thead>
               <tr>
-                <th></th>
+                <th ng-if="applicationState.application.endpointManagement"></th>
                 <th>
                   <a ui-sref="endpoints" ng-click="order('Name')">
                     Name
@@ -147,16 +159,16 @@
                     <span ng-show="sortType == 'TLS' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
                   </a>
                 </th>
-                <th></th>
+                <th ng-if="applicationState.application.endpointManagement"></th>
               </tr>
             </thead>
             <tbody>
               <tr dir-paginate="endpoint in (state.filteredEndpoints = (endpoints | filter:state.filter | orderBy:sortType:sortReverse | itemsPerPage: state.pagination_count))">
-                <td><input type="checkbox" ng-model="endpoint.Checked" ng-change="selectItem(endpoint)" /></td>
+                <td ng-if="applicationState.application.endpointManagement"><input type="checkbox" ng-model="endpoint.Checked" ng-change="selectItem(endpoint)" /></td>
                 <td><i class="fa fa-star" aria-hidden="true" ng-if="endpoint.Id === activeEndpoint.Id"></i> {{ endpoint.Name }}</td>
                 <td>{{ endpoint.URL | stripprotocol }}</td>
                 <td><i class="fa fa-shield" aria-hidden="true" ng-if="endpoint.TLS"></i></td>
-                <td>
+                <td ng-if="applicationState.application.endpointManagement">
                   <span ng-if="endpoint.Id !== activeEndpoint.Id">
                     <a ui-sref="endpoint({id: endpoint.Id})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a>
                   </span>

--- a/app/services/stateManager.js
+++ b/app/services/stateManager.js
@@ -24,6 +24,7 @@ angular.module('portainer.services')
       } else {
         Config.$promise.then(function success(data) {
           state.application.authentication = data.authentication;
+          state.application.endpointManagement = data.endpointManagement;
           state.application.logo = data.logo;
           LocalStorage.storeApplicationState(state.application);
           state.loading = false;


### PR DESCRIPTION
… source

This PR introduces external endpoint management as required in #484

Two new CLI flags are introduced:

* `--external-endpoints`: enable external endpoint management by specifying the path to a JSON endpoint source in a file
* `--sync-interval`: time interval between two endpoints synchronization requests (expressed as a string, e.g. `30s`, `5m`, `1h`... as supported by the `time.ParseDuration` method https://golang.org/pkg/time/#ParseDuration). Optional, defaults to `60s`

 When using the `--external-endpoints` flag, Portainer will read the specified JSON file at startup and automatically create the endpoints. The first endpoint in the list will be defined as the currently active endpoint.

Portainer will then read the file based on the interval defined in `--sync-interval` (every minute by default) and will automatically do the following:

* For each endpoint in the database, it will automatically merge any configuration find in the file *using the enpoint name* as the comparison key
* If an endpoint exists in the database but is not present in the file, it will be removed from the database
* If an endpoint exists in the file but not in the database it will be created in the database

When starting Portainer with the `--external-endpoints` flag with either an invalid JSON file or an empty array (`[]`), Portainer will log an error and exit. 

When using external endpoint management, **endpoint management will via the UI will be disabled** to avoid any possible configuration overwrite (the endpoints view is still accessible but will only display the list of endpoints without giving the possibility to create/update endpoints). A simple warning message will be displayed in the endpoints view.

Also, the `-H` is mutually exclusive with `--external-endpoints`, Portainer will exit and an error will be printed when using both options on the CLI.

# Endpoint JSON schema

An endpoint element must be valid JSON object.

Examples:

* An endpoint accessed via the Unix socket:

```json
{
  "Name": "my-local-endpoint",
  "URL": "unix:///var/run/docker.sock",
}
```

* A TLS secured endpoint accessed via TCP:

```json
{
  "Name": "my-secure-endpoint",
  "URL": "tcp://myendpoint.mydomain:2375",
  "TLS": true,
  "TLSCACert": "/tmp/ca.pem",
  "TLSCert": "/tmp/cert.pem",
  "TLSKey": "/tmp/key.pem"
}
```

### Name

*Required*

Name of the endpoint. Used to check if an endpoint already exists in the database during a synchronization request. It will also be displayed in the UI.

### URL

*Required*

How to reach the endpoint. Protocol **must** be specified, only `tcp://` and `unix://` are supported at the moment. Any definition not using one of these 2 protocols will be skipped.


### TLS

*Optional*

Specify this field to `true` if you need to use TLS to connect to the endpoint. Defaults to false. When applying the `true` value to this field, Portainer will expect the `TLSCACertPath`, `TLSCertPath` and `TLSKeyPath` fields to be defined too.

### TLSCACert

*Optional*

Path to the CA used to connect to the endpoint.

### TLSCert

*Optional*

Path to the certificate used to connect to the endpoint.

### TLSKey

*Optional*

Path to the key used to connect to the endpoint.

# Endpoints definition source

The content of the file specified as a parameter to the `--external-endpoints` file must be a valid JSON array.

Example:

```json
[
  {
    "Name": "my-local-endpoint",
    "URL": "unix:///var/run/docker.sock"
  },
  {
    "Name": "my-secure-endpoint",
    "URL": "tcp://myendpoint.mydomain:2375",
    "TLS": true,
    "TLSCACert": "/tmp/ca.pem",
    "TLSCert": "/tmp/cert.pem",
    "TLSKey": "/tmp/key.pem"
  }
]
```
