### PR TITLE
fix(container-creation): split the container command to a token array

### DIFF
--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -16,6 +16,7 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
   $scope.config = {
     Image: '',
     Env: [],
+    Cmd: '',
     ExposedPorts: {},
     HostConfig: {
       RestartPolicy: {
@@ -243,6 +244,7 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
 
   function prepareConfiguration() {
     var config = angular.copy($scope.config);
+    config.Cmd = ContainerHelper.commandStringToArray(config.Cmd);
     prepareNetworkConfig(config);
     prepareImageConfig(config);
     preparePortBindings(config);


### PR DESCRIPTION
Fix #557 

https://github.com/deviantony/splitargs was introduced with https://github.com/portainer/portainer/pull/585