### PR TITLE
#803 fix(services) Replicas count misunderstanding

### DIFF
--- a/app/components/services/servicesController.js
+++ b/app/components/services/servicesController.js
@@ -154,7 +154,7 @@ function ($q, $scope, $stateParams, $state, Service, ServiceHelper, Notification
       $scope.swarmManagerIP = NodeHelper.getManagerIP(data.nodes);
       $scope.services = data.services.map(function (service) {
         var serviceTasks = data.tasks.filter(function (task) {
-          return task.ServiceID === service.ID;
+          return task.ServiceID === service.ID && task.Status.State === "running";
         });
         var taskNodes = data.nodes.filter(function (node) {
           return node.Spec.Availability === 'active' && node.Status.State === 'ready';


### PR DESCRIPTION
Fixes #803 

Can be tested by running a service with 1 replica of nginx image
Then scale up to 10, and refresh services view quickly
You can see X/10 grow from 1 to 10 when services are up

Before the change, portainer display immediately 10/10