### PR TITLE
fix(cli): Allow setting admin password from CLI

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -15,11 +15,12 @@ import (
 type Service struct{}
 
 const (
-	errInvalidEnpointProtocol  = portainer.Error("Invalid endpoint protocol: Portainer only supports unix:// or tcp://")
-	errSocketNotFound          = portainer.Error("Unable to locate Unix socket")
-	errEndpointsFileNotFound   = portainer.Error("Unable to locate external endpoints file")
-	errInvalidSyncInterval     = portainer.Error("Invalid synchronization interval")
-	errEndpointExcludeExternal = portainer.Error("Cannot use the -H flag mutually with --external-endpoints")
+	errInvalidEndpointProtocol     = portainer.Error("Invalid endpoint protocol: Portainer only supports unix:// or tcp://")
+	errSocketNotFound              = portainer.Error("Unable to locate Unix socket")
+	errEndpointsFileNotFound       = portainer.Error("Unable to locate external endpoints file")
+	errInvalidSyncInterval         = portainer.Error("Invalid synchronization interval")
+	errEndpointExcludeExternal     = portainer.Error("Cannot use the -H flag mutually with --external-endpoints")
+	errNoAuthExcludeAdminPassword  = portainer.Error("Cannot use --no-auth with --admin-password")
 )
 
 // ParseFlags parse the CLI flags and return a portainer.Flags struct
@@ -42,6 +43,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		TLSCacert:         kingpin.Flag("tlscacert", "Path to the CA").Default(defaultTLSCACertPath).String(),
 		TLSCert:           kingpin.Flag("tlscert", "Path to the TLS certificate file").Default(defaultTLSCertPath).String(),
 		TLSKey:            kingpin.Flag("tlskey", "Path to the TLS key").Default(defaultTLSKeyPath).String(),
+		AdminPassword:     kingpin.Flag("admin-password", "Hashed admin password").String(),
 	}
 
 	kingpin.Parse()
@@ -70,13 +72,17 @@ func (*Service) ValidateFlags(flags *portainer.CLIFlags) error {
 		return err
 	}
 
+  if *flags.NoAuth && (*flags.AdminPassword != "") {
+    return errNoAuthExcludeAdminPassword
+  }
+
 	return nil
 }
 
 func validateEndpoint(endpoint string) error {
 	if endpoint != "" {
 		if !strings.HasPrefix(endpoint, "unix://") && !strings.HasPrefix(endpoint, "tcp://") {
-			return errInvalidEnpointProtocol
+			return errInvalidEndpointProtocol
 		}
 
 		if strings.HasPrefix(endpoint, "unix://") {

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -140,6 +140,19 @@ func main() {
 		}
 	}
 
+	if *flags.AdminPassword != "" {
+		log.Printf("Creating admin user with password hash %s", *flags.AdminPassword)
+		user := &portainer.User{
+			Username: "admin",
+			Role:     portainer.AdministratorRole,
+			Password: *flags.AdminPassword,
+		}
+		err := store.UserService.CreateUser(user)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	var server portainer.Server = &http.Server{
 		BindAddress:            *flags.Addr,
 		AssetsPath:             *flags.Assets,

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -28,6 +28,7 @@ type (
 		TLSCacert         *string
 		TLSCert           *string
 		TLSKey            *string
+		AdminPassword     *string
 	}
 
 	// Settings represents Portainer settings.


### PR DESCRIPTION
This pull request allow users to specify an hash for the admin password from the command line. Fixes #428.

A pull request to update the documentation is coming soon but in the meantime a couple of caveats:

- The password can be generate using the command `htpasswd -nb -B admin <password>`
- If portainer is run from the binary escape the `$` in the password hash with `\` to avoid shell expansion
- If portainer is run from inside a container escape the `$` in the password hash with `\\` to avoid expansion from the shell outside and inside the container.