### PR TITLE
feat(containers): add buttons disabling based on cluster selection

### DIFF
--- a/app/components/containers/containers.html
+++ b/app/components/containers/containers.html
@@ -25,12 +25,12 @@
     <rd-widget-taskbar classes="col-lg-12">
       <div class="pull-left">
         <div class="btn-group" role="group" aria-label="...">
-          <button type="button" class="btn btn-success btn-responsive" ng-click="startAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-play space-right" aria-hidden="true"></i>Start</button>
-          <button type="button" class="btn btn-danger btn-responsive" ng-click="stopAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-stop space-right" aria-hidden="true"></i>Stop</button>
+          <button type="button" class="btn btn-success btn-responsive" ng-click="startAction()" ng-disabled="!state.selectedItemCount || state.noStoppedItemsSelected"><i class="fa fa-play space-right" aria-hidden="true"></i>Start</button>
+          <button type="button" class="btn btn-danger btn-responsive" ng-click="stopAction()" ng-disabled="!state.selectedItemCount || state.noRunningItemsSelected"><i class="fa fa-stop space-right" aria-hidden="true"></i>Stop</button>
           <button type="button" class="btn btn-danger btn-responsive" ng-click="killAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-bomb space-right" aria-hidden="true"></i>Kill</button>
           <button type="button" class="btn btn-primary btn-responsive" ng-click="restartAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-refresh space-right" aria-hidden="true"></i>Restart</button>
-          <button type="button" class="btn btn-primary btn-responsive" ng-click="pauseAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-pause space-right" aria-hidden="true"></i>Pause</button>
-          <button type="button" class="btn btn-primary btn-responsive" ng-click="unpauseAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-play space-right" aria-hidden="true"></i>Resume</button>
+          <button type="button" class="btn btn-primary btn-responsive" ng-click="pauseAction()" ng-disabled="!state.selectedItemCount || state.noRunningItemsSelected"><i class="fa fa-pause space-right" aria-hidden="true"></i>Pause</button>
+          <button type="button" class="btn btn-primary btn-responsive" ng-click="unpauseAction()" ng-disabled="!state.selectedItemCount || state.noPausedItemsSelected"><i class="fa fa-play space-right" aria-hidden="true"></i>Resume</button>
           <button type="button" class="btn btn-danger btn-responsive" ng-click="confirmRemoveAction()" ng-disabled="!state.selectedItemCount"><i class="fa fa-trash space-right" aria-hidden="true"></i>Remove</button>
         </div>
         <a class="btn btn-primary" type="button" ui-sref="actions.create.container"><i class="fa fa-plus space-right" aria-hidden="true"></i>Add container</a>

--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -8,6 +8,9 @@ angular.module('containers', [])
   $scope.sortType = 'State';
   $scope.sortReverse = false;
   $scope.state.selectedItemCount = 0;
+  $scope.state.noStoppedItemsSelected = true;
+  $scope.state.noRunningItemsSelected = true;
+  $scope.state.noPausedItemsSelected = true;
   $scope.order = function (sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;
     $scope.sortType = sortType;
@@ -41,6 +44,7 @@ angular.module('containers', [])
         }
         return model;
       });
+      updateSelectionFlags();
       $('#loadContainersSpinner').hide();
     }, function (e) {
       $('#loadContainersSpinner').hide();
@@ -117,17 +121,15 @@ angular.module('containers', [])
     angular.forEach($scope.state.filteredContainers, function (container) {
       if (container.Checked !== allSelected) {
         container.Checked = allSelected;
-        $scope.selectItem(container);
+        toggleItemSelection(item);
       }
     });
+    updateSelectionFlags();
   };
 
   $scope.selectItem = function (item) {
-    if (item.Checked) {
-      $scope.state.selectedItemCount++;
-    } else {
-      $scope.state.selectedItemCount--;
-    }
+    toggleItemSelection(item);
+    updateSelectionFlags();
   };
 
   $scope.toggleGetAll = function () {
@@ -186,6 +188,33 @@ angular.module('containers', [])
       }
     );
   };
+  
+  function toggleItemSelection(item) {
+    if (item.Checked) {
+      $scope.state.selectedItemCount++;
+    } else {
+      $scope.state.selectedItemCount--;
+    }
+  }
+  
+  function updateSelectionFlags() {
+    $scope.state.noStoppedItemsSelected = true;
+    $scope.state.noRunningItemsSelected = true;
+    $scope.state.noPausedItemsSelected = true;
+    $scope.containers.forEach(function(container) {
+      if(!container.Checked) {
+        return;
+      }
+      
+      if(container.Status === 'paused') {
+        $scope.state.noPausedItemsSelected = false;
+      } else if(container.Status === 'stopped') {
+        $scope.state.noStoppedItemsSelected = false;
+      } else if(container.Status === 'running') {
+        $scope.state.noRunningItemsSelected = false;
+      }
+    } );
+  }
 
   function retrieveSwarmHostsInfo(data) {
     var swarm_hosts = {};

--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -8,9 +8,6 @@ angular.module('containers', [])
   $scope.sortType = 'State';
   $scope.sortReverse = false;
   $scope.state.selectedItemCount = 0;
-  $scope.state.noStoppedItemsSelected = true;
-  $scope.state.noRunningItemsSelected = true;
-  $scope.state.noPausedItemsSelected = true;
   $scope.order = function (sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;
     $scope.sortType = sortType;
@@ -121,7 +118,7 @@ angular.module('containers', [])
     angular.forEach($scope.state.filteredContainers, function (container) {
       if (container.Checked !== allSelected) {
         container.Checked = allSelected;
-        toggleItemSelection(item);
+        toggleItemSelection(container);
       }
     });
     updateSelectionFlags();


### PR DESCRIPTION
This PR applies next changes to the button disable conditions besides container selection:

- Start button requires selected stopped container
- Stop button requires selected running container
- Pause button requires selected running container
- Resume button requires selected paused container

Fixes #978 