### PR TITLE
WIP: pushState based routing

### DIFF
--- a/api/http/file_handler.go
+++ b/api/http/file_handler.go
@@ -2,17 +2,23 @@ package http
 
 import (
 	"net/http"
+	"os"
+	"path"
 	"strings"
 )
 
 // FileHandler represents an HTTP API handler for managing static files.
 type FileHandler struct {
 	http.Handler
+	AssetPath       string
+	NotFoundHandler http.Handler
 }
 
 func newFileHandler(assetPath string) *FileHandler {
 	h := &FileHandler{
-		Handler: http.FileServer(http.Dir(assetPath)),
+		Handler:         http.FileServer(http.Dir(assetPath)),
+		AssetPath:       assetPath,
+		NotFoundHandler: http.HandlerFunc(notFound),
 	}
 	return h
 }
@@ -26,11 +32,22 @@ func isHTML(acceptContent []string) bool {
 	return false
 }
 
+func notFound(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, "index.html")
+}
+
 func (fileHandler *FileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !isHTML(r.Header["Accept"]) {
 		w.Header().Set("Cache-Control", "max-age=31536000")
 	} else {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}
-	fileHandler.Handler.ServeHTTP(w, r)
+
+	_, err := os.Open(path.Join(fileHandler.AssetPath, path.Clean(r.URL.Path)))
+	if os.IsNotExist(err) {
+		fileHandler.NotFoundHandler.ServeHTTP(w, r)
+		return
+	} else {
+		fileHandler.Handler.ServeHTTP(w, r)
+	}
 }

--- a/app/app.js
+++ b/app/app.js
@@ -51,7 +51,7 @@ angular.module('portainer', [
   'user',
   'users',
   'volumes'])
-  .config(['$stateProvider', '$urlRouterProvider', '$httpProvider', 'localStorageServiceProvider', 'jwtOptionsProvider', 'AnalyticsProvider', '$uibTooltipProvider', function ($stateProvider, $urlRouterProvider, $httpProvider, localStorageServiceProvider, jwtOptionsProvider, AnalyticsProvider, $uibTooltipProvider) {
+  .config(['$stateProvider', '$urlRouterProvider', '$locationProvider', '$httpProvider', 'localStorageServiceProvider', 'jwtOptionsProvider', 'AnalyticsProvider', '$uibTooltipProvider', function ($stateProvider, $urlRouterProvider, $locationProvider, $httpProvider, localStorageServiceProvider, jwtOptionsProvider, AnalyticsProvider, $uibTooltipProvider) {
     'use strict';
 
     localStorageServiceProvider
@@ -70,6 +70,8 @@ angular.module('portainer', [
 
     AnalyticsProvider.setAccount('@@CONFIG_GA_ID');
     AnalyticsProvider.startOffline(true);
+
+    $locationProvider.html5Mode(true);
 
     $urlRouterProvider.otherwise('/auth');
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   <meta name="description" content="">
   <meta name="author" content="<%= pkg.author %>">
 
+  <base href="/">
+
   <!-- build:css css/app.css -->
   <link href="css/vendor.css" rel="stylesheet">
   <link href="css/portainer.css" rel="stylesheet">


### PR DESCRIPTION
This is a PR for https://github.com/portainer/portainer/issues/791 that enables pushState based routing. 

Currently have to set `<base href="/">` in order for it to work properly, which means that it will break when Portainer is reverse proxied behind a virtual directory.

I've marked this PR as WIP till a solution can be figured out for this.