### PR TITLE
#40 refactor(build-system): reduce gruntfile verbosity, drop grunt-if, allow custom build

### DIFF
--- a/build/build_cross-platform.sh
+++ b/build/build_cross-platform.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+binary="portainer-$1-$2"
+
+docker run -tv $(pwd)/api:/src -e BUILD_GOOS="$1" -e BUILD_GOARCH="$2" portainer/golang-builder:cross-platform /src/cmd/portainer
+
+mkdir -p dist
+mv "api/cmd/portainer/$binary" dist/
+shasum "dist/$binary" > portainer-checksum.txt

--- a/build/build_in_container.sh
+++ b/build/build_in_container.sh
@@ -2,8 +2,9 @@
 
 binary="portainer-$1-$2"
 
+mkdir -p dist
+
 docker run -tv $(pwd)/api:/src -e BUILD_GOOS="$1" -e BUILD_GOARCH="$2" portainer/golang-builder:cross-platform /src/cmd/portainer
 
-mkdir -p dist
 mv "api/cmd/portainer/$binary" dist/
-shasum "dist/$binary" > portainer-checksum.txt
+#sha256sum "dist/$binary" > portainer-checksum.txt

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "grunt-contrib-watch": "~0.3.1",
     "grunt-filerev": "^2.3.1",
     "grunt-html2js": "~0.1.0",
-    "grunt-if": "^0.1.5",
     "grunt-karma": "~0.4.4",
     "grunt-postcss": "^0.8.0",
     "grunt-replace": "^1.0.1",


### PR DESCRIPTION
# Reduce verbosity in `gruntfile.js`

`build*Binary` tasks are all equal, except `BUILD_GOOS`, `BUILD_GOARCH` and the executable name. I moved the instructions to a separate bash file (`build/build_cross-platform.sh`) which takes two args. Then, I replaced all the tasks with a single function-based one: https://stackoverflow.com/questions/20799069/grunt-grunt-shell-and-command-argument

Furthermore, the existence of `dist/portainer(.exe)` can be checked with `grunt.file.isFile`: https://nodejs.org/docs/latest/api/fs.html#fs_class_fs_stats . As a result, the dependency on `grunt-if`` can be dropped:

``` javascript
buildBinary: { command: function (p, a) {
  var file = 'dist/portainer'; 
  if ( p === "windows" ) { file = 'dist/portainer.exe'; }   
  if (grunt.file.isFile(file)) { return 'echo \'BinaryExists\'';
  } else {                      return 'build/build_cross-platform.sh ' + p + ' ' + a; }
}},  
```
Then, `if:<platform><Arch>BinaryNotExist` tasks are replaced with `'shell:buildBinary:<platform>:<Arch>`.

The very same approach can be applied to `release-<platform>-<arch>` tasks, which are replaced with a single one named `release`:

``` javascript
  grunt.task.registerTask('release', 'release:platform:arch', function(p, a) {
	var cp = 'copy';
	if ( p === "linux" && ( a === "386" || a === "amd64" ) ) { cp = 'copy:assets'; }
	grunt.task.run(['config:prod', 'clean:all', 'shell:buildBinary:'+p+':'+a, 'before-copy', cp, 'after-copy' ]);
  });
```
https://gruntjs.com/api/grunt.task
https://gruntjs.com/configuring-tasks

where

``` javascript
  grunt.registerTask('before-copy', [
    'html2js',
    'useminPrepare:release',
    'recess:build',
    'concat',
    'clean:tmpl',
    'cssmin',
    'replace',
    'uglify', 
  ]);
  grunt.registerTask('after-copy', [
    'filerev',
    'usemin',
    'clean:tmp' 
  ]);
```
Note these are also used in `build` and `build-webapp` to further reduce verbosity.

# Reduce verbosity in `build.sh`

Despite `PLATFORM` and `ARCH` being defined, these are always used as `PLATFORM-ARCH`. Therefore couples (tags) can explicitly defined in that form. On top of that, an array can hold multiple tags:

```
platforms='linux-amd64 linux-386 linux-arm linux-arm64 linux-ppc64le darwin-amd64 windows-amd64'
 
for tag in ${platforms}; do
  grunt release:`echo "$tag" | tr '-' ':'`
  if [ `echo $tag | cut -d \- -f 1` == "linux" ]; then build_and_push_images "$tag"; fi
  build_archive "$tag"
done
```
- `build_and_push_images` and `build_archive` are modified to accept a single argument.
- Due to previous modifications, calls to grunt must be `release:<platform>:<arch>`. Then, `echo` and `tr` are used to replace `-` with `:`. 

Furthermore, during development, `build.sh` is modified in order to allow custom build commands. If the first four characters in "<VERSION>" are "echo", "$@" is passed to "bash -c":

``` bash
Usage: build.sh <VERSION>
       build.sh "echo 'Custom' && <BASH COMMANDS>"
```

Close #40 