### PR TITLE
chore(codefresh): add a step to download docker binary

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -22,7 +22,7 @@ steps:
     image: busybox
     working_directory: ${{build_frontend}}
     commands:
-      - wget -O /tmp/docker-binaries.zip https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.zip
+      - wget -O /tmp/docker-binaries.zip https://download.docker.com/linux/static/stable/x86_64/docker-${{DOCKER_VERSION}}.zip
       - tar -xf /tmp/docker-binaries.zip -C /tmp
       - mv /tmp/docker/docker dist/
 

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -18,9 +18,17 @@ steps:
       - grunt build-webapp
       - mv api/cmd/portainer/portainer dist/
 
+  download_docker_binary:
+    image: busybox
+    working_directory: ${{build_frontend}}
+    commands:
+      - wget -O /tmp/docker-binaries.zip https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.zip
+      - tar -xf /tmp/docker-binaries.zip -C /tmp
+      - mv /tmp/docker/docker dist/
+
   build_image:
     type: build
-    working_directory: ${{build_frontend}}
+    working_directory: ${{download_docker_binary}}
     dockerfile: ./build/linux/Dockerfile
     image_name: portainer/portainer
     tag: ${{CF_BRANCH}}

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -22,8 +22,8 @@ steps:
     image: busybox
     working_directory: ${{build_frontend}}
     commands:
-      - wget -O /tmp/docker-binaries.zip https://download.docker.com/linux/static/stable/x86_64/docker-${{DOCKER_VERSION}}.zip
-      - tar -xf /tmp/docker-binaries.zip -C /tmp
+      - wget -O /tmp/docker-binaries.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${{DOCKER_VERSION}}.tgz
+      - tar -xf /tmp/docker-binaries.tgz -C /tmp
       - mv /tmp/docker/docker dist/
 
   build_image:


### PR DESCRIPTION
This PR adds a step to ensure the image built via CI on Codefresh (`portainer/portainer:develop`) contains the Docker binary.