### PR TITLE
fix(service-details): add missing Arguments field

### DIFF
--- a/app/models/service.js
+++ b/app/models/service.js
@@ -51,6 +51,7 @@ function ServiceViewModel(data, runningTasks, nodes) {
     this.User = containerSpec.User;
     this.Dir = containerSpec.Dir;
     this.Command = containerSpec.Command;
+    this.Arguments = containerSpec.Args;
     this.Secrets = containerSpec.Secrets;
   }
   if (data.Endpoint) {


### PR DESCRIPTION
The only missing field is the `Arguments` field. This PR fixes this issue.

Fix #854 