### PR TITLE
Replace individual package load with pattern

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,8 +4,9 @@ var loadGruntTasks = require('load-grunt-tasks');
 
 module.exports = function (grunt) {
 
-  loadGruntTasks(grunt);
-  grunt.loadNpmTasks('gruntify-eslint');
+  loadGruntTasks(grunt, {
+    pattern: ['grunt-*', 'gruntify-*']
+  });
 
   grunt.registerTask('default', ['eslint', 'build']);
   grunt.registerTask('before-copy', [


### PR DESCRIPTION
As @1138-4EB [mentioned](https://github.com/portainer/portainer/pull/1276#issuecomment-337538243) there is a more generic way to handle grunt packages which don't fit default pattern instead of loading them individually.

[Default pattern](https://www.npmjs.com/package/load-grunt-tasks#pattern) is `['grunt-*', '@*/grunt-*']` so I've dropped `@*/grunt-*` as it's not being used anyway and added `gruntify-*`.