### PR TITLE
feat(container-creation): add support for ip assignments (#473)

### DIFF
--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -12,7 +12,9 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
     Registry: '',
     NetworkContainer: '',
     Labels: [],
-    ExtraHosts: []
+    ExtraHosts: [],
+    IPv4: '',
+    IPv6: ''
   };
 
   $scope.imageConfig = {};
@@ -33,6 +35,9 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
       Privileged: false,
       ExtraHosts: [],
       Devices:[]
+    },
+    NetworkingConfig: {
+      EndpointsConfig: {}
     },
     Labels: {}
   };
@@ -266,6 +271,13 @@ function ($scope, $state, $stateParams, $filter, Config, Info, Container, Contai
       networkMode += ':' + containerName;
     }
     config.HostConfig.NetworkMode = networkMode;
+
+    config.NetworkingConfig.EndpointsConfig[networkMode] = {
+      IPAMConfig: {
+        IPv4Address: $scope.formValues.IPv4,
+        IPv6Address: $scope.formValues.IPv6
+      }
+    };
 
     $scope.formValues.ExtraHosts.forEach(function (v) {
     if (v.value) {

--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -354,7 +354,7 @@
               <div class="form-group">
                 <label for="container_ipv4" class="col-sm-2 col-lg-1 control-label text-left">IPv4 Address</label>
                 <div class="col-sm-9">
-                  <input type="text" class="form-control" ng-model="formValues.IPv4" id="container_ipv4" placeholder="(Optional) e.g. xxx.xxx.xxx.xxx">
+                  <input type="text" class="form-control" ng-model="formValues.IPv4" id="container_ipv4" placeholder="e.g. 172.20.0.7">
                 </div>
               </div>
               <!-- !ipv4-input -->
@@ -362,7 +362,7 @@
               <div class="form-group">
                 <label for="container_ipv6" class="col-sm-2 col-lg-1 control-label text-left">IPv6 Address</label>
                 <div class="col-sm-9">
-                  <input type="text" class="form-control" ng-model="formValues.IPv6" id="container_ipv6" placeholder="(Optional) e.g. xxxx:xxxx::xx">
+                  <input type="text" class="form-control" ng-model="formValues.IPv6" id="container_ipv6" placeholder="e.g. a:b:c:d::1234">
                 </div>
               </div>
               <!-- !ipv6-input -->

--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -350,6 +350,22 @@
                 </div>
               </div>
               <!-- !domainname -->
+              <!-- ipv4-input -->
+              <div class="form-group">
+                <label for="container_ipv4" class="col-sm-2 col-lg-1 control-label text-left">IPv4 Address</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control" ng-model="formValues.IPv4" id="container_ipv4" placeholder="(Optional) e.g. xxx.xxx.xxx.xxx">
+                </div>
+              </div>
+              <!-- !ipv4-input -->
+              <!-- ipv6-input -->
+              <div class="form-group">
+                <label for="container_ipv6" class="col-sm-2 col-lg-1 control-label text-left">IPv6 Address</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control" ng-model="formValues.IPv6" id="container_ipv6" placeholder="(Optional) e.g. xxxx:xxxx::xx">
+                </div>
+              </div>
+              <!-- !ipv6-input -->
               <!-- extra-hosts-variables -->
               <div class="form-group">
                 <div class="col-sm-12" style="margin-top: 5px;">


### PR DESCRIPTION
Added two new fields to the container creation page for statically setting the IPv4 and IPv6 addresses a container will be assigned.