### PR TITLE
add rpm based packaging and add systemd service file

### DIFF
--- a/packaging/portainer.service
+++ b/packaging/portainer.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=%p node
+After=docker.service
+# mongodb.service
+Wants=docker.service
+Wants=docker-latest.service
+
+[Service]
+Type=simple
+Environment=ASSETS=/usr/share/portainer
+Environment=DBFILES=/var/lib/portainer
+EnvironmentFile=-/etc/sysconfig/%p
+ExecStart=/usr/sbin/portainer -a $ASSETS -d $DBFILES
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/portainer.spec
+++ b/packaging/portainer.spec
@@ -1,0 +1,113 @@
+#
+# spec file for package portainer
+#
+# Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           portainer
+Version:        1.15.0
+Release:        0
+License:        Zlib
+Summary:        A lightweight docker management UI
+Url:            https://portainer.io
+Group:          BLAH
+Source0:        https://github.com/portainer/portainer/releases/download/%{version}/portainer-%{version}-linux-amd64.tar.gz
+Source1:        portainer.service
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if 0%{?suse_version}
+BuildRequires:  help2man
+%endif
+Requires:       docker
+%{?systemd_requires}
+BuildRequires: systemd
+
+%description
+Portainer is a lightweight management UI which allows you to easily manage
+your different Docker environments (Docker hosts or Swarm clusters).
+Portainer is meant to be as simple to deploy as it is to use.
+It consists of a single container that can run on any Docker engine
+(can be deployed as Linux container or a Windows native container).
+Portainer allows you to manage your Docker containers, images, volumes,
+networks and more ! It is compatible with the standalone Docker engine and with Docker Swarm mode.
+
+%prep
+%setup -qn portainer
+
+%build
+%if 0%{?suse_version}
+help2man -N --no-discard-stderr ./portainer  > portainer.1
+%endif
+
+%install
+# Create directory structure
+install -D -m 0755 portainer %{buildroot}%{_sbindir}/portainer
+install -d -m 0755 %{buildroot}%{_datadir}/portainer
+install -d -m 0755 %{buildroot}%{_localstatedir}/lib/portainer
+install -D -m 0644 %{S:1} %{buildroot}%{_unitdir}/portainer.service
+%if 0%{?suse_version}
+install -D -m 0644 portainer.1 %{buildroot}%{_mandir}/man1/portainer.1
+( cd  %{buildroot}%{_sbindir} ; ln -s service rcportainer )
+%endif
+# populate
+# don't install docker binary with package use system wide installed one
+for src in css fonts ico images index.html js;do
+	cp -a $src %{buildroot}%{_datadir}/portainer/
+done
+
+%pre
+%if 0%{?suse_version}
+%service_add_pre portainer.service
+#%%else # this does not work on rhel 7?
+#%%systemd_pre portainer.service
+true
+%endif
+
+%preun
+%if 0%{?suse_version}
+%service_del_preun portainer.service
+%else
+%systemd_preun portainer.service
+%endif
+
+%post
+%if 0%{?suse_version}
+%service_add_post portainer.service
+%else
+%systemd_post portainer.service
+%endif
+
+%postun
+%if 0%{?suse_version}
+%service_del_postun portainer.service
+%else
+%systemd_postun_with_restart portainer.service
+%endif
+
+
+%files
+%defattr(-,root,root)
+%{_sbindir}/portainer
+%dir %{_datadir}/portainer
+%{_datadir}/portainer/css
+%{_datadir}/portainer/fonts
+%{_datadir}/portainer/ico
+%{_datadir}/portainer/images
+%{_datadir}/portainer/index.html
+%{_datadir}/portainer/js
+%dir %{_localstatedir}/lib/portainer/
+%{_unitdir}/portainer.service
+%if 0%{?suse_version}
+%{_mandir}/man1/portainer.1*
+%{_sbindir}/rcportainer
+%endif


### PR DESCRIPTION
I am using portainer on rhel 7 and as selinux support is still in development (#849) it is easier to use portainer as a host based service, these files provide you with way of using it as systemd service
(i have built packages using OBS https://build.opensuse.org/package/show/home:bmanojlovic/portainer )
