### PR TITLE
 feat(container-details): toggle short/full container ID (#1026)

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -35,7 +35,14 @@
           <tbody>
             <tr>
               <td>ID</td>
-              <td>{{ container.Id }}</td>
+              <td ng-if="!container.toggleId">
+                {{ container.Id|truncate:20 }}
+                <a href="" data-toggle="tooltip" title="Show full ID" ng-click="container.toggleId = true;"><i class="fa fa-eye"></i></a>
+              </td>
+              <td ng-if="container.toggleId">
+                {{ container.Id }}
+                <a href="" data-toggle="tooltip" title="Show short ID" ng-click="container.toggleId = false;"><i class="fa fa-eye-slash"></i></a>
+              </td>
             </tr>
             <tr>
               <td>Name</td>


### PR DESCRIPTION
This PR enhances [a7df43bd45](https://github.com/portainer/portainer/commit/a7df43bd45b77d5ef5e9cb08af1ca4cf99782fc6) by adding a toggle to select between the short and full ID. The approach is similar to the 'edit' in 'Name'.

There is an annoying issue that I don't know how to handle:

![shortid](https://user-images.githubusercontent.com/6628437/28191208-4b419bde-682f-11e7-8a1c-2f433fccc17e.gif)

It seems that the size of the column is not updated when the content is changed, so everything is centered.
