### PR TITLE
#954 feat(endpoint): support other TLS modes

### DIFF
--- a/api/file/file.go
+++ b/api/file/file.go
@@ -107,6 +107,29 @@ func (service *Service) DeleteTLSFiles(endpointID portainer.EndpointID) error {
 	return nil
 }
 
+func (service *Service) DeleteTLSFile(endpointID portainer.EndpointID, fileType portainer.TLSFileType) error {
+	var fileName string
+	switch fileType {
+	case portainer.TLSFileCA:
+		fileName = TLSCACertFile
+	case portainer.TLSFileCert:
+		fileName = TLSCertFile
+	case portainer.TLSFileKey:
+		fileName = TLSKeyFile
+	default:
+		return portainer.ErrUndefinedTLSFileType
+	}
+
+	ID := strconv.Itoa(int(endpointID))
+	filePath := path.Join(service.fileStorePath, TLSStorePath, ID, fileName)
+
+	err := os.Remove(filePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // createDirectoryInStoreIfNotExist creates a new directory in the file store if it doesn't exists on the file system.
 func (service *Service) createDirectoryInStoreIfNotExist(name string) error {
 	path := path.Join(service.fileStorePath, name)

--- a/api/http/handler/websocket.go
+++ b/api/http/handler/websocket.go
@@ -72,7 +72,9 @@ func (handler *WebSocketHandler) webSocketDockerExec(ws *websocket.Conn) {
 	// Should not be managed here
 	var tlsConfig *tls.Config
 	if endpoint.TLS {
-		tlsConfig, err = crypto.CreateTLSConfiguration(endpoint.TLSCACertPath,
+		tlsConfig, err = crypto.CreateTLSConfiguration(endpoint.TLSVerify,
+			endpoint.TLSClientCert,
+			endpoint.TLSCACertPath,
 			endpoint.TLSCertPath,
 			endpoint.TLSKeyPath)
 		if err != nil {

--- a/api/http/proxy/factory.go
+++ b/api/http/proxy/factory.go
@@ -24,7 +24,7 @@ func (factory *proxyFactory) newHTTPProxy(u *url.URL) http.Handler {
 func (factory *proxyFactory) newHTTPSProxy(u *url.URL, endpoint *portainer.Endpoint) (http.Handler, error) {
 	u.Scheme = "https"
 	proxy := factory.createReverseProxy(u)
-	config, err := crypto.CreateTLSConfiguration(endpoint.TLSCACertPath, endpoint.TLSCertPath, endpoint.TLSKeyPath)
+	config, err := crypto.CreateTLSConfiguration(endpoint.TLSVerify, endpoint.TLSClientCert, endpoint.TLSCACertPath, endpoint.TLSCertPath, endpoint.TLSKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -129,6 +129,8 @@ type (
 		URL             string     `json:"URL"`
 		PublicURL       string     `json:"PublicURL"`
 		TLS             bool       `json:"TLS"`
+		TLSVerify       bool       `json:"TLSVerify"`
+		TLSClientCert   bool       `json:"TLSClientCert"`
 		TLSCACertPath   string     `json:"TLSCACert,omitempty"`
 		TLSCertPath     string     `json:"TLSCert,omitempty"`
 		TLSKeyPath      string     `json:"TLSKey,omitempty"`
@@ -295,6 +297,7 @@ type (
 		StoreTLSFile(endpointID EndpointID, fileType TLSFileType, r io.Reader) error
 		GetPathForTLSFile(endpointID EndpointID, fileType TLSFileType) (string, error)
 		DeleteTLSFiles(endpointID EndpointID) error
+		DeleteTLSFile(endpointID EndpointID, fileType TLSFileType) error
 	}
 
 	// EndpointWatcher represents a service to synchronize the endpoints via an external source.

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -47,7 +47,7 @@
             <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 TLS
-                <portainer-tooltip position="bottom" message="Enable this option if you need to specify TLS certificates to connect to the Docker endpoint."></portainer-tooltip>
+                <portainer-tooltip position="bottom" message="Enable this option if you need to connect to the Docker endpoint with TLS."></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
                 <input type="checkbox" ng-model="endpoint.TLS"><i></i>
@@ -57,12 +57,23 @@
           <!-- !tls-checkbox -->
           <!-- tls-certs -->
           <div ng-if="endpoint.TLS">
-            <!-- ca-input -->
             <div class="form-group">
+              <div class="col-sm-10">
+                <label for="tls_verify" class="control-label text-left">
+                  TLS Verify
+                  <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate server based on given CA."></portainer-tooltip>
+                </label>
+                <label class="switch" style="margin-left: 20px;">
+                  <input type="checkbox" ng-model="endpoint.TLSVerify"><i></i>
+                </label>
+              </div>
+            </div>
+            <!-- ca-input -->
+            <div class="form-group" ng-if="endpoint.TLSVerify">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
-                <span style="margin-left: 5px;">
+                <span style="margin-left: 5px;" ng-if="formValues.UseTLSCACert">
                   <span ng-if="formValues.TLSCACert !== endpoint.TLSCACert">{{ formValues.TLSCACert.name }}</span>
                   <i class="fa fa-check green-icon" ng-if="formValues.TLSCACert && formValues.TLSCACert === endpoint.TLSCACert" aria-hidden="true"></i>
                   <i class="fa fa-times red-icon" ng-if="!formValues.TLSCACert" aria-hidden="true"></i>
@@ -71,39 +82,52 @@
               </div>
             </div>
             <!-- !ca-input -->
-            <!-- cert-input -->
             <div class="form-group">
-              <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
-                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                <span style="margin-left: 5px;">
-                  <span ng-if="formValues.TLSCert !== endpoint.TLSCert">{{ formValues.TLSCert.name }}</span>
-                  <i class="fa fa-check green-icon" ng-if="formValues.TLSCert && formValues.TLSCert === endpoint.TLSCert" aria-hidden="true"></i>
-                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
-                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                </span>
+                <label for="tls_client_cert" class="control-label text-left">
+                  TLS Client Certificate
+                  <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate with client certificate."></portainer-tooltip>
+                </label>
+                <label class="switch" style="margin-left: 20px;">
+                  <input type="checkbox" ng-model="endpoint.TLSClientCert"><i></i>
+                </label>
               </div>
             </div>
-            <!-- !cert-input -->
-            <!-- key-input -->
-            <div class="form-group">
-              <label class="col-sm-2 control-label text-left">TLS key</label>
-              <div class="col-sm-10">
-                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                <span style="margin-left: 5px;">
-                  <span ng-if="formValues.TLSKey !== endpoint.TLSKey">{{ formValues.TLSKey.name }}</span>
-                  <i class="fa fa-check green-icon" ng-if="formValues.TLSKey && formValues.TLSKey === endpoint.TLSKey" aria-hidden="true"></i>
-                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
-                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                </span>
+            <div ng-if="endpoint.TLSClientCert">
+              <!-- cert-input -->
+              <div class="form-group">
+                <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
+                <div class="col-sm-10">
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                  <span style="margin-left: 5px;">
+                    <span ng-if="formValues.TLSCert !== endpoint.TLSCert">{{ formValues.TLSCert.name }}</span>
+                    <i class="fa fa-check green-icon" ng-if="formValues.TLSCert && formValues.TLSCert === endpoint.TLSCert" aria-hidden="true"></i>
+                    <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                    <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                  </span>
+                </div>
               </div>
+              <!-- !cert-input -->
+              <!-- key-input -->
+              <div class="form-group">
+                <label class="col-sm-2 control-label text-left">TLS key</label>
+                <div class="col-sm-10">
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                  <span style="margin-left: 5px;">
+                    <span ng-if="formValues.TLSKey !== endpoint.TLSKey">{{ formValues.TLSKey.name }}</span>
+                    <i class="fa fa-check green-icon" ng-if="formValues.TLSKey && formValues.TLSKey === endpoint.TLSKey" aria-hidden="true"></i>
+                    <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                    <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                  </span>
+                </div>
+              </div>
+              <!-- !key-input -->
             </div>
-            <!-- !key-input -->
           </div>
           <!-- !tls-certs -->
           <div class="form-group">
             <div class="col-sm-12">
-              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!endpoint.Name || !endpoint.URL || (endpoint.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="updateEndpoint()">Update endpoint</button>
+              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!endpoint.Name || !endpoint.URL || (endpoint.TLS && ((endpoint.TLSVerify && !formValues.TLSCACert) || (endpoint.TLSClientCert && (!formValues.TLSCert || !formValues.TLSKey))))" ng-click="updateEndpoint()">Update endpoint</button>
               <a type="button" class="btn btn-default btn-sm" ui-sref="endpoints">Cancel</a>
               <i id="updateEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
               <span class="text-danger" ng-if="state.error" style="margin: 5px;">

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -64,6 +64,10 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Notifications)
       $scope.formValues.UseTLSCACert = Boolean(data.TLSCACert);
       $scope.formValues.UseTLSCert = Boolean(data.TLSCert);
       $scope.formValues.UseTLSKey = Boolean(data.TLSKey);
+      if (!$scope.endpoint.TLS) {
+        $scope.endpoint.TLSVerify = true
+        $scope.endpoint.TLSClientCert = true
+      }
     }, function error(err) {
       $('#loadingViewSpinner').hide();
       Notifications.error('Failure', err, 'Unable to retrieve endpoint details');

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -19,14 +19,18 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Notifications)
 
   $scope.updateEndpoint = function() {
     var ID = $scope.endpoint.Id;
+    var TLSVerify = $scope.endpoint.TLS && $scope.endpoint.TLSVerify;
+    var TLSClientCert = $scope.endpoint.TLS && $scope.endpoint.TLSClientCert;
     var endpointParams = {
       name: $scope.endpoint.Name,
       URL: $scope.endpoint.URL,
       PublicURL: $scope.endpoint.PublicURL,
       TLS: $scope.endpoint.TLS,
-      TLSCACert: $scope.formValues.TLSCACert !== $scope.endpoint.TLSCACert ? $scope.formValues.TLSCACert : null,
-      TLSCert: $scope.formValues.TLSCert !== $scope.endpoint.TLSCert ? $scope.formValues.TLSCert : null,
-      TLSKey: $scope.formValues.TLSKey !== $scope.endpoint.TLSKey ? $scope.formValues.TLSKey : null,
+      TLSVerify: TLSVerify,
+      TLSClientCert: TLSClientCert,
+      TLSCACert: (TLSVerify && ($scope.formValues.TLSCACert !== $scope.endpoint.TLSCACert)) ? $scope.formValues.TLSCACert : null,
+      TLSCert: (TLSClientCert && ($scope.formValues.TLSCert !== $scope.endpoint.TLSCert)) ? $scope.formValues.TLSCert : null,
+      TLSKey: (TLSClientCert && ($scope.formValues.TLSKey !== $scope.endpoint.TLSKey)) ? $scope.formValues.TLSKey : null,
       type: $scope.endpointType
     };
 
@@ -57,6 +61,9 @@ function ($scope, $state, $stateParams, $filter, EndpointService, Notifications)
       $scope.formValues.TLSCACert = data.TLSCACert;
       $scope.formValues.TLSCert = data.TLSCert;
       $scope.formValues.TLSKey = data.TLSKey;
+      $scope.formValues.UseTLSCACert = Boolean(data.TLSCACert);
+      $scope.formValues.UseTLSCert = Boolean(data.TLSCert);
+      $scope.formValues.UseTLSKey = Boolean(data.TLSKey);
     }, function error(err) {
       $('#loadingViewSpinner').hide();
       Notifications.error('Failure', err, 'Unable to retrieve endpoint details');

--- a/app/components/endpointInit/endpointInit.html
+++ b/app/components/endpointInit/endpointInit.html
@@ -86,8 +86,20 @@
               <!-- !tls-checkbox -->
               <!-- tls-certs -->
               <div ng-if="formValues.TLS">
-                <!-- ca-input -->
                 <div class="form-group">
+                  <div class="col-sm-10">
+                    <label for="tls_verify" class="control-label text-left">
+                      TLS Verify
+                      <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate server based on given CA."></portainer-tooltip>
+                    </label>
+                    <label class="switch" style="margin-left: 20px;">
+                      <input type="checkbox" ng-model="formValues.TLSVerify"><i></i>
+                    </label>
+                  </div>
+                </div>
+
+                <!-- ca-input -->
+                <div class="form-group" ng-if="formValues.TLSVerify">
                   <label class="col-sm-3 control-label text-left">TLS CA certificate</label>
                   <div class="col-sm-9">
                     <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
@@ -99,32 +111,45 @@
                   </div>
                 </div>
                 <!-- !ca-input -->
-                <!-- cert-input -->
                 <div class="form-group">
-                  <label for="tls_cert" class="col-sm-3 control-label text-left">TLS certificate</label>
-                  <div class="col-sm-9">
-                    <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                    <span style="margin-left: 5px;">
-                      {{ formValues.TLSCert.name }}
-                      <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
-                      <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                    </span>
+                  <div class="col-sm-10">
+                    <label for="tls_client_cert" class="control-label text-left">
+                      TLS Client Certificate
+                      <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate with client certificate."></portainer-tooltip>
+                    </label>
+                    <label class="switch" style="margin-left: 20px;">
+                      <input type="checkbox" ng-model="formValues.TLSClientCert"><i></i>
+                    </label>
                   </div>
                 </div>
-                <!-- !cert-input -->
-                <!-- key-input -->
-                <div class="form-group">
-                  <label class="col-sm-3 control-label text-left">TLS key</label>
-                  <div class="col-sm-9">
-                    <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                    <span style="margin-left: 5px;">
-                      {{ formValues.TLSKey.name }}
-                      <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
-                      <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                    </span>
+                <div ng-if="formValues.TLSClientCert">
+                  <!-- cert-input -->
+                  <div class="form-group">
+                    <label for="tls_cert" class="col-sm-3 control-label text-left">TLS certificate</label>
+                    <div class="col-sm-9">
+                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                      <span style="margin-left: 5px;">
+                        {{ formValues.TLSCert.name }}
+                        <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                        <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                      </span>
+                    </div>
                   </div>
+                  <!-- !cert-input -->
+                  <!-- key-input -->
+                  <div class="form-group">
+                    <label class="col-sm-3 control-label text-left">TLS key</label>
+                    <div class="col-sm-9">
+                      <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                      <span style="margin-left: 5px;">
+                        {{ formValues.TLSKey.name }}
+                        <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                        <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                      </span>
+                    </div>
+                  </div>
+                  <!-- !key-input -->
                 </div>
-                <!-- !key-input -->
               </div>
               <!-- !tls-certs -->
               <!-- connect button -->
@@ -135,7 +160,7 @@
                   </p>
                   <span class="pull-right">
                     <i id="initEndpointSpinner" class="fa fa-cog fa-spin" style="margin-right: 5px; display: none;"></i>
-                    <button type="submit" class="btn btn-primary" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="createRemoteEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
+                    <button type="submit" class="btn btn-primary" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && ((formValues.TLSVerify && !formValues.TLSCACert) || (formValues.TLSClientCert && (!formValues.TLSCert || !formValues.TLSKey))))" ng-click="createRemoteEndpoint()"><i class="fa fa-plug" aria-hidden="true"></i> Connect</button>
                   </span>
                 </div>
               </div>

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -11,6 +11,8 @@ function ($scope, $state, EndpointService, StateManager, EndpointProvider, Notif
     Name: '',
     URL: '',
     TLS: false,
+    TLSVerify: false,
+    TLSClientCert: false,
     TLSCACert: null,
     TLSCert: null,
     TLSKey: null
@@ -69,11 +71,13 @@ function ($scope, $state, EndpointService, StateManager, EndpointProvider, Notif
     var URL = $scope.formValues.URL;
     var PublicURL = URL.split(':')[0];
     var TLS = $scope.formValues.TLS;
-    var TLSCAFile = $scope.formValues.TLSCACert;
-    var TLSCertFile = $scope.formValues.TLSCert;
-    var TLSKeyFile = $scope.formValues.TLSKey;
+    var TLSVerify = TLS && $scope.formValues.TLSVerify;
+    var TLSClientCert = TLS && $scope.formValues.TLSClientCert;
+    var TLSCAFile = TLSVerify ? $scope.formValues.TLSCACert : null;
+    var TLSCertFile = TLSClientCert ? $scope.formValues.TLSCert : null;
+    var TLSKeyFile = TLSClientCert ? $scope.formValues.TLSKey: null;
 
-    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile)
+    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSVerify, TLSClientCert, TLSCAFile, TLSCertFile, TLSKeyFile)
     .then(function success(data) {
       var endpointID = data.Id;
       updateEndpointState(endpointID);

--- a/app/components/endpointInit/endpointInitController.js
+++ b/app/components/endpointInit/endpointInitController.js
@@ -11,8 +11,8 @@ function ($scope, $state, EndpointService, StateManager, EndpointProvider, Notif
     Name: '',
     URL: '',
     TLS: false,
-    TLSVerify: false,
-    TLSClientCert: false,
+    TLSVerify: true,
+    TLSClientCert: true,
     TLSCACert: null,
     TLSCert: null,
     TLSKey: null

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -62,7 +62,7 @@
             <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 TLS
-                <portainer-tooltip position="bottom" message="Enable this option if you need to specify TLS certificates to connect to the Docker endpoint."></portainer-tooltip>
+                <portainer-tooltip position="bottom" message="Enable this option if you need to connect to the Docker endpoint with TLS."></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
                 <input type="checkbox" ng-model="formValues.TLS"><i></i>
@@ -72,8 +72,19 @@
           <!-- !tls-checkbox -->
           <!-- tls-certs -->
           <div ng-if="formValues.TLS">
-            <!-- ca-input -->
             <div class="form-group">
+              <div class="col-sm-10">
+                <label for="tls_verify" class="control-label text-left">
+                  TLS Verify
+                  <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate server based on given CA."></portainer-tooltip>
+                </label>
+                <label class="switch" style="margin-left: 20px;">
+                  <input type="checkbox" ng-model="formValues.TLSVerify"><i></i>
+                </label>
+              </div>
+            </div>
+            <!-- ca-input -->
+            <div class="form-group" ng-if="formValues.TLSVerify">
               <label class="col-sm-2 control-label text-left">TLS CA certificate</label>
               <div class="col-sm-10">
                 <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCACert">Select file</button>
@@ -85,37 +96,50 @@
               </div>
             </div>
             <!-- !ca-input -->
-            <!-- cert-input -->
             <div class="form-group">
-              <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
               <div class="col-sm-10">
-                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
-                <span style="margin-left: 5px;">
-                  {{ formValues.TLSCert.name }}
-                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
-                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                </span>
+                <label for="tls_client_cert" class="control-label text-left">
+                  TLS Client Certificate
+                  <portainer-tooltip position="bottom" message="Enable this option if you need to authenticate with client certificate."></portainer-tooltip>
+                </label>
+                <label class="switch" style="margin-left: 20px;">
+                  <input type="checkbox" ng-model="formValues.TLSClientCert"><i></i>
+                </label>
               </div>
             </div>
-            <!-- !cert-input -->
-            <!-- key-input -->
-            <div class="form-group">
-              <label class="col-sm-2 control-label text-left">TLS key</label>
-              <div class="col-sm-10">
-                <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
-                <span style="margin-left: 5px;">
-                  {{ formValues.TLSKey.name }}
-                  <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
-                  <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
-                </span>
+            <div ng-if="formValues.TLSClientCert">
+              <!-- cert-input -->
+              <div class="form-group">
+                <label for="tls_cert" class="col-sm-2 control-label text-left">TLS certificate</label>
+                <div class="col-sm-10">
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSCert">Select file</button>
+                  <span style="margin-left: 5px;">
+                    {{ formValues.TLSCert.name }}
+                    <i class="fa fa-times red-icon" ng-if="!formValues.TLSCert" aria-hidden="true"></i>
+                    <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                  </span>
+                </div>
               </div>
+              <!-- !cert-input -->
+              <!-- key-input -->
+              <div class="form-group">
+                <label class="col-sm-2 control-label text-left">TLS key</label>
+                <div class="col-sm-10">
+                  <button class="btn btn-sm btn-primary" ngf-select ng-model="formValues.TLSKey">Select file</button>
+                  <span style="margin-left: 5px;">
+                    {{ formValues.TLSKey.name }}
+                    <i class="fa fa-times red-icon" ng-if="!formValues.TLSKey" aria-hidden="true"></i>
+                    <i class="fa fa-circle-o-notch fa-spin" ng-if="state.uploadInProgress"></i>
+                  </span>
+                </div>
+              </div>
+              <!-- !key-input -->
             </div>
-            <!-- !key-input -->
           </div>
           <!-- !tls-certs -->
           <div class="form-group">
             <div class="col-sm-12">
-              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && (!formValues.TLSCACert || !formValues.TLSCert || !formValues.TLSKey))" ng-click="addEndpoint()">Add endpoint</button>
+              <button type="button" class="btn btn-primary btn-sm" ng-disabled="!formValues.Name || !formValues.URL || (formValues.TLS && ((formValues.TLSVerify && !formValues.TLSCACert) || (formValues.TLSClientCert && (!formValues.TLSCert || !formValues.TLSKey))))" ng-click="addEndpoint()">Add endpoint</button>
               <i id="createEndpointSpinner" class="fa fa-cog fa-spin" style="margin-left: 5px; display: none;"></i>
               <span class="text-danger" ng-if="state.error" style="margin: 5px;">
                 <i class="fa fa-exclamation-circle" aria-hidden="true"></i> {{ state.error }}

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -15,8 +15,8 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
     URL: '',
     PublicURL: '',
     TLS: false,
-    TLSVerify: false,
-    TLSClientCert: false,
+    TLSVerify: true,
+    TLSClientCert: true,
     TLSCACert: null,
     TLSCert: null,
     TLSKey: null

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -15,6 +15,8 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
     URL: '',
     PublicURL: '',
     TLS: false,
+    TLSVerify: false,
+    TLSClientCert: false,
     TLSCACert: null,
     TLSCert: null,
     TLSKey: null
@@ -55,10 +57,13 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
       PublicURL = URL.split(':')[0];
     }
     var TLS = $scope.formValues.TLS;
-    var TLSCAFile = $scope.formValues.TLSCACert;
-    var TLSCertFile = $scope.formValues.TLSCert;
-    var TLSKeyFile = $scope.formValues.TLSKey;
-    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile, false).then(function success(data) {
+    var TLSVerify = TLS && $scope.formValues.TLSVerify;
+    var TLSClientCert = TLS && $scope.formValues.TLSClientCert;
+    var TLSCAFile = TLSVerify ? $scope.formValues.TLSCACert : null;
+    var TLSCertFile = TLSClientCert ? $scope.formValues.TLSCert : null;
+    var TLSKeyFile = TLSClientCert ? $scope.formValues.TLSKey : null;
+
+    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSVerify, TLSClientCert, TLSCAFile, TLSCertFile, TLSKeyFile).then(function success(data) {
       Notifications.success('Endpoint created', name);
       $state.reload();
     }, function error(err) {

--- a/app/services/api/endpointService.js
+++ b/app/services/api/endpointService.js
@@ -20,6 +20,8 @@ angular.module('portainer.services')
       name: endpointParams.name,
       PublicURL: endpointParams.PublicURL,
       TLS: endpointParams.TLS,
+      TLSVerify: endpointParams.TLSVerify,
+      TLSClientCert: endpointParams.TLSClientCert,
       authorizedUsers: endpointParams.authorizedUsers
     };
     if (endpointParams.type && endpointParams.URL) {
@@ -55,18 +57,20 @@ angular.module('portainer.services')
     return Endpoints.create({}, endpoint).$promise;
   };
 
-  service.createRemoteEndpoint = function(name, URL, PublicURL, TLS, TLSCAFile, TLSCertFile, TLSKeyFile) {
+  service.createRemoteEndpoint = function(name, URL, PublicURL, TLS, TLSVerify, TLSClientCert, TLSCAFile, TLSCertFile, TLSKeyFile) {
     var endpoint = {
       Name: name,
       URL: 'tcp://' + URL,
       PublicURL: PublicURL,
-      TLS: TLS
+      TLS: TLS,
+      TLSVerify: TLSVerify,
+      TLSClientCert: TLSClientCert
     };
     var deferred = $q.defer();
     Endpoints.create({}, endpoint).$promise
     .then(function success(data) {
       var endpointID = data.Id;
-      if (TLS) {
+      if (TLSVerify || TLSClientCert) {
         deferred.notify({upload: true});
         FileUploadService.uploadTLSFilesForEndpoint(endpointID, TLSCAFile, TLSCertFile, TLSKeyFile)
         .then(function success() {


### PR DESCRIPTION
This PR adds endpoint TLS options `TLS Verify` and `TLS Client Cert`. By doing so, portainer can support all [Docker client TLS modes](https://docs.docker.com/engine/security/https/#client-modes).

| Docker CLI option | TLS | TLS Verify | TLS Client Cert | 
|---------------------|-----|------------|------------------|
| tls                         | true | false        | false                 |
| tlsverify, tlscacert| true | true         | false                 |
| tls, tlscert, tlskey | true | false | true |
| tlsverify, tlscacert, tlscert, tlskey | true | true | true|

Closes #954 
Also closes #786.

