### PR TITLE
feat(volumes): add a label in front of dangling volumes

### DIFF
--- a/app/components/volumes/volumes.html
+++ b/app/components/volumes/volumes.html
@@ -83,7 +83,10 @@
           <tbody>
             <tr dir-paginate="volume in (state.filteredVolumes = (volumes | filter:{dangling: state.danglingVolumesOnly} | filter:state.filter | orderBy:sortType:sortReverse | itemsPerPage: state.pagination_count))">
               <td><input type="checkbox" ng-model="volume.Checked" ng-change="selectItem(volume)"/></td>
-              <td><a ui-sref="volume({id: volume.Id})" class="monospaced">{{ volume.Id|truncate:25 }}</a></td>
+              <td>
+                <a ui-sref="volume({id: volume.Id})" class="monospaced">{{ volume.Id|truncate:25 }}</a>
+                <span style="margin-left: 10px;" class="label label-warning image-tag" ng-if="volume.dangling">Dangling</span></td>
+              </td>
               <td>{{ volume.Driver }}</td>
               <td>{{ volume.Mountpoint | truncate:52 }}</td>
               <td ng-if="applicationState.application.authentication">


### PR DESCRIPTION
This PR introduces a label in front of the volume name if the volume is considered 'dangling'.

![portainer 16](https://user-images.githubusercontent.com/5485061/28131003-d48e6b08-6738-11e7-852c-32dccbe7567b.png)

Close #1011 