### PR TITLE
feat(templates): Support interactive templates (#819)

### DIFF
--- a/app/helpers/templateHelper.js
+++ b/app/helpers/templateHelper.js
@@ -66,6 +66,18 @@ angular.module('portainer.helpers')
     return env;
   };
 
+  helper.getConsoleConfiguration = function(interactiveFlag) {
+    var consoleConfiguration = {
+      openStdin: false,
+      tty: false
+    };
+    if (interactiveFlag === true) {
+      consoleConfiguration.openStdin = true;
+      consoleConfiguration.tty = true;
+    }
+    return consoleConfiguration;
+  };
+
   helper.createVolumeBindings = function(volumes, generatedVolumesPile) {
     volumes.forEach(function (volume) {
       if (volume.containerPath) {

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -11,6 +11,7 @@ function TemplateViewModel(data) {
   this.Env = data.env ? data.env : [];
   this.Privileged = data.privileged ? data.privileged : false;
   this.Volumes = [];
+  this.Interactive = data.interactive ? data.interactive : false;
   if (data.volumes) {
     this.Volumes = data.volumes.map(function (v) {
       return {

--- a/app/services/templateService.js
+++ b/app/services/templateService.js
@@ -42,6 +42,9 @@ angular.module('portainer.services')
     var portConfiguration = TemplateHelper.portArrayToPortConfiguration(template.Ports);
     configuration.HostConfig.PortBindings = portConfiguration.bindings;
     configuration.ExposedPorts = portConfiguration.exposedPorts;
+    var consoleConfiguration = TemplateHelper.getConsoleConfiguration(template.Interactive);
+    configuration.OpenStdin = consoleConfiguration.openStdin;
+    configuration.Tty = consoleConfiguration.tty;
     return configuration;
   };
 


### PR DESCRIPTION
Add support to templates for an optional 'interactive: true' field that starts the container using -i -t.

Closes #819