### PR TITLE
fix(frontend): use network.Id to create container

### DIFF
--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -295,7 +295,7 @@
                 <div class="col-sm-9">
                   <select class="form-control" ng-model="config.HostConfig.NetworkMode" id="container_network">
                     <option selected disabled hidden value="">Select a network</option>
-                    <option ng-repeat="net in availableNetworks" ng-value="net.Name">{{ net.Name }}</option>
+                    <option ng-repeat="net in availableNetworks" ng-value="net.Id">{{ net.Name }}</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
Change frontend to use network.Id 
Fix for #704

