### PR TITLE
refactor(api): relocate /docker API endpoint under /endpoints

### DIFF
--- a/api/http/handler/docker.go
+++ b/api/http/handler/docker.go
@@ -30,7 +30,7 @@ func NewDockerHandler(bouncer *security.RequestBouncer) *DockerHandler {
 		Router: mux.NewRouter(),
 		Logger: log.New(os.Stderr, "", log.LstdFlags),
 	}
-	h.PathPrefix("/{id}/").Handler(
+	h.PathPrefix("/{id}/docker").Handler(
 		bouncer.AuthenticatedAccess(http.HandlerFunc(h.proxyRequestsToDockerAPI)))
 	return h
 }
@@ -90,5 +90,5 @@ func (handler *DockerHandler) proxyRequestsToDockerAPI(w http.ResponseWriter, r 
 		}
 	}
 
-	http.StripPrefix("/"+id, proxy).ServeHTTP(w, r)
+	http.StripPrefix("/"+id+"/docker", proxy).ServeHTTP(w, r)
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -51,7 +51,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if strings.HasPrefix(r.URL.Path, "/api/team_memberships") {
 		http.StripPrefix("/api", h.TeamMembershipHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/endpoints") {
-		if strings.Contains(r.URL.Path, "docker") {
+		if strings.Contains(r.URL.Path, "/docker") {
 			http.StripPrefix("/api/endpoints", h.DockerHandler).ServeHTTP(w, r)
 		} else {
 			http.StripPrefix("/api", h.EndpointHandler).ServeHTTP(w, r)
@@ -75,10 +75,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if strings.HasPrefix(r.URL.Path, "/") {
 		h.FileHandler.ServeHTTP(w, r)
 	}
-	// else if strings.HasPrefix(r.URL.Path, "/api/docker") {
-	// 	http.StripPrefix("/api/docker", h.DockerHandler).ServeHTTP(w, r)
-	// }
-
 }
 
 // encodeJSON encodes v to w in JSON format. Error() is called if encoding fails.

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -51,7 +51,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if strings.HasPrefix(r.URL.Path, "/api/team_memberships") {
 		http.StripPrefix("/api", h.TeamMembershipHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/endpoints") {
-		http.StripPrefix("/api", h.EndpointHandler).ServeHTTP(w, r)
+		if strings.Contains(r.URL.Path, "docker") {
+			http.StripPrefix("/api/endpoints", h.DockerHandler).ServeHTTP(w, r)
+		} else {
+			http.StripPrefix("/api", h.EndpointHandler).ServeHTTP(w, r)
+		}
 	} else if strings.HasPrefix(r.URL.Path, "/api/registries") {
 		http.StripPrefix("/api", h.RegistryHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/dockerhub") {
@@ -68,11 +72,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.UploadHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/api/websocket") {
 		http.StripPrefix("/api", h.WebSocketHandler).ServeHTTP(w, r)
-	} else if strings.HasPrefix(r.URL.Path, "/api/docker") {
-		http.StripPrefix("/api/docker", h.DockerHandler).ServeHTTP(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/") {
 		h.FileHandler.ServeHTTP(w, r)
 	}
+	// else if strings.HasPrefix(r.URL.Path, "/api/docker") {
+	// 	http.StripPrefix("/api/docker", h.DockerHandler).ServeHTTP(w, r)
+	// }
+
 }
 
 // encodeJSON encodes v to w in JSON format. Error() is called if encoding fails.

--- a/app/app.js
+++ b/app/app.js
@@ -744,7 +744,6 @@ angular.module('portainer', [
   // This is your docker url that the api will use to make requests
   // You need to set this to the api endpoint without the port i.e. http://192.168.1.9
   // .constant('DOCKER_PORT', '') // Docker port, leave as an empty string if no port is required.  If you have a port, prefix it with a ':' i.e. :4243
-  .constant('DOCKER_ENDPOINT', 'api/docker')
   .constant('CONFIG_ENDPOINT', 'api/old_settings')
   .constant('SETTINGS_ENDPOINT', 'api/settings')
   .constant('STATUS_ENDPOINT', 'api/status')

--- a/app/app.js
+++ b/app/app.js
@@ -744,17 +744,16 @@ angular.module('portainer', [
   // This is your docker url that the api will use to make requests
   // You need to set this to the api endpoint without the port i.e. http://192.168.1.9
   // .constant('DOCKER_PORT', '') // Docker port, leave as an empty string if no port is required.  If you have a port, prefix it with a ':' i.e. :4243
-  .constant('CONFIG_ENDPOINT', 'api/old_settings')
-  .constant('SETTINGS_ENDPOINT', 'api/settings')
-  .constant('STATUS_ENDPOINT', 'api/status')
-  .constant('AUTH_ENDPOINT', 'api/auth')
-  .constant('USERS_ENDPOINT', 'api/users')
-  .constant('TEAMS_ENDPOINT', 'api/teams')
-  .constant('TEAM_MEMBERSHIPS_ENDPOINT', 'api/team_memberships')
-  .constant('RESOURCE_CONTROL_ENDPOINT', 'api/resource_controls')
-  .constant('ENDPOINTS_ENDPOINT', 'api/endpoints')
-  .constant('DOCKERHUB_ENDPOINT', 'api/dockerhub')
-  .constant('REGISTRIES_ENDPOINT', 'api/registries')
-  .constant('TEMPLATES_ENDPOINT', 'api/templates')
+  .constant('API_ENDPOINT_AUTH', 'api/auth')
+  .constant('API_ENDPOINT_DOCKERHUB', 'api/dockerhub')
+  .constant('API_ENDPOINT_ENDPOINTS', 'api/endpoints')
+  .constant('API_ENDPOINT_REGISTRIES', 'api/registries')
+  .constant('API_ENDPOINT_RESOURCE_CONTROLS', 'api/resource_controls')
+  .constant('API_ENDPOINT_SETTINGS', 'api/settings')
+  .constant('API_ENDPOINT_STATUS', 'api/status')
+  .constant('API_ENDPOINT_USERS', 'api/users')
+  .constant('API_ENDPOINT_TEAMS', 'api/teams')
+  .constant('API_ENDPOINT_TEAM_MEMBERSHIPS', 'api/team_memberships')
+  .constant('API_ENDPOINT_TEMPLATES', 'api/templates')
   .constant('DEFAULT_TEMPLATES_URL', 'https://raw.githubusercontent.com/portainer/templates/master/templates.json')
   .constant('PAGINATION_MAX_ITEMS', 10);

--- a/app/rest/api/auth.js
+++ b/app/rest/api/auth.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Auth', ['$resource', 'AUTH_ENDPOINT', function AuthFactory($resource, AUTH_ENDPOINT) {
+.factory('Auth', ['$resource', 'API_ENDPOINT_AUTH', function AuthFactory($resource, API_ENDPOINT_AUTH) {
   'use strict';
-  return $resource(AUTH_ENDPOINT, {}, {
+  return $resource(API_ENDPOINT_AUTH, {}, {
     login: {
       method: 'POST'
     }

--- a/app/rest/api/dockerhub.js
+++ b/app/rest/api/dockerhub.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('DockerHub', ['$resource', 'DOCKERHUB_ENDPOINT', function DockerHubFactory($resource, DOCKERHUB_ENDPOINT) {
+.factory('DockerHub', ['$resource', 'API_ENDPOINT_DOCKERHUB', function DockerHubFactory($resource, API_ENDPOINT_DOCKERHUB) {
   'use strict';
-  return $resource(DOCKERHUB_ENDPOINT, {}, {
+  return $resource(API_ENDPOINT_DOCKERHUB, {}, {
     get: { method: 'GET' },
     update: { method: 'PUT' }
   });

--- a/app/rest/api/endpoint.js
+++ b/app/rest/api/endpoint.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Endpoints', ['$resource', 'ENDPOINTS_ENDPOINT', function EndpointsFactory($resource, ENDPOINTS_ENDPOINT) {
+.factory('Endpoints', ['$resource', 'API_ENDPOINT_ENDPOINTS', function EndpointsFactory($resource, API_ENDPOINT_ENDPOINTS) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:id/:action', {}, {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:id/:action', {}, {
     create: { method: 'POST' },
     query: { method: 'GET', isArray: true },
     get: { method: 'GET', params: { id: '@id' } },

--- a/app/rest/api/registry.js
+++ b/app/rest/api/registry.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Registries', ['$resource', 'REGISTRIES_ENDPOINT', function RegistriesFactory($resource, REGISTRIES_ENDPOINT) {
+.factory('Registries', ['$resource', 'API_ENDPOINT_REGISTRIES', function RegistriesFactory($resource, API_ENDPOINT_REGISTRIES) {
   'use strict';
-  return $resource(REGISTRIES_ENDPOINT + '/:id/:action', {}, {
+  return $resource(API_ENDPOINT_REGISTRIES + '/:id/:action', {}, {
     create: { method: 'POST' },
     query: { method: 'GET', isArray: true },
     get: { method: 'GET', params: { id: '@id' } },

--- a/app/rest/api/resourceControl.js
+++ b/app/rest/api/resourceControl.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('ResourceControl', ['$resource', 'RESOURCE_CONTROL_ENDPOINT', function ResourceControlFactory($resource, RESOURCE_CONTROL_ENDPOINT) {
+.factory('ResourceControl', ['$resource', 'API_ENDPOINT_RESOURCE_CONTROLS', function ResourceControlFactory($resource, API_ENDPOINT_RESOURCE_CONTROLS) {
   'use strict';
-  return $resource(RESOURCE_CONTROL_ENDPOINT + '/:id', {}, {
+  return $resource(API_ENDPOINT_RESOURCE_CONTROLS + '/:id', {}, {
     create: { method: 'POST' },
     get: { method: 'GET', params: { id: '@id' } },
     update: { method: 'PUT', params: { id: '@id' } },

--- a/app/rest/api/settings.js
+++ b/app/rest/api/settings.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Settings', ['$resource', 'SETTINGS_ENDPOINT', function SettingsFactory($resource, SETTINGS_ENDPOINT) {
+.factory('Settings', ['$resource', 'API_ENDPOINT_SETTINGS', function SettingsFactory($resource, API_ENDPOINT_SETTINGS) {
   'use strict';
-  return $resource(SETTINGS_ENDPOINT, {}, {
+  return $resource(API_ENDPOINT_SETTINGS, {}, {
     get: { method: 'GET' },
     update: { method: 'PUT' }
   });

--- a/app/rest/api/status.js
+++ b/app/rest/api/status.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Status', ['$resource', 'STATUS_ENDPOINT', function StatusFactory($resource, STATUS_ENDPOINT) {
+.factory('Status', ['$resource', 'API_ENDPOINT_STATUS', function StatusFactory($resource, API_ENDPOINT_STATUS) {
   'use strict';
-  return $resource(STATUS_ENDPOINT, {}, {
+  return $resource(API_ENDPOINT_STATUS, {}, {
     get: { method: 'GET' }
   });
 }]);

--- a/app/rest/api/team.js
+++ b/app/rest/api/team.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Teams', ['$resource', 'TEAMS_ENDPOINT', function TeamsFactory($resource, TEAMS_ENDPOINT) {
+.factory('Teams', ['$resource', 'API_ENDPOINT_TEAMS', function TeamsFactory($resource, API_ENDPOINT_TEAMS) {
   'use strict';
-  return $resource(TEAMS_ENDPOINT + '/:id/:entity/:entityId', {}, {
+  return $resource(API_ENDPOINT_TEAMS + '/:id/:entity/:entityId', {}, {
     create: { method: 'POST' },
     query: { method: 'GET', isArray: true },
     get: { method: 'GET', params: { id: '@id' } },

--- a/app/rest/api/teamMembership.js
+++ b/app/rest/api/teamMembership.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('TeamMemberships', ['$resource', 'TEAM_MEMBERSHIPS_ENDPOINT', function TeamMembershipsFactory($resource, TEAM_MEMBERSHIPS_ENDPOINT) {
+.factory('TeamMemberships', ['$resource', 'API_ENDPOINT_TEAM_MEMBERSHIPS', function TeamMembershipsFactory($resource, API_ENDPOINT_TEAM_MEMBERSHIPS) {
   'use strict';
-  return $resource(TEAM_MEMBERSHIPS_ENDPOINT + '/:id/:action', {}, {
+  return $resource(API_ENDPOINT_TEAM_MEMBERSHIPS + '/:id/:action', {}, {
     create: { method: 'POST' },
     query: { method: 'GET', isArray: true },
     update: { method: 'PUT', params: { id: '@id' } },

--- a/app/rest/api/template.js
+++ b/app/rest/api/template.js
@@ -1,6 +1,6 @@
 angular.module('portainer.rest')
-.factory('Template', ['$resource', 'TEMPLATES_ENDPOINT', function TemplateFactory($resource, TEMPLATES_ENDPOINT) {
-  return $resource(TEMPLATES_ENDPOINT, {}, {
+.factory('Template', ['$resource', 'API_ENDPOINT_TEMPLATES', function TemplateFactory($resource, API_ENDPOINT_TEMPLATES) {
+  return $resource(API_ENDPOINT_TEMPLATES, {}, {
     get: {method: 'GET', isArray: true}
   });
 }]);

--- a/app/rest/api/user.js
+++ b/app/rest/api/user.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Users', ['$resource', 'USERS_ENDPOINT', function UsersFactory($resource, USERS_ENDPOINT) {
+.factory('Users', ['$resource', 'API_ENDPOINT_USERS', function UsersFactory($resource, API_ENDPOINT_USERS) {
   'use strict';
-  return $resource(USERS_ENDPOINT + '/:id/:entity/:entityId', {}, {
+  return $resource(API_ENDPOINT_USERS + '/:id/:entity/:entityId', {}, {
     create: { method: 'POST' },
     query: { method: 'GET', isArray: true },
     get: { method: 'GET', params: { id: '@id' } },

--- a/app/rest/docker/container.js
+++ b/app/rest/docker/container.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Container', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function ContainerFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Container', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/containers/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/containers/:id/:action', {
     name: '@name',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/container.js
+++ b/app/rest/docker/container.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Container', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Container', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ContainerFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/containers/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/containers/:id/:action', {
     name: '@name',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/containerCommit.js
+++ b/app/rest/docker/containerCommit.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('ContainerCommit', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function ContainerCommitFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('ContainerCommit', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerCommitFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/commit', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/commit', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/containerCommit.js
+++ b/app/rest/docker/containerCommit.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('ContainerCommit', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerCommitFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('ContainerCommit', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ContainerCommitFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/commit', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/commit', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/containerLogs.js
+++ b/app/rest/docker/containerLogs.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ContainerLogs', ['$http', 'DOCKER_ENDPOINT', 'EndpointProvider', function ContainerLogsFactory($http, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('ContainerLogs', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerLogsFactory($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback) {
       $http({
         method: 'GET',
-        url: DOCKER_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/logs',
+        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/logs',
         params: {
           'stdout': params.stdout || 0,
           'stderr': params.stderr || 0,

--- a/app/rest/docker/containerLogs.js
+++ b/app/rest/docker/containerLogs.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ContainerLogs', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ContainerLogsFactory($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('ContainerLogs', ['$http', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ContainerLogsFactory($http, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback) {
       $http({
         method: 'GET',
-        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/logs',
+        url: API_ENDPOINT_ENDPOINTS + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/logs',
         params: {
           'stdout': params.stdout || 0,
           'stderr': params.stderr || 0,

--- a/app/rest/docker/containerTop.js
+++ b/app/rest/docker/containerTop.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ContainerTop', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('ContainerTop', ['$http', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ($http, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback, errorCallback) {
       $http({
         method: 'GET',
-        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/top',
+        url: API_ENDPOINT_ENDPOINTS + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/top',
         params: {
           ps_args: params.ps_args
         }

--- a/app/rest/docker/containerTop.js
+++ b/app/rest/docker/containerTop.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ContainerTop', ['$http', 'DOCKER_ENDPOINT', 'EndpointProvider', function ($http, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('ContainerTop', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback, errorCallback) {
       $http({
         method: 'GET',
-        url: DOCKER_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/top',
+        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/containers/' + id + '/top',
         params: {
           ps_args: params.ps_args
         }

--- a/app/rest/docker/exec.js
+++ b/app/rest/docker/exec.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Exec', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function ExecFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Exec', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ExecFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/exec/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/exec/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/exec.js
+++ b/app/rest/docker/exec.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Exec', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ExecFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Exec', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ExecFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/exec/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/exec/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/image.js
+++ b/app/rest/docker/image.js
@@ -1,8 +1,8 @@
 angular.module('portainer.rest')
-.factory('Image', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper', function ImageFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider, HttpRequestHelper) {
+.factory('Image', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', 'HttpRequestHelper', function ImageFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, HttpRequestHelper) {
   'use strict';
 
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/images/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/images/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/image.js
+++ b/app/rest/docker/image.js
@@ -1,8 +1,8 @@
 angular.module('portainer.rest')
-.factory('Image', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper', function ImageFactory($resource, DOCKER_ENDPOINT, EndpointProvider, HttpRequestHelper) {
+.factory('Image', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper', function ImageFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider, HttpRequestHelper) {
   'use strict';
 
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/images/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/images/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/network.js
+++ b/app/rest/docker/network.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Network', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function NetworkFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Network', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function NetworkFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/networks/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/networks/:id/:action', {
     id: '@id',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/network.js
+++ b/app/rest/docker/network.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Network', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function NetworkFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Network', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function NetworkFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/networks/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/networks/:id/:action', {
     id: '@id',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/node.js
+++ b/app/rest/docker/node.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Node', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function NodeFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Node', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function NodeFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/nodes/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/nodes/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/node.js
+++ b/app/rest/docker/node.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Node', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function NodeFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Node', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function NodeFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/nodes/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/nodes/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/secret.js
+++ b/app/rest/docker/secret.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Secret', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SecretFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Secret', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function SecretFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/secrets/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/secrets/:id/:action', {
     endpointId: EndpointProvider.endpointID
   }, {
     get: { method: 'GET', params: {id: '@id'} },

--- a/app/rest/docker/secret.js
+++ b/app/rest/docker/secret.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Secret', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function SecretFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Secret', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SecretFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/secrets/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/secrets/:id/:action', {
     endpointId: EndpointProvider.endpointID
   }, {
     get: { method: 'GET', params: {id: '@id'} },

--- a/app/rest/docker/service.js
+++ b/app/rest/docker/service.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Service', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper' ,function ServiceFactory($resource, DOCKER_ENDPOINT, EndpointProvider, HttpRequestHelper) {
+.factory('Service', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper' ,function ServiceFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider, HttpRequestHelper) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/services/:id/:action', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/services/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/service.js
+++ b/app/rest/docker/service.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Service', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', 'HttpRequestHelper' ,function ServiceFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider, HttpRequestHelper) {
+.factory('Service', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', 'HttpRequestHelper' ,function ServiceFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, HttpRequestHelper) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/services/:id/:action', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/services/:id/:action', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/serviceLogs.js
+++ b/app/rest/docker/serviceLogs.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ServiceLogs', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ServiceLogsFactory($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('ServiceLogs', ['$http', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function ServiceLogsFactory($http, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback) {
       $http({
         method: 'GET',
-        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/services/' + id + '/logs',
+        url: API_ENDPOINT_ENDPOINTS + '/' + EndpointProvider.endpointID() + '/services/' + id + '/logs',
         params: {
           'stdout': params.stdout || 0,
           'stderr': params.stderr || 0,

--- a/app/rest/docker/serviceLogs.js
+++ b/app/rest/docker/serviceLogs.js
@@ -1,11 +1,11 @@
 angular.module('portainer.rest')
-.factory('ServiceLogs', ['$http', 'DOCKER_ENDPOINT', 'EndpointProvider', function ServiceLogsFactory($http, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('ServiceLogs', ['$http', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function ServiceLogsFactory($http, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
   return {
     get: function (id, params, callback) {
       $http({
         method: 'GET',
-        url: DOCKER_ENDPOINT + '/' + EndpointProvider.endpointID() + '/services/' + id + '/logs',
+        url: ENDPOINTS_ENDPOINT + '/' + EndpointProvider.endpointID() + '/services/' + id + '/logs',
         params: {
           'stdout': params.stdout || 0,
           'stderr': params.stderr || 0,

--- a/app/rest/docker/swarm.js
+++ b/app/rest/docker/swarm.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Swarm', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SwarmFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Swarm', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function SwarmFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/swarm', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/swarm', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/swarm.js
+++ b/app/rest/docker/swarm.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Swarm', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function SwarmFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Swarm', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SwarmFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/swarm', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/swarm', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/system.js
+++ b/app/rest/docker/system.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('System', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function SystemFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('System', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SystemFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/:action/:subAction', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/:action/:subAction', {
     name: '@name',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/system.js
+++ b/app/rest/docker/system.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('System', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function SystemFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('System', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function SystemFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/:action/:subAction', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/:action/:subAction', {
     name: '@name',
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/task.js
+++ b/app/rest/docker/task.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Task', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function TaskFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Task', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function TaskFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/tasks/:id', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/tasks/:id', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/task.js
+++ b/app/rest/docker/task.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Task', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function TaskFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Task', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function TaskFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/tasks/:id', {
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/tasks/:id', {
     endpointId: EndpointProvider.endpointID
   },
   {

--- a/app/rest/docker/volume.js
+++ b/app/rest/docker/volume.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Volume', ['$resource', 'DOCKER_ENDPOINT', 'EndpointProvider', function VolumeFactory($resource, DOCKER_ENDPOINT, EndpointProvider) {
+.factory('Volume', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function VolumeFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
   'use strict';
-  return $resource(DOCKER_ENDPOINT + '/:endpointId/volumes/:id/:action',
+  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/volumes/:id/:action',
   {
     endpointId: EndpointProvider.endpointID
   },

--- a/app/rest/docker/volume.js
+++ b/app/rest/docker/volume.js
@@ -1,7 +1,7 @@
 angular.module('portainer.rest')
-.factory('Volume', ['$resource', 'ENDPOINTS_ENDPOINT', 'EndpointProvider', function VolumeFactory($resource, ENDPOINTS_ENDPOINT, EndpointProvider) {
+.factory('Volume', ['$resource', 'API_ENDPOINT_ENDPOINTS', 'EndpointProvider', function VolumeFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
   'use strict';
-  return $resource(ENDPOINTS_ENDPOINT + '/:endpointId/docker/volumes/:id/:action',
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/volumes/:id/:action',
   {
     endpointId: EndpointProvider.endpointID
   },


### PR DESCRIPTION
This PR introduces breaking changes for the HTTP API.

The `api/docker/:endpointId` API endpoint is now relocated under `/endpoints/:endpointId/docker` to make the HTTP API more coherent.

