### PR TITLE
fix(containers): available buttons for created container

### DIFF
--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -205,7 +205,8 @@ angular.module('containers', [])
 
       if(container.Status === 'paused') {
         $scope.state.noPausedItemsSelected = false;
-      } else if(container.Status === 'stopped') {
+      } else if(container.Status === 'stopped' || 
+                container.Status === 'created') {
         $scope.state.noStoppedItemsSelected = false;
       } else if(container.Status === 'running') {
         $scope.state.noRunningItemsSelected = false;


### PR DESCRIPTION
Now for created container available buttons are the same as for stopped.

Fixes #1063