### PR TITLE
fix(networks): review how networks are loaded for usage in multiple v…

### DIFF
--- a/app/components/container/containerController.js
+++ b/app/components/container/containerController.js
@@ -1,6 +1,6 @@
 angular.module('container', [])
-.controller('ContainerController', ['$scope', '$state','$stateParams', '$filter', 'Container', 'ContainerCommit', 'ContainerService', 'ImageHelper', 'Network', 'Notifications', 'Pagination', 'ModalService',
-function ($scope, $state, $stateParams, $filter, Container, ContainerCommit, ContainerService, ImageHelper, Network, Notifications, Pagination, ModalService) {
+.controller('ContainerController', ['$scope', '$state','$stateParams', '$filter', 'Container', 'ContainerCommit', 'ContainerService', 'ImageHelper', 'Network', 'NetworkService', 'Notifications', 'Pagination', 'ModalService',
+function ($scope, $state, $stateParams, $filter, Container, ContainerCommit, ContainerService, ImageHelper, Network, NetworkService, Notifications, Pagination, ModalService) {
   $scope.activityTime = 0;
   $scope.portBindings = [];
   $scope.config = {
@@ -213,25 +213,21 @@ function ($scope, $state, $stateParams, $filter, Container, ContainerCommit, Con
     });
   };
 
-  Network.query({}, function (d) {
-      var networks = d;
-      if ($scope.applicationState.endpoint.mode.provider === 'DOCKER_SWARM' || $scope.applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE') {
-        networks = d.filter(function (network) {
-          if (network.Scope === 'global') {
-            return network;
-          }
-        });
-        networks.push({Name: 'bridge'});
-        networks.push({Name: 'host'});
-        networks.push({Name: 'none'});
-      }
-      $scope.availableNetworks = networks;
-      if (!_.find(networks, {'Name': 'bridge'})) {
-        networks.push({Name: 'nat'});
-      }
-    }, function (e) {
-      Notifications.error('Failure', e, 'Unable to retrieve networks');
-    });
+  var provider = $scope.applicationState.endpoint.mode.provider;
+  var apiVersion = $scope.applicationState.endpoint.apiVersion;
+  NetworkService.networks(
+    provider === 'DOCKER_STANDALONE' || provider === 'DOCKER_SWARM_MODE',
+    false,
+    provider === 'DOCKER_SWARM_MODE' && apiVersion >= 1.25,
+    provider === 'DOCKER_SWARM'
+  )
+  .then(function success(data) {
+    var networks = data;
+    $scope.availableNetworks = networks;
+  })
+  .catch(function error(err) {
+    Notifications.error('Failure', err, 'Unable to retrieve networks');
+  });
 
   update();
 }]);

--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -1,8 +1,8 @@
 // @@OLD_SERVICE_CONTROLLER: this service should be rewritten to use services.
 // See app/components/templates/templatesController.js as a reference.
 angular.module('createContainer', [])
-.controller('CreateContainerController', ['$q', '$scope', '$state', '$stateParams', '$filter', 'Container', 'ContainerHelper', 'Image', 'ImageHelper', 'Volume', 'Network', 'ResourceControlService', 'Authentication', 'Notifications', 'ContainerService', 'ImageService', 'FormValidator',
-function ($q, $scope, $state, $stateParams, $filter, Container, ContainerHelper, Image, ImageHelper, Volume, Network, ResourceControlService, Authentication, Notifications, ContainerService, ImageService, FormValidator) {
+.controller('CreateContainerController', ['$q', '$scope', '$state', '$stateParams', '$filter', 'Container', 'ContainerHelper', 'Image', 'ImageHelper', 'Volume', 'NetworkService', 'ResourceControlService', 'Authentication', 'Notifications', 'ContainerService', 'ImageService', 'FormValidator',
+function ($q, $scope, $state, $stateParams, $filter, Container, ContainerHelper, Image, ImageHelper, Volume, NetworkService, ResourceControlService, Authentication, Notifications, ContainerService, ImageService, FormValidator) {
 
   $scope.formValues = {
     alwaysPull: true,
@@ -240,26 +240,25 @@ function ($q, $scope, $state, $stateParams, $filter, Container, ContainerHelper,
       Notifications.error('Failure', e, 'Unable to retrieve volumes');
     });
 
-    Network.query({}, function (d) {
-      var networks = d;
-      if ($scope.applicationState.endpoint.mode.provider === 'DOCKER_SWARM' || $scope.applicationState.endpoint.mode.provider === 'DOCKER_SWARM_MODE') {
-        networks = d.filter(function (network) {
-          if (network.Scope === 'global') {
-            return network;
-          }
-        });
-        $scope.globalNetworkCount = networks.length;
-        networks.push({Name: 'bridge'});
-        networks.push({Name: 'host'});
-        networks.push({Name: 'none'});
-      }
-      networks.push({Name: 'container'});
+    var provider = $scope.applicationState.endpoint.mode.provider;
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;
+    NetworkService.networks(
+      provider === 'DOCKER_STANDALONE' || provider === 'DOCKER_SWARM_MODE',
+      false,
+      provider === 'DOCKER_SWARM_MODE' && apiVersion >= 1.25,
+      provider === 'DOCKER_SWARM'
+    )
+    .then(function success(data) {
+      var networks = data;
+      networks.push({ Name: 'container' });
       $scope.availableNetworks = networks;
-      if (!_.find(networks, {'Name': 'bridge'})) {
+
+      if (_.find(networks, {'Name': 'nat'})) {
         $scope.config.HostConfig.NetworkMode = 'nat';
       }
-    }, function (e) {
-      Notifications.error('Failure', e, 'Unable to retrieve networks');
+    })
+    .catch(function error(err) {
+      Notifications.error('Failure', err, 'Unable to retrieve networks');
     });
 
     Container.query({}, function (d) {

--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -305,10 +305,11 @@ function ($q, $scope, $state, Service, ServiceHelper, SecretHelper, SecretServic
   function initView() {
     $('#loadingViewSpinner').show();
     var apiVersion = $scope.applicationState.endpoint.apiVersion;
+
     $q.all({
       volumes: VolumeService.volumes(),
-      networks: NetworkService.retrieveSwarmNetworks(),
-      secrets: apiVersion >= 1.25 ? SecretService.secrets() : []
+      secrets: apiVersion >= 1.25 ? SecretService.secrets() : [],
+      networks: NetworkService.networks(true, true, false, false)
     })
     .then(function success(data) {
       $scope.availableVolumes = data.volumes;

--- a/app/components/templates/templatesController.js
+++ b/app/components/templates/templatesController.js
@@ -144,27 +144,20 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, $filter, ContainerSer
     return containerMapping;
   }
 
-  function filterNetworksBasedOnProvider(networks) {
-    var endpointProvider = $scope.applicationState.endpoint.mode.provider;
-    if (endpointProvider === 'DOCKER_SWARM' || endpointProvider === 'DOCKER_SWARM_MODE') {
-      if (endpointProvider === 'DOCKER_SWARM') {
-        networks = NetworkService.filterGlobalNetworks(networks);
-      } else {
-        networks = NetworkService.filterSwarmModeAttachableNetworks(networks);
-      }
-      $scope.globalNetworkCount = networks.length;
-      NetworkService.addPredefinedLocalNetworks(networks);
-    }
-    return networks;
-  }
-
   function initTemplates() {
     var templatesKey = $stateParams.key;
+    var provider = $scope.applicationState.endpoint.mode.provider;
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;
+
     $q.all({
       templates: TemplateService.getTemplates(templatesKey),
       containers: ContainerService.getContainers(0),
-      networks: NetworkService.networks(),
-      volumes: VolumeService.getVolumes()
+      volumes: VolumeService.getVolumes(),
+      networks: NetworkService.networks(
+        provider === 'DOCKER_STANDALONE' || provider === 'DOCKER_SWARM_MODE',
+        false,
+        provider === 'DOCKER_SWARM_MODE' && apiVersion >= 1.25,
+        provider === 'DOCKER_SWARM')
     })
     .then(function success(data) {
       $scope.templates = data.templates;
@@ -174,8 +167,10 @@ function ($scope, $q, $state, $stateParams, $anchorScroll, $filter, ContainerSer
       });
       $scope.availableCategories = _.sortBy(_.uniq(availableCategories));
       $scope.runningContainers = data.containers;
-      $scope.availableNetworks = filterNetworksBasedOnProvider(data.networks);
       $scope.availableVolumes = data.volumes.Volumes;
+      var networks = data.networks;
+      $scope.availableNetworks = networks;
+      $scope.globalNetworkCount = networks.length;
     })
     .catch(function error(err) {
       $scope.templates = [];


### PR DESCRIPTION
…iews

Reviews how the networks are loaded in different views & using different providers:

* Provider Docker Swarm mode:

templates: local networks + swarm attachable networks (API version > 1.25)
container-creation: local networks + swarm attachable networks (API version > 1.25)
container-details (join list): local networks + swarm attachable networks (API version > 1.25)
service-creation: all swarm networks

* Provider Docker Swarm standalone:

templates: global networks
container-creation: global networks
container-details (join list): global networks

* Provider Docker standalone:

templates: local networks
container-creation: local networks
container-details (join list): local networks

Fix #1103 