### PR TITLE
WIP : Stacks API

### DIFF
--- a/api/http/handler.go
+++ b/api/http/handler.go
@@ -17,6 +17,7 @@ type Handler struct {
 	SettingsHandler  *SettingsHandler
 	TemplatesHandler *TemplatesHandler
 	DockerHandler    *DockerHandler
+  StacksHandler    *StacksHandler
 	WebSocketHandler *WebSocketHandler
 	UploadHandler    *UploadHandler
 	FileHandler      *FileHandler
@@ -51,6 +52,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.WebSocketHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/docker") {
 		http.StripPrefix("/api/docker", h.DockerHandler).ServeHTTP(w, r)
+	} else if strings.HasPrefix(r.URL.Path, "/api/stacks") {
+		http.StripPrefix("/api/stacks", h.StacksHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/") {
 		h.FileHandler.ServeHTTP(w, r)
 	}

--- a/api/http/handler.go
+++ b/api/http/handler.go
@@ -17,7 +17,7 @@ type Handler struct {
 	SettingsHandler  *SettingsHandler
 	TemplatesHandler *TemplatesHandler
 	DockerHandler    *DockerHandler
-  StacksHandler    *StacksHandler
+	StacksHandler    *StacksHandler
 	WebSocketHandler *WebSocketHandler
 	UploadHandler    *UploadHandler
 	FileHandler      *FileHandler

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -45,6 +45,8 @@ func (server *Server) Start() error {
 	templatesHandler.templatesURL = server.TemplatesURL
 	var dockerHandler = NewDockerHandler(middleWareService, server.ResourceControlService)
 	dockerHandler.EndpointService = server.EndpointService
+	var stacksHandler = NewStacksHandler(middleWareService, server.ResourceControlService)
+	stacksHandler.EndpointService = server.EndpointService
 	var websocketHandler = NewWebSocketHandler()
 	websocketHandler.EndpointService = server.EndpointService
 	var endpointHandler = NewEndpointHandler(middleWareService)
@@ -62,6 +64,7 @@ func (server *Server) Start() error {
 		SettingsHandler:  settingsHandler,
 		TemplatesHandler: templatesHandler,
 		DockerHandler:    dockerHandler,
+		StacksHandler:    stacksHandler,
 		WebSocketHandler: websocketHandler,
 		FileHandler:      fileHandler,
 		UploadHandler:    uploadHandler,

--- a/api/http/stacks_handler.go
+++ b/api/http/stacks_handler.go
@@ -13,6 +13,7 @@ import (
   "bytes"
   "os/exec"
   "io/ioutil"
+  "encoding/json"
 
 	"github.com/gorilla/mux"
 )
@@ -22,6 +23,12 @@ type StacksHandler struct {
 	*mux.Router
 	Logger          *log.Logger
 	EndpointService portainer.EndpointService
+}
+
+type StackCommandResult struct {
+  Error       error
+  Stdout      string
+  Stderr      string
 }
 
 // NewStacksHandler returns a new instance of StacksHandler.
@@ -53,13 +60,17 @@ func (handler *StacksHandler) executeDockerStackRm(w http.ResponseWriter, r *htt
 
   cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "rm", stack)
 
-  var out bytes.Buffer
-  cmd.Stdout = &out
-  cmd.Stderr = &out
+  var stdout bytes.Buffer
+  var stderr bytes.Buffer
+  cmd.Stdout = &stdout
+  cmd.Stderr = &stderr
   err = cmd.Run()
 
-  fmt.Fprintln(w, out.String())
-  fmt.Fprintln(w, "err: ", err)
+  result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
+  jsonResult, err := json.Marshal(result)
+  /*fmt.Fprintln(w, out.String())
+  fmt.Fprintln(w, "err: ", err)*/
+  fmt.Fprintln(w, string(jsonResult))
 }
 
 func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r *http.Request) {
@@ -86,13 +97,17 @@ func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r 
 
   cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "deploy", "--compose-file", tmpfile.Name(), stack)
 
-  var out bytes.Buffer
-  cmd.Stdout = &out
-  cmd.Stderr = &out
+  var stdout bytes.Buffer
+  var stderr bytes.Buffer
+  cmd.Stdout = &stdout
+  cmd.Stderr = &stderr
   err = cmd.Run()
 
-  fmt.Fprintln(w, out.String())
-  fmt.Fprintln(w, "err: ", err)
+  result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
+  jsonResult, err := json.Marshal(result)
+  /*fmt.Fprintln(w, out.String())
+  fmt.Fprintln(w, "err: ", err)*/
+  fmt.Fprintln(w, string(jsonResult))
 
   tmpfile.Close()
 }

--- a/api/http/stacks_handler.go
+++ b/api/http/stacks_handler.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/portainer/portainer"
 
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
-  "fmt"
-  "bytes"
-  "os/exec"
-  "io/ioutil"
-  "encoding/json"
+	"os/exec"
 
 	"github.com/gorilla/mux"
 )
@@ -26,9 +26,9 @@ type StacksHandler struct {
 }
 
 type StackCommandResult struct {
-  Error       error
-  Stdout      string
-  Stderr      string
+	Error  error
+	Stdout string
+	Stderr string
 }
 
 // NewStacksHandler returns a new instance of StacksHandler.
@@ -58,35 +58,35 @@ func (handler *StacksHandler) executeDockerStackRm(w http.ResponseWriter, r *htt
 	endpointID := portainer.EndpointID(parsedID)
 	endpoint, _ := handler.EndpointService.Endpoint(endpointID)
 
-  cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "rm", stack)
+	cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "rm", stack)
 
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
-  err = cmd.Run()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 
-  result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
-  jsonResult, err := json.Marshal(result)
-  /*fmt.Fprintln(w, out.String())
-  fmt.Fprintln(w, "err: ", err)*/
-  fmt.Fprintln(w, string(jsonResult))
+	result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
+	jsonResult, err := json.Marshal(result)
+	/*fmt.Fprintln(w, out.String())
+	  fmt.Fprintln(w, "err: ", err)*/
+	fmt.Fprintln(w, string(jsonResult))
 }
 
 func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 	stack := vars["stack"]
-  u, _ := url.Parse(r.URL.String())
-  queryParams := u.Query()
+	u, _ := url.Parse(r.URL.String())
+	queryParams := u.Query()
 
-  // Get Body (compose-file)
-  body, _ := ioutil.ReadAll(r.Body)
+	// Get Body (compose-file)
+	body, _ := ioutil.ReadAll(r.Body)
 
-  // Place body in tempfile
-  tmpfile, err := ioutil.TempFile("/", "portainer_compose_file_")
-  defer os.Remove(tmpfile.Name())
-  tmpfile.Write(body)
+	// Place body in tempfile
+	tmpfile, err := ioutil.TempFile("/", "portainer_compose_file_")
+	defer os.Remove(tmpfile.Name())
+	tmpfile.Write(body)
 
 	parsedID, err := strconv.Atoi(id)
 	if err != nil {
@@ -97,24 +97,24 @@ func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r 
 	endpointID := portainer.EndpointID(parsedID)
 	endpoint, _ := handler.EndpointService.Endpoint(endpointID)
 
-  cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "deploy", "--compose-file", tmpfile.Name(), stack)
-  // Add env from queryParams
-  cmd.Env = []string{}
-  for k, v := range queryParams { 
-    cmd.Env = append(cmd.Env, k + "=" + v[0])
-  }
+	cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "deploy", "--compose-file", tmpfile.Name(), stack)
+	// Add env from queryParams
+	cmd.Env = []string{}
+	for k, v := range queryParams {
+		cmd.Env = append(cmd.Env, k+"="+v[0])
+	}
 
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
-  err = cmd.Run()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 
-  result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
-  jsonResult, err := json.Marshal(result)
-  /*fmt.Fprintln(w, out.String())
-  fmt.Fprintln(w, "err: ", err)*/
-  fmt.Fprintln(w, string(jsonResult))
+	result := StackCommandResult{Error: err, Stdout: stdout.String(), Stderr: stderr.String()}
+	jsonResult, err := json.Marshal(result)
+	/*fmt.Fprintln(w, out.String())
+	  fmt.Fprintln(w, "err: ", err)*/
+	fmt.Fprintln(w, string(jsonResult))
 
-  tmpfile.Close()
+	tmpfile.Close()
 }

--- a/api/http/stacks_handler.go
+++ b/api/http/stacks_handler.go
@@ -7,7 +7,7 @@ import (
 
 	"log"
 	"net/http"
-	//"net/url"
+	"net/url"
 	"os"
   "fmt"
   "bytes"
@@ -77,6 +77,8 @@ func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r 
 	vars := mux.Vars(r)
 	id := vars["id"]
 	stack := vars["stack"]
+  u, _ := url.Parse(r.URL.String())
+  queryParams := u.Query()
 
   // Get Body (compose-file)
   body, _ := ioutil.ReadAll(r.Body)
@@ -96,6 +98,11 @@ func (handler *StacksHandler) executeDockerStackDeploy(w http.ResponseWriter, r 
 	endpoint, _ := handler.EndpointService.Endpoint(endpointID)
 
   cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", "deploy", "--compose-file", tmpfile.Name(), stack)
+  // Add env from queryParams
+  cmd.Env = []string{}
+  for k, v := range queryParams { 
+    cmd.Env = append(cmd.Env, k + "=" + v[0])
+  }
 
   var stdout bytes.Buffer
   var stderr bytes.Buffer

--- a/api/http/stacks_handler.go
+++ b/api/http/stacks_handler.go
@@ -30,9 +30,9 @@ func NewStacksHandler(mw *middleWareService, resourceControlService portainer.Re
 		Router: mux.NewRouter(),
 		Logger: log.New(os.Stderr, "", log.LstdFlags),
 	}
-	h.PathPrefix("/{id}/{stack}/deploy").Handler(
+	h.PathPrefix("/{id}/{stack}").Methods("POST").Handler(
 		mw.authenticated(http.HandlerFunc(h.executeDockerStackDeploy)))
-	h.PathPrefix("/{id}/{stack}/rm").Handler(
+	h.PathPrefix("/{id}/{stack}").Methods("DELETE").Handler(
 		mw.authenticated(http.HandlerFunc(h.executeDockerStackRm)))
 	return h
 }

--- a/api/http/stacks_handler.go
+++ b/api/http/stacks_handler.go
@@ -1,0 +1,62 @@
+package http
+
+import (
+	"strconv"
+
+	"github.com/portainer/portainer"
+
+	"log"
+	"net/http"
+	//"net/url"
+	"os"
+  "fmt"
+  "bytes"
+  "os/exec"
+
+	"github.com/gorilla/mux"
+)
+
+// StacksHandler represents an HTTP API handler for proxying requests to the Docker API.
+type StacksHandler struct {
+	*mux.Router
+	Logger          *log.Logger
+	EndpointService portainer.EndpointService
+}
+
+// NewStacksHandler returns a new instance of StacksHandler.
+func NewStacksHandler(mw *middleWareService, resourceControlService portainer.ResourceControlService) *StacksHandler {
+	h := &StacksHandler{
+		Router: mux.NewRouter(),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
+	}
+	h.PathPrefix("/{id}/{stack}/{command}").Handler(
+		mw.authenticated(http.HandlerFunc(h.executeDockerStackCommand)))
+	return h
+}
+
+func (handler *StacksHandler) executeDockerStackCommand(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+	stack := vars["stack"]
+  command := vars["command"]
+
+	parsedID, err := strconv.Atoi(id)
+	if err != nil {
+		Error(w, err, http.StatusBadRequest, handler.Logger)
+		return
+	}
+
+	endpointID := portainer.EndpointID(parsedID)
+	endpoint, _ := handler.EndpointService.Endpoint(endpointID)
+
+  cmd := exec.Command("/docker", "-H", endpoint.URL, "stack", command, stack)
+
+  var out bytes.Buffer
+  cmd.Stdout = &out
+  cmd.Stderr = &out
+  err = cmd.Run()
+
+  fmt.Fprintln(w, out.String())
+  fmt.Fprintln(w, "err: ", err)
+}
+


### PR DESCRIPTION
Just to init the stacks API to discuss here
This allow portainer to call "stack rm" and "stack deploy" using the docker client logic

In order to work, we need to place docker static binary in portainer image
Ideally, grunt place it in dist

## Api call for docker stack rm : 
```
curl -X DELETE http://localhost:9000/api/stacks/<endpoint_id>/<stack_name>
```
### Return if something in stack : 
```
{
    "Error": null,
    "Stderr": "Removing service stack1_nginx\nRemoving service stack1_mysql\nRemoving service stack1_apache\nRemoving network stack1_default\n",
    "Stdout": ""
}
```
### Return if nothing in stack : 
```
{
    "Error": null,
    "Stderr": "",
    "Stdout": "Nothing found in stack: stack1\n"
}
```
## Api call for docker stack deploy with variable : 
```
curl -X POST 'http://localhost:9000/api/stacks/1/stack1?MYSQL_ROOT_PASSWORD=mypass' \
 --data-binary 'version: "3"
services:
  mysql:
    image: mysql
    environment:
      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"'
```
### Return if OK : 
```
{
    "Error": null,
    "Stderr": "",
    "Stdout": "Creating network stack1_default\nCreating service stack1_mysql\n"
}
```
### Return if updating a existing stack : 
```
{
    "Error": null,
    "Stderr": "",
    "Stdout": "Updating service stack1_mysql (id: m30qzjqmy6w1eb4e4a4opdw7d)\n"
}
```
### Return if upload of a compose v1/v2 file : 
```
{
    "Error": {
        "Stderr": null
    },
    "Stderr": "unsupported Compose file version: 2\n",
    "Stdout": ""
}
```

TODO : 
- [x] Output in Json instead of raw stdout/stderr
- [x] Limit commands to rm / deploy
- [x] Code the deploy to manage --compose-file parameter
- [x] Test if we can send a compose-file with variable (template)
- [ ] Add support for TLS endpoints