### PR TITLE
feat(swarm-api): make swarm api endpoint admin user protected

### DIFF
--- a/api/http/proxy/response.go
+++ b/api/http/proxy/response.go
@@ -85,6 +85,11 @@ func rewriteResponse(response *http.Response, newResponseData interface{}, statu
 	response.StatusCode = statusCode
 	response.Body = body
 	response.ContentLength = int64(len(jsonData))
+
+	if response.Header == nil {
+		response.Header = make(http.Header)
+	}
 	response.Header.Set("Content-Length", strconv.Itoa(len(jsonData)))
+
 	return nil
 }

--- a/api/http/proxy/transport.go
+++ b/api/http/proxy/transport.go
@@ -59,6 +59,8 @@ func (p *proxyTransport) proxyDockerRequest(request *http.Request) (*http.Respon
 		return p.proxyServiceRequest(request)
 	} else if strings.HasPrefix(path, "/volumes") {
 		return p.proxyVolumeRequest(request)
+	} else if strings.HasPrefix(path, "/swarm") {
+		return p.proxySwarmRequest(request)
 	}
 
 	return p.executeDockerRequest(request)
@@ -141,6 +143,10 @@ func (p *proxyTransport) proxyVolumeRequest(request *http.Request) (*http.Respon
 		volumeID := path.Base(requestPath)
 		return p.restrictedOperation(request, volumeID)
 	}
+}
+
+func (p *proxyTransport) proxySwarmRequest(request *http.Request) (*http.Response, error) {
+	return p.administratorOperation(request)
 }
 
 // restrictedOperation ensures that the current user has the required authorizations


### PR DESCRIPTION
See: #990

This PR adds admin protection to the swarm api endpoint. This won't affect any of the existing features from Portainer from what I could tell. 

It also contains a fix for an issue I encountered when testing this:
> When accessing the swarm api without admin permissions, you receive an empty response because the header key-value map is `nil`. This change will ensure that there is always a map.
