### PR TITLE
feat(templates): add support for the note field

### DIFF
--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -15,9 +15,9 @@
       <rd-widget-body classes="padding">
         <form class="form-horizontal">
           <!-- description -->
-          <div class="form-group" ng-if="state.selectedTemplate.Description">
+          <div class="form-group" ng-if="state.selectedTemplate.Note">
             <div class="col-sm-12">
-              <span class="small" style="margin-left: 5px;">{{ state.selectedTemplate.Description }}</span>
+              <span class="small" style="margin-left: 5px;" ng-bind-html="state.selectedTemplate.Note"></span>
             </div>
           </div>
           <!-- !description -->

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -1,6 +1,7 @@
 function TemplateViewModel(data) {
   this.Title = data.title;
   this.Description = data.description;
+  this.Note = data.note ? data.note : data.description;
   this.Category = data.category;
   this.Logo = data.logo;
   this.Image = data.image;


### PR DESCRIPTION
This PR brings support for the `note` field in any template definition. This field will be displayed if existing otherwise it will display the content of the `description` field (actual behavior).

This field supports HTML format.

Current display (nginx template, no `note` field):
![portainer 1](https://cloud.githubusercontent.com/assets/5485061/25140348/4510a3f8-2460-11e7-9fd4-35724c776244.png)

Note display (new template with a specific `note` field):
![portainer](https://cloud.githubusercontent.com/assets/5485061/25140349/451274c6-2460-11e7-9323-12a031d0ddd4.png)


Close #804 

