### PR TITLE
feat(cli): add a --no-analytics flag to disable google analytics

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -22,18 +22,19 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	kingpin.Version(version)
 
 	flags := &portainer.CLIFlags{
-		Endpoint:  kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
-		Logo:      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
-		Labels:    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
-		Addr:      kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
-		Assets:    kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
-		Data:      kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
-		Templates: kingpin.Flag("templates", "URL to the templates (apps) definitions").Default(defaultTemplatesURL).Short('t').String(),
-		NoAuth:    kingpin.Flag("no-auth", "Disable authentication").Default(defaultNoAuth).Bool(),
-		TLSVerify: kingpin.Flag("tlsverify", "TLS support").Default(defaultTLSVerify).Bool(),
-		TLSCacert: kingpin.Flag("tlscacert", "Path to the CA").Default(defaultTLSCACertPath).String(),
-		TLSCert:   kingpin.Flag("tlscert", "Path to the TLS certificate file").Default(defaultTLSCertPath).String(),
-		TLSKey:    kingpin.Flag("tlskey", "Path to the TLS key").Default(defaultTLSKeyPath).String(),
+		Endpoint:    kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
+		Logo:        kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
+		Labels:      pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
+		Addr:        kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
+		Assets:      kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
+		Data:        kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
+		Templates:   kingpin.Flag("templates", "URL to the templates (apps) definitions").Default(defaultTemplatesURL).Short('t').String(),
+		NoAuth:      kingpin.Flag("no-auth", "Disable authentication").Default(defaultNoAuth).Bool(),
+		NoAnalytics: kingpin.Flag("no-analytics", "Disable Analytics in app").Default(defaultNoAuth).Bool(),
+		TLSVerify:   kingpin.Flag("tlsverify", "TLS support").Default(defaultTLSVerify).Bool(),
+		TLSCacert:   kingpin.Flag("tlscacert", "Path to the CA").Default(defaultTLSCACertPath).String(),
+		TLSCert:     kingpin.Flag("tlscert", "Path to the TLS certificate file").Default(defaultTLSCertPath).String(),
+		TLSKey:      kingpin.Flag("tlskey", "Path to the TLS key").Default(defaultTLSKeyPath).String(),
 	}
 
 	kingpin.Parse()

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -8,6 +8,7 @@ const (
 	defaultAssetsDirectory = "."
 	defaultTemplatesURL    = "https://raw.githubusercontent.com/portainer/templates/master/templates.json"
 	defaultNoAuth          = "false"
+	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"
 	defaultTLSCACertPath   = "/certs/ca.pem"
 	defaultTLSCertPath     = "/certs/cert.pem"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -6,6 +6,7 @@ const (
 	defaultAssetsDirectory = "."
 	defaultTemplatesURL    = "https://raw.githubusercontent.com/portainer/templates/master/templates.json"
 	defaultNoAuth          = "false"
+	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"
 	defaultTLSCACertPath   = "C:\\certs\\ca.pem"
 	defaultTLSCertPath     = "C:\\certs\\cert.pem"

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -28,6 +28,7 @@ func main() {
 		HiddenLabels:   *flags.Labels,
 		Logo:           *flags.Logo,
 		Authentication: !*flags.NoAuth,
+		Analytics:      !*flags.NoAnalytics,
 	}
 
 	fileService, err := file.NewService(*flags.Data, "")

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -13,18 +13,19 @@ type (
 
 	// CLIFlags represents the available flags on the CLI.
 	CLIFlags struct {
-		Addr      *string
-		Assets    *string
-		Data      *string
-		Endpoint  *string
-		Labels    *[]Pair
-		Logo      *string
-		Templates *string
-		NoAuth    *bool
-		TLSVerify *bool
-		TLSCacert *string
-		TLSCert   *string
-		TLSKey    *string
+		Addr        *string
+		Assets      *string
+		Data        *string
+		Endpoint    *string
+		Labels      *[]Pair
+		Logo        *string
+		Templates   *string
+		NoAuth      *bool
+		NoAnalytics *bool
+		TLSVerify   *bool
+		TLSCacert   *string
+		TLSCert     *string
+		TLSKey      *string
 	}
 
 	// Settings represents Portainer settings.
@@ -32,6 +33,7 @@ type (
 		HiddenLabels   []Pair `json:"hiddenLabels"`
 		Logo           string `json:"logo"`
 		Authentication bool   `json:"authentication"`
+		Analytics      bool   `json:"analytics"`
 	}
 
 	// User represent a user account.

--- a/app/app.js
+++ b/app/app.js
@@ -66,6 +66,7 @@ angular.module('portainer', [
     $httpProvider.interceptors.push('jwtInterceptor');
 
     AnalyticsProvider.setAccount('@@CONFIG_GA_ID');
+    AnalyticsProvider.startOffline(true);
 
     $urlRouterProvider.otherwise('/auth');
 
@@ -497,13 +498,17 @@ angular.module('portainer', [
           $state.go('auth', {error: 'Your session has expired'});
         });
       }
+      if (state.application.analytics) {
+        Analytics.offline(false);
+        Analytics.registerScriptTags();
+        Analytics.registerTrackers();
+        $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
+          Analytics.trackPage(toState.url);
+          Analytics.pageView();
+        });
+      }
     }, function error(err) {
       Messages.error("Failure", err, 'Unable to retrieve application settings');
-    });
-
-    $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
-      Analytics.trackPage(toState.url);
-      Analytics.pageView();
     });
 
     $rootScope.$state = $state;

--- a/app/services/stateManager.js
+++ b/app/services/stateManager.js
@@ -24,6 +24,7 @@ angular.module('portainer.services')
       } else {
         Config.$promise.then(function success(data) {
           state.application.authentication = data.authentication;
+          state.application.analytics = data.analytics;
           state.application.logo = data.logo;
           LocalStorage.storeApplicationState(state.application);
           state.loading = false;

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -407,28 +407,28 @@ module.exports = function (grunt) {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer'
+          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics'
         ].join(';')
       },
       runSwarm: {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run -d -p 9000:9000 --name portainer portainer -H tcp://10.0.7.10:2375'
+          'docker run -d -p 9000:9000 --name portainer portainer -H tcp://10.0.7.10:2375 --no-analytics'
         ].join(';')
       },
       runSwarmLocal: {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run -d -p 9000:9000 -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer'
+          'docker run -d -p 9000:9000 -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics'
         ].join(';')
       },
       runSsl: {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run -d -p 9000:9000 -v /tmp/portainer:/data -v /tmp/docker-ssl:/certs --name portainer portainer -H tcp://10.0.7.10:2376 --tlsverify'
+          'docker run -d -p 9000:9000 -v /tmp/portainer:/data -v /tmp/docker-ssl:/certs --name portainer portainer -H tcp://10.0.7.10:2376 --tlsverify --no-analytics'
         ].join(';')
       },
       cleanImages: {


### PR DESCRIPTION
This PR introduces the flag `--no-analytics` (defaults to false) which will disable Google Analytics in app.

It re-create the same behavior as the user opt-out feature in Google Analytics.

Close #600 