### PR TITLE
Clarify 'Manage instance where Portainer is running' warning

### DIFF
--- a/app/components/endpointInit/endpointInit.html
+++ b/app/components/endpointInit/endpointInit.html
@@ -32,8 +32,8 @@
             <div ng-if="formValues.endpointType === 'local'" style="margin-top: 25px;">
               <div class="form-group">
                 <i class="fa fa-exclamation-triangle" aria-hidden="true" style="margin-right: 5px;"></i>
-                <span class="small text-primary">This feature is not available with Docker <b>on</b> Windows yet.</span>
-                <div class="small text-primary">On Linux / Mac, ensure that you have started Portainer container with the following Docker flag <code>-v "/var/run/docker.sock:/var/run/docker.sock"</code></div>
+                <span class="small text-primary">This feature is not yet available for native Docker Windows containers.</span>
+                <div class="small text-primary">On Linux and when using Docker for Mac or Docker for Windows or Docker Toolbox, ensure that you have started Portainer container with the following Docker flag <code>-v "/var/run/docker.sock:/var/run/docker.sock"</code></div>
               </div>
               <!-- connect button -->
               <div class="form-group" style="margin-top: 10px;">


### PR DESCRIPTION
Addressed some confusion in: https://github.com/portainer/portainer/issues/450

I'm hoping this change would make it clear that Portainer works fine when running Linux containers on Docker for Mac/Win and with Toolbox.