### PR TITLE
fix(swarm): fix multiple Swarm related issues 

### DIFF
--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -185,7 +185,7 @@ angular.module('containers', [])
       }
     );
   };
-  
+
   function toggleItemSelection(item) {
     if (item.Checked) {
       $scope.state.selectedItemCount++;
@@ -193,7 +193,7 @@ angular.module('containers', [])
       $scope.state.selectedItemCount--;
     }
   }
-  
+
   function updateSelectionFlags() {
     $scope.state.noStoppedItemsSelected = true;
     $scope.state.noRunningItemsSelected = true;
@@ -202,7 +202,7 @@ angular.module('containers', [])
       if(!container.Checked) {
         return;
       }
-      
+
       if(container.Status === 'paused') {
         $scope.state.noPausedItemsSelected = false;
       } else if(container.Status === 'stopped') {
@@ -233,7 +233,7 @@ angular.module('containers', [])
     $q.when(provider !== 'DOCKER_SWARM' || SystemService.info())
     .then(function success(data) {
       if (provider === 'DOCKER_SWARM') {
-        $scope.swarm_hosts = retrieveSwarmHostsInfo(d);
+        $scope.swarm_hosts = retrieveSwarmHostsInfo(data);
       }
       update({all: $scope.state.displayAll ? 1 : 0});
     })

--- a/app/components/createVolume/createVolumeController.js
+++ b/app/components/createVolume/createVolumeController.js
@@ -70,16 +70,18 @@ function ($scope, $state, VolumeService, SystemService, ResourceControlService, 
 
   function initView() {
     $('#loadingViewSpinner').show();
-    SystemService.getVolumePlugins()
-    .then(function success(data) {
-      $scope.availableVolumeDrivers = data;
-    })
-    .catch(function error(err) {
-      Notifications.error('Failure', err, 'Unable to retrieve volume drivers');
-    })
-    .finally(function final() {
-      $('#loadingViewSpinner').hide();
-    });
+    if ($scope.applicationState.endpoint.mode.provider !== 'DOCKER_SWARM') {
+      SystemService.getVolumePlugins()
+      .then(function success(data) {
+        $scope.availableVolumeDrivers = data;
+      })
+      .catch(function error(err) {
+        Notifications.error('Failure', err, 'Unable to retrieve volume drivers');
+      })
+      .finally(function final() {
+        $('#loadingViewSpinner').hide();
+      });
+    }
   }
 
   initView();

--- a/app/components/images/images.html
+++ b/app/components/images/images.html
@@ -70,7 +70,7 @@
         <div class="pull-right">
           <input type="text" id="filter" ng-model="state.filter" placeholder="Filter..." class="form-control input-sm" />
         </div>
-        <span class="btn-group btn-group-sm pull-right" style="margin-right: 20px;">
+        <span class="btn-group btn-group-sm pull-right" style="margin-right: 20px;" ng-if="applicationState.endpoint.mode.provider !== 'DOCKER_SWARM'">
           <label class="btn btn-primary" ng-model="state.containersCountFilter" uib-btn-radio="undefined">
             All
           </label>
@@ -125,7 +125,7 @@
                 <td><input type="checkbox" ng-model="image.Checked" ng-change="selectItem(image)" /></td>
                 <td>
                   <a class="monospaced" ui-sref="image({id: image.Id})">{{ image.Id|truncate:20}}</a>
-                  <span style="margin-left: 10px;" class="label label-warning image-tag" ng-if="::image.Containers === 0">Unused</span></td>
+                  <span style="margin-left: 10px;" class="label label-warning image-tag" ng-if="::image.Containers === 0 && applicationState.endpoint.mode.provider !== 'DOCKER_SWARM'">Unused</span></td>
                 <td>
                   <span class="label label-primary image-tag" ng-repeat="tag in (image|repotags)">{{ tag }}</span>
                 </td>

--- a/app/components/images/imagesController.js
+++ b/app/components/images/imagesController.js
@@ -93,7 +93,8 @@ function ($scope, $state, ImageService, Notifications, Pagination, ModalService)
 
   function fetchImages() {
     $('#loadImagesSpinner').show();
-    ImageService.images()
+    var endpointProvider = $scope.applicationState.endpoint.mode.provider;
+    ImageService.images(endpointProvider !== 'DOCKER_SWARM')
     .then(function success(data) {
       $scope.images = data;
     })

--- a/app/models/docker/image.js
+++ b/app/models/docker/image.js
@@ -3,7 +3,7 @@ function ImageViewModel(data) {
   this.Tag = data.Tag;
   this.Repository = data.Repository;
   this.Created = data.Created;
-  this.Containers = data.dataUsage.Containers;
+  this.Containers = data.dataUsage ? data.dataUsage.Containers : 0;
   this.Checked = false;
   this.RepoTags = data.RepoTags;
   this.VirtualSize = data.VirtualSize;

--- a/app/services/docker/imageService.js
+++ b/app/services/docker/imageService.js
@@ -20,11 +20,11 @@ angular.module('portainer.services')
     return deferred.promise;
   };
 
-  service.images = function() {
+  service.images = function(withUsage) {
     var deferred = $q.defer();
-    
+
     $q.all({
-      dataUsage: SystemService.dataUsage(),
+      dataUsage: withUsage ? SystemService.dataUsage() : { Images: [] },
       images: Image.query({}).$promise
     })
     .then(function success(data) {
@@ -32,7 +32,7 @@ angular.module('portainer.services')
         item.dataUsage = data.dataUsage.Images.find(function(usage) {
            return item.Id === usage.Id;
         });
-        
+
         return new ImageViewModel(item);
       });
       deferred.resolve(images);


### PR DESCRIPTION
This PR fixes an issue where it would be impossible to display containers in the containers view.

Fix #977 

It also fixes an issue introduced with #1009 as the system usage endpoint is not compliant with the Swarm API. Therefore, displaying unused/used images is disabled when using Swarm.

It fixes as well another issue with the volume-creation view, the Swarm API do not expose the required information to retrieve available plugins. Therefore, the dropdown is replaced by a simple input when using Swarm.