### PR TITLE
fix(UAC): allow a team member to delete a resource control

### DIFF
--- a/api/http/security/authorization.go
+++ b/api/http/security/authorization.go
@@ -22,7 +22,7 @@ func AuthorizedResourceControlDeletion(resourceControl *portainer.ResourceContro
 	if teamAccessesCount > 0 {
 		for _, access := range resourceControl.TeamAccesses {
 			for _, membership := range context.UserMemberships {
-				if membership.TeamID == access.TeamID && membership.Role == portainer.TeamLeader {
+				if membership.TeamID == access.TeamID {
 					return true
 				}
 			}


### PR DESCRIPTION
Fix #1029 