### PR TITLE
feat(Dockerfile): use portainer/base image

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM centurylink/ca-certs
+FROM portainer/base
 
 COPY dist /
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,7 +4,7 @@ var loadGruntTasks = require('load-grunt-tasks');
 
 module.exports = function (grunt) {
 
-  loadGruntTasks(grunt);  
+  loadGruntTasks(grunt);
 
   grunt.registerTask('default', ['eslint', 'build']);
   grunt.registerTask('before-copy', [
@@ -180,7 +180,7 @@ module.exports = function (grunt) {
       run: {
         command: [
           'docker rm -f portainer',
-          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer centurylink/ca-certs /app/portainer-linux-amd64 --no-analytics -a /app'
+          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer portainer/base /app/portainer-linux-amd64 --no-analytics -a /app'
         ].join(';')
       }
     },


### PR DESCRIPTION
This PR replace the `centurylink/ca-cert` image with `portainer/base`.

Close #832 