### PR TITLE
feat(templates): LinuxServer.io templates integration

### DIFF
--- a/api/http/server.go
+++ b/api/http/server.go
@@ -42,7 +42,7 @@ func (server *Server) Start() error {
 	var settingsHandler = NewSettingsHandler(middleWareService)
 	settingsHandler.settings = server.Settings
 	var templatesHandler = NewTemplatesHandler(middleWareService)
-	templatesHandler.templatesURL = server.TemplatesURL
+	templatesHandler.containerTemplatesURL = server.TemplatesURL
 	var dockerHandler = NewDockerHandler(middleWareService, server.ResourceControlService)
 	dockerHandler.EndpointService = server.EndpointService
 	var websocketHandler = NewWebSocketHandler()

--- a/app/app.js
+++ b/app/app.js
@@ -458,6 +458,7 @@ angular.module('portainer', [
       url: '/templates/',
       params: {
         key: 'containers',
+        hide_descriptions: false
       },
       views: {
         "content@": {
@@ -474,6 +475,7 @@ angular.module('portainer', [
       url: '^/templates/linuxserver.io',
       params: {
         key: 'linuxserver.io',
+        hide_descriptions: true
       },
       views: {
         "content@": {

--- a/app/app.js
+++ b/app/app.js
@@ -456,6 +456,25 @@ angular.module('portainer', [
     })
     .state('templates', {
       url: '/templates/',
+      params: {
+        key: 'containers',
+      },
+      views: {
+        "content@": {
+          templateUrl: 'app/components/templates/templates.html',
+          controller: 'TemplatesController'
+        },
+        "sidebar@": {
+          templateUrl: 'app/components/sidebar/sidebar.html',
+          controller: 'SidebarController'
+        }
+      }
+    })
+    .state('templates_linuxserver', {
+      url: '^/templates/linuxserver.io',
+      params: {
+        key: 'linuxserver.io',
+      },
       views: {
         "content@": {
           templateUrl: 'app/components/templates/templates.html',

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -21,7 +21,7 @@
     </li>
     <li class="sidebar-list">
       <a ui-sref="templates" ui-sref-active="active">App Templates <span class="menu-icon fa fa-rocket"></span></a>
-      <div class="sidebar-sublist">
+      <div class="sidebar-sublist" ng-if="$state.current.name === 'templates'">
         <a ui-sref="templates" ui-sref-active="active">LinuxServer.io</a>
       </div>
     </li>

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -21,8 +21,8 @@
     </li>
     <li class="sidebar-list">
       <a ui-sref="templates" ui-sref-active="active">App Templates <span class="menu-icon fa fa-rocket"></span></a>
-      <div class="sidebar-sublist" ng-if="$state.current.name === 'templates'">
-        <a ui-sref="templates" ui-sref-active="active">LinuxServer.io</a>
+      <div class="sidebar-sublist" ng-if="$state.current.name === 'templates' || $state.current.name === 'templates_linuxserver'">
+        <a ui-sref="templates_linuxserver" ui-sref-active="active">LinuxServer.io</a>
       </div>
     </li>
     <li class="sidebar-list" ng-if="applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE'">

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -21,7 +21,7 @@
     </li>
     <li class="sidebar-list">
       <a ui-sref="templates" ui-sref-active="active">App Templates <span class="menu-icon fa fa-rocket"></span></a>
-      <div class="sidebar-sublist" ng-if="$state.current.name === 'templates' || $state.current.name === 'templates_linuxserver'">
+      <div class="sidebar-sublist" ng-if="toggle && ($state.current.name === 'templates' || $state.current.name === 'templates_linuxserver')">
         <a ui-sref="templates_linuxserver" ui-sref-active="active">LinuxServer.io</a>
       </div>
     </li>

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -21,6 +21,9 @@
     </li>
     <li class="sidebar-list">
       <a ui-sref="templates" ui-sref-active="active">App Templates <span class="menu-icon fa fa-rocket"></span></a>
+      <div class="sidebar-sublist">
+        <a ui-sref="templates" ui-sref-active="active">LinuxServer.io</a>
+      </div>
     </li>
     <li class="sidebar-list" ng-if="applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE'">
       <a ui-sref="services" ui-sref-active="active">Services <span class="menu-icon fa fa-list-alt"></span></a>

--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -228,7 +228,7 @@
           <div dir-paginate="tpl in templates | itemsPerPage: state.pagination_count" class="container-template hvr-underline-from-center" id="template_{{ tpl.index }}" ng-click="selectTemplate(tpl.index)">
             <img class="logo" ng-src="{{ tpl.Logo }}" />
             <div class="title">{{ tpl.Title }}</div>
-            <div class="description">{{ tpl.Description }}</div>
+            <div class="description" ng-if="tpl.Description">{{ tpl.Description | truncate:50 }}</div>
           </div>
           <div ng-if="!templates" class="text-center text-muted">
             Loading...

--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -14,17 +14,13 @@
       </rd-widget-custom-header>
       <rd-widget-body classes="padding">
         <form class="form-horizontal">
-          <div class="form-group" ng-if="globalNetworkCount === 0 && applicationState.endpoint.mode.provider === 'DOCKER_SWARM'">
+          <!-- description -->
+          <div class="form-group" ng-if="state.selectedTemplate.Description">
             <div class="col-sm-12">
-              <span class="small text-muted">When using Swarm, we recommend deploying containers in a shared network. Looks like you don't have any shared network, head over the <a ui-sref="networks">networks view</a> to create one.</span>
+              <span class="small" style="margin-left: 5px;">{{ state.selectedTemplate.Description }}</span>
             </div>
           </div>
-          <div class="form-group" ng-if="applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE'">
-            <div class="col-sm-12">
-              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-              <span class="small text-muted">App templates cannot be used with swarm-mode at the moment. You can still use them to quickly deploy containers to the Docker host.</span>
-            </div>
-          </div>
+          <!-- !description -->
           <!-- name-and-network-inputs -->
           <div class="form-group">
             <label for="container_name" class="col-sm-1 control-label text-left">Name</label>
@@ -200,6 +196,13 @@
             <div class="col-sm-12">
               <button type="button" class="btn btn-primary btn-sm" ng-disabled="!formValues.network" ng-click="createTemplate()">Create</button>
               <i id="createContainerSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
+              <span class="small text-muted" style="margin-left: 10px" ng-if="globalNetworkCount === 0 && applicationState.endpoint.mode.provider === 'DOCKER_SWARM'">
+                When using Swarm, we recommend deploying containers in a shared network. Looks like you don't have any shared network, head over the <a ui-sref="networks">networks view</a> to create one.
+              </span>
+              <span ng-if="applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE'" style="margin-left: 10px">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                <span class="small text-muted" style="margin-left: 5px;">App templates cannot be deployed as Swarm Mode services for the moment. You can still use them to quickly deploy containers on the Docker host.</span>
+              </span>
             </div>
           </div>
         </form>
@@ -228,7 +231,7 @@
           <div dir-paginate="tpl in templates | itemsPerPage: state.pagination_count" class="container-template hvr-underline-from-center" id="template_{{ tpl.index }}" ng-click="selectTemplate(tpl.index)">
             <img class="logo" ng-src="{{ tpl.Logo }}" />
             <div class="title">{{ tpl.Title }}</div>
-            <div class="description" ng-if="tpl.Description">{{ tpl.Description | truncate:50 }}</div>
+            <div class="description" ng-if="tpl.Description && !state.hideDescriptions">{{ tpl.Description }}</div>
           </div>
           <div ng-if="!templates" class="text-center text-muted">
             Loading...

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -1,6 +1,6 @@
 angular.module('templates', [])
-.controller('TemplatesController', ['$scope', '$q', '$state', '$anchorScroll', 'Config', 'ContainerService', 'ContainerHelper', 'ImageService', 'NetworkService', 'TemplateService', 'TemplateHelper', 'VolumeService', 'Messages', 'Pagination', 'ResourceControlService', 'Authentication',
-function ($scope, $q, $state, $anchorScroll, Config, ContainerService, ContainerHelper, ImageService, NetworkService, TemplateService, TemplateHelper, VolumeService, Messages, Pagination, ResourceControlService, Authentication) {
+.controller('TemplatesController', ['$scope', '$q', '$state', '$stateParams', '$anchorScroll', 'Config', 'ContainerService', 'ContainerHelper', 'ImageService', 'NetworkService', 'TemplateService', 'TemplateHelper', 'VolumeService', 'Messages', 'Pagination', 'ResourceControlService', 'Authentication',
+function ($scope, $q, $state, $stateParams, $anchorScroll, Config, ContainerService, ContainerHelper, ImageService, NetworkService, TemplateService, TemplateHelper, VolumeService, Messages, Pagination, ResourceControlService, Authentication) {
   $scope.state = {
     selectedTemplate: null,
     showAdvancedOptions: false,
@@ -130,15 +130,20 @@ function ($scope, $q, $state, $anchorScroll, Config, ContainerService, Container
   }
 
   function initTemplates() {
+    var templatesKey = $stateParams.key;
     Config.$promise.then(function (c) {
       $q.all({
-        templates: TemplateService.getTemplates(),
+        templates: TemplateService.getTemplates(templatesKey),
         containers: ContainerService.getContainers(0, c.hiddenLabels),
         networks: NetworkService.getNetworks(),
         volumes: VolumeService.getVolumes()
       })
       .then(function success(data) {
-        $scope.templates = data.templates;
+        var templates = data.templates;
+        if (templatesKey == 'linuxserver.io') {
+          templates = TemplateService.filterLinuxServerTemplates(templates);
+        }
+        $scope.templates = templates;
         $scope.runningContainers = data.containers;
         $scope.availableNetworks = filterNetworksBasedOnProvider(data.networks);
         $scope.availableVolumes = data.volumes.Volumes;

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -4,6 +4,7 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, Config, ContainerServ
   $scope.state = {
     selectedTemplate: null,
     showAdvancedOptions: false,
+    hideDescriptions: $stateParams.hide_descriptions,
     pagination_count: Pagination.getPaginationCount('templates')
   };
   $scope.formValues = {
@@ -124,7 +125,7 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, Config, ContainerServ
     if (endpointProvider === 'DOCKER_SWARM' || endpointProvider === 'DOCKER_SWARM_MODE') {
       if (endpointProvider === 'DOCKER_SWARM') {
         networks = NetworkService.filterGlobalNetworks(networks);
-      } else { 
+      } else {
         networks = NetworkService.filterSwarmModeAttachableNetworks(networks);
       }
       $scope.globalNetworkCount = networks.length;
@@ -145,7 +146,7 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, Config, ContainerServ
       .then(function success(data) {
         var templates = data.templates;
         if (templatesKey == 'linuxserver.io') {
-          templates = TemplateService.filterLinuxServerTemplates(templates);
+          templates = TemplateService.filterLinuxServerIOTemplates(templates);
         }
         $scope.templates = templates;
         $scope.runningContainers = data.containers;

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -145,7 +145,7 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, Config, ContainerServ
       })
       .then(function success(data) {
         var templates = data.templates;
-        if (templatesKey == 'linuxserver.io') {
+        if (templatesKey === 'linuxserver.io') {
           templates = TemplateService.filterLinuxServerIOTemplates(templates);
         }
         $scope.templates = templates;

--- a/app/helpers/templateHelper.js
+++ b/app/helpers/templateHelper.js
@@ -93,5 +93,22 @@ angular.module('portainer.helpers')
     return count;
   };
 
+  helper.filterLinuxServerIOTemplates = function(templates) {
+    return templates.filter(function f(template) {
+      var valid = false;
+      if (template.Category) {
+        angular.forEach(template.Category, function(category) {
+          if (_.startsWith(category, 'Network')) {
+            valid = true;
+          }
+        });
+      }
+      return valid;
+    }).map(function(template, idx) {
+      template.index = idx;
+      return template;
+    });
+  };
+
   return helper;
 }]);

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -1,6 +1,7 @@
 function TemplateViewModel(data) {
   this.Title = data.title;
   this.Description = data.description;
+  this.Category = data.category;
   this.Logo = data.logo;
   this.Image = data.image;
   this.Registry = data.registry ? data.registry : '';

--- a/app/services/templateService.js
+++ b/app/services/templateService.js
@@ -3,9 +3,9 @@ angular.module('portainer.services')
   'use strict';
   var service = {};
 
-  service.getTemplates = function() {
+  service.getTemplates = function(key) {
     var deferred = $q.defer();
-    Template.get().$promise
+    Template.get({key: key}).$promise
     .then(function success(data) {
       var templates = data.map(function (tpl, idx) {
         var template = new TemplateViewModel(tpl);
@@ -18,6 +18,13 @@ angular.module('portainer.services')
       deferred.reject({ msg: 'Unable to retrieve templates', err: err });
     });
     return deferred.promise;
+  };
+
+  service.filterLinuxServerTemplates = function(templates) {
+    console.log(JSON.stringify(templates, null, 4));
+    return templates.filter(function f(template) {
+      return template;
+    });
   };
 
   service.createTemplateConfiguration = function(template, containerName, network, containerMapping) {

--- a/app/services/templateService.js
+++ b/app/services/templateService.js
@@ -20,11 +20,8 @@ angular.module('portainer.services')
     return deferred.promise;
   };
 
-  service.filterLinuxServerTemplates = function(templates) {
-    console.log(JSON.stringify(templates, null, 4));
-    return templates.filter(function f(template) {
-      return template;
-    });
+  service.filterLinuxServerIOTemplates = function(templates) {
+    return TemplateHelper.filterLinuxServerIOTemplates(templates);
   };
 
   service.createTemplateConfiguration = function(template, containerName, network, containerMapping) {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -321,7 +321,8 @@ ul.sidebar .sidebar-list .sidebar-sublist a {
 
 ul.sidebar .sidebar-list .sidebar-sublist a.active {
   color: #fff;
-  border: 0;
+  border-left: 3px solid #fff;
+  background: #2d3e63;
 }
 
 @media(min-width: 768px) and (max-width: 992px) {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -301,6 +301,10 @@ ul.sidebar {
   bottom: 40px;
 }
 
+ul.sidebar .sidebar-title {
+  height: auto;
+}
+
 ul.sidebar .sidebar-list a.active {
   color: #fff;
   text-indent: 22px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -293,6 +293,19 @@ ul.sidebar .sidebar-list a.active {
   background: #2d3e63;
 }
 
+ul.sidebar .sidebar-list .sidebar-sublist a {
+  text-indent: 35px;
+  font-size: 12px;
+  color: #b2bfdc;
+  line-height: 40px;
+}
+
+ul.sidebar .sidebar-list .sidebar-sublist a.active {
+  color: #fff;
+  border: 0;
+}
+
+
 @media (min-width: 768px) {
     .pull-sm-left {
         float: left !important;

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -408,7 +408,7 @@ module.exports = function (grunt) {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics'
+          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --templates http://tools.linuxserver.io/lsio/portainer.php'
         ].join(';')
       },
       runSwarm: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -408,7 +408,7 @@ module.exports = function (grunt) {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --no-auth'
+          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics'
         ].join(';')
       },
       runSwarm: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -408,7 +408,7 @@ module.exports = function (grunt) {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --templates http://tools.linuxserver.io/portainer.json --no-auth'
+          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --no-auth'
         ].join(';')
       },
       runSwarm: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -408,7 +408,7 @@ module.exports = function (grunt) {
         command: [
           'docker stop portainer',
           'docker rm portainer',
-          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --templates http://tools.linuxserver.io/lsio/portainer.php'
+          'docker run --privileged -d -p 9000:9000 -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock --name portainer portainer --no-analytics --templates http://tools.linuxserver.io/portainer.json --no-auth'
         ].join(';')
       },
       runSwarm: {


### PR DESCRIPTION
This PR creates a new sub-navigation tab in the sidebar under the App Templates section. This allows to display the container templates of LinuxServer.io (for now, only the templates related to the *Network* category).

Close #666 