### PR TITLE
fix(Dockerfiles): use a volume to store data

### DIFF
--- a/build/windows/microsoftservercore/Dockerfile
+++ b/build/windows/microsoftservercore/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/windowsservercore
 
 COPY dist /
 
-RUN mkdir C:\\data
+VOLUME C:\\data
 
 WORKDIR /
 

--- a/build/windows/nanoserver/Dockerfile
+++ b/build/windows/nanoserver/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/nanoserver
 
 COPY dist /
 
-RUN mkdir C:\\data
+VOLUME C:\\data
 
 WORKDIR /
 


### PR DESCRIPTION
Now that the builder images are using Golang 1.8 (introduced in https://github.com/portainer/golang-builder/commit/ff5108c031d90ebd02c450372212c45f4f8cb327) we can revert the VOLUME definition in the Windows Dockerfile.