### PR TITLE
Fix 'gruntify-eslint' usage

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -5,6 +5,7 @@ var loadGruntTasks = require('load-grunt-tasks');
 module.exports = function (grunt) {
 
   loadGruntTasks(grunt);
+  grunt.loadNpmTasks('gruntify-eslint');
 
   grunt.registerTask('default', ['eslint', 'build']);
   grunt.registerTask('before-copy', [


### PR DESCRIPTION
`eslint` is task from `gruntify-eslint` package and therefore package
should be loaded as well.

And btw we have around 20 errors 😭 