### PR TITLE
Feat723 endpoint color

### DIFF
--- a/api/http/handler/endpoint.go
+++ b/api/http/handler/endpoint.go
@@ -60,6 +60,7 @@ type (
 		Name                string `valid:"required"`
 		URL                 string `valid:"required"`
 		PublicURL           string `valid:"-"`
+		Color               string
 		TLS                 bool
 		TLSSkipVerify       bool
 		TLSSkipClientVerify bool
@@ -78,6 +79,7 @@ type (
 		Name                string `valid:"-"`
 		URL                 string `valid:"-"`
 		PublicURL           string `valid:"-"`
+		Color               string `valid:"-"`
 		TLS                 bool   `valid:"-"`
 		TLSSkipVerify       bool   `valid:"-"`
 		TLSSkipClientVerify bool   `valid:"-"`
@@ -128,6 +130,7 @@ func (handler *EndpointHandler) handlePostEndpoints(w http.ResponseWriter, r *ht
 
 	endpoint := &portainer.Endpoint{
 		Name:      req.Name,
+		Color:     req.Color,
 		URL:       req.URL,
 		PublicURL: req.PublicURL,
 		TLSConfig: portainer.TLSConfiguration{
@@ -286,6 +289,10 @@ func (handler *EndpointHandler) handlePutEndpoint(w http.ResponseWriter, r *http
 
 	if req.Name != "" {
 		endpoint.Name = req.Name
+	}
+
+	if req.Color != "" {
+		endpoint.Color = req.Color
 	}
 
 	if req.URL != "" {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -172,6 +172,7 @@ type (
 	Endpoint struct {
 		ID              EndpointID       `json:"Id"`
 		Name            string           `json:"Name"`
+		Color           string           `json:"Color"`
 		URL             string           `json:"URL"`
 		PublicURL       string           `json:"PublicURL"`
 		TLSConfig       TLSConfiguration `json:"TLSConfig"`

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2152,6 +2152,10 @@ definitions:
         type: "string"
         example: "my-endpoint"
         description: "Name that will be used to identify this endpoint"
+      Name:
+        type: "string"
+        example: "#FF0000"
+        description: "Color that will be used to visually identify this endpoint"
       URL:
         type: "string"
         example: "docker.mydomain.tld:2375"

--- a/app/components/endpoint/endpoint.html
+++ b/app/components/endpoint/endpoint.html
@@ -23,6 +23,17 @@
             </div>
           </div>
           <!-- !name-input -->
+          <!-- color-input -->
+          <div class="form-group">
+            <label for="container_color" class="col-sm-3 col-lg-2 control-label text-left">
+              Color
+              <portainer-tooltip position="bottom" message="Background color when endpoint is active"></portainer-tooltip>
+            </label>
+            <div class="col-sm-9 col-lg-10">
+              <input type="color" class="form-control" id="container_color" ng-model="endpoint.Color">
+            </div>
+          </div>
+          <!-- !color-input -->
           <!-- endpoint-url-input -->
           <div class="form-group">
             <label for="endpoint_url" class="col-sm-3 col-lg-2 control-label text-left">

--- a/app/components/endpoint/endpointController.js
+++ b/app/components/endpoint/endpointController.js
@@ -24,6 +24,7 @@ function ($scope, $state, $transition$, $filter, EndpointService, Notifications)
 
     var endpointParams = {
       name: endpoint.Name,
+      Color: endpoint.Color,
       URL: endpoint.URL,
       PublicURL: endpoint.PublicURL,
       TLS: TLS,
@@ -54,6 +55,7 @@ function ($scope, $state, $transition$, $filter, EndpointService, Notifications)
     EndpointService.endpoint($transition$.params().id)
     .then(function success(data) {
       var endpoint = data;
+      endpoint.Color = endpoint.Color || '#FFFFFF';
       if (endpoint.URL.indexOf('unix://') === 0) {
         $scope.endpointType = 'local';
       } else {

--- a/app/components/endpoints/endpoints.html
+++ b/app/components/endpoints/endpoints.html
@@ -38,6 +38,17 @@
             </div>
           </div>
           <!-- !name-input -->
+          <!-- color-input -->
+          <div class="form-group">
+            <label for="container_color" class="col-sm-3 col-lg-2 control-label text-left">
+              Color
+              <portainer-tooltip position="bottom" message="Background color when endpoint is active"></portainer-tooltip>
+            </label>
+            <div class="col-sm-9 col-lg-10">
+              <input type="color" class="form-control" id="container_color" ng-model="formValues.Color">
+            </div>
+          </div>
+          <!-- !color-input -->
           <!-- endpoint-url-input -->
           <div class="form-group">
             <label for="endpoint_url" class="col-sm-3 col-lg-2 control-label text-left">

--- a/app/components/endpoints/endpointsController.js
+++ b/app/components/endpoints/endpointsController.js
@@ -1,6 +1,6 @@
 angular.module('endpoints', [])
-.controller('EndpointsController', ['$scope', '$state', 'EndpointService', 'EndpointProvider', 'Notifications', 'Pagination',
-function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagination) {
+.controller('EndpointsController', ['$scope', '$state', 'EndpointService', 'EndpointProvider', 'Notifications', 'Pagination', 'EndpointHelper',
+function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagination, EndpointHelper) {
   $scope.state = {
     uploadInProgress: false,
     selectedItemCount: 0,
@@ -11,11 +11,12 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
 
   $scope.formValues = {
     Name: '',
+    Color: EndpointHelper.getRandomHexColor(),
     URL: '',
     PublicURL: '',
     SecurityFormData: new EndpointSecurityFormData()
   };
-
+  
   $scope.order = function(sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;
     $scope.sortType = sortType;
@@ -44,6 +45,7 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
 
   $scope.addEndpoint = function() {
     var name = $scope.formValues.Name;
+    var color = $scope.formValues.Color;
     var URL = $scope.formValues.URL;
     var PublicURL = $scope.formValues.PublicURL;
     if (PublicURL === '') {
@@ -59,7 +61,7 @@ function ($scope, $state, EndpointService, EndpointProvider, Notifications, Pagi
     var TLSCertFile = TLSSkipClientVerify ? null : securityData.TLSCert;
     var TLSKeyFile = TLSSkipClientVerify ? null : securityData.TLSKey;
 
-    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSSkipVerify, TLSSkipClientVerify, TLSCAFile, TLSCertFile, TLSKeyFile).then(function success(data) {
+    EndpointService.createRemoteEndpoint(name, URL, PublicURL, TLS, TLSSkipVerify, TLSSkipClientVerify, TLSCAFile, TLSCertFile, TLSKeyFile, color).then(function success(data) {
       Notifications.success('Endpoint created', name);
       $state.reload();
     }, function error(err) {

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -12,7 +12,9 @@
       <span>Active endpoint</span>
     </li>
     <li class="sidebar-title">
-      <select class="select-endpoint form-control" ng-options="endpoint.Name for endpoint in endpoints" ng-model="activeEndpoint" ng-change="switchEndpoint(activeEndpoint)">
+      <select class="select-endpoint form-control" ng-options="endpoint.Name for endpoint in endpoints" ng-model="activeEndpoint" ng-change="switchEndpoint(activeEndpoint)" style="
+        background: {{activeEndpoint.Color}};
+        border-color: {{activeEndpoint.Color}};">
       </select>
     </li>
     <li class="sidebar-title"><span>Endpoint actions</span></li>

--- a/app/helpers/endpointHelper.js
+++ b/app/helpers/endpointHelper.js
@@ -1,0 +1,13 @@
+angular.module('portainer.helpers')
+.factory('EndpointHelper', ['MathHelper', function EndpointHelperFactory(MathHelper) {
+  'use strict';
+
+  var helper = {},
+      MAX_DECIMAL_COLOR = 16777215;
+
+  helper.getRandomHexColor = function() {
+    return '#' + MathHelper.getRandomInt(0, MAX_DECIMAL_COLOR).toString(16);
+  };
+  
+  return helper;
+}]);

--- a/app/helpers/mathHelper.js
+++ b/app/helpers/mathHelper.js
@@ -1,0 +1,12 @@
+angular.module('portainer.helpers')
+.factory('MathHelper', [function MathHelperFactory() {
+  'use strict';
+
+  var helper = {};
+
+  helper.getRandomInt = function(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  };
+  
+  return helper;
+}]);

--- a/app/services/api/endpointService.js
+++ b/app/services/api/endpointService.js
@@ -18,6 +18,7 @@ angular.module('portainer.services')
   service.updateEndpoint = function(id, endpointParams) {
     var query = {
       name: endpointParams.name,
+      Color: endpointParams.Color,
       PublicURL: endpointParams.PublicURL,
       TLS: endpointParams.TLS,
       TLSSkipVerify: endpointParams.TLSSkipVerify,
@@ -57,9 +58,10 @@ angular.module('portainer.services')
     return Endpoints.create({}, endpoint).$promise;
   };
 
-  service.createRemoteEndpoint = function(name, URL, PublicURL, TLS, TLSSkipVerify, TLSSkipClientVerify, TLSCAFile, TLSCertFile, TLSKeyFile) {
+  service.createRemoteEndpoint = function(name, URL, PublicURL, TLS, TLSSkipVerify, TLSSkipClientVerify, TLSCAFile, TLSCertFile, TLSKeyFile, color) {
     var endpoint = {
       Name: name,
+      Color: color,
       URL: 'tcp://' + URL,
       PublicURL: PublicURL,
       TLS: TLS,


### PR DESCRIPTION
This PR adds an ability to set the background color for endpoint when it's active. 

For color input [`<input type="color">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) was used which supported by all major browser except for IE.

By default first endpoint won't be having any color. When a new endpoint is created random color will be proposed.

<img width="1017" alt="screen shot 2017-10-16 at 07 58 22" src="https://user-images.githubusercontent.com/6943514/31597776-f56cea10-b252-11e7-92a5-a9c4f6abfb27.png">
<img width="252" alt="screen shot 2017-10-16 at 07 58 27" src="https://user-images.githubusercontent.com/6943514/31597777-f58a9fd8-b252-11e7-87ed-d2d47adb5e48.png">

Closes #723 