### PR TITLE
fix(authentication): check username instead of id to identify admin user

### DIFF
--- a/api/http/handler/auth.go
+++ b/api/http/handler/auth.go
@@ -96,7 +96,7 @@ func (handler *AuthHandler) handlePostAuth(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if settings.AuthenticationMethod == portainer.AuthenticationLDAP && u.ID != 1 {
+	if settings.AuthenticationMethod == portainer.AuthenticationLDAP && username != "admin" {
 		err = handler.LDAPService.AuthenticateUser(username, password, &settings.LDAPSettings)
 		if err != nil {
 			httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)

--- a/app/components/users/users.html
+++ b/app/components/users/users.html
@@ -177,8 +177,8 @@
                   {{ user.RoleName }}
                 </td>
                 <td>
-                  <span ng-if="AuthenticationMethod === 1 || user.Id === 1">Internal</span>
-                  <span ng-if="AuthenticationMethod === 2 && user.Id !== 1">LDAP</span>
+                  <span ng-if="AuthenticationMethod === 1 || user.Username === 'admin'">Internal</span>
+                  <span ng-if="AuthenticationMethod === 2 && user.Username !== 'admin'">LDAP</span>
                 </td>
                 <td ng-if="isAdmin">
                   <a ui-sref="user({id: user.Id})"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> Edit</a>


### PR DESCRIPTION
Fixes #1145 

When LDAP authentication is enabled, Portainer looks for a user with an ID of 1 to identify it as the admin user and use internal authentication. If the admin user has been deleted and re-created, it will no longer have an ID of 1.