### PR TITLE
fix(deployment) make assets default relative

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/portainer"
 
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -54,6 +55,15 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	}
 
 	kingpin.Parse()
+
+	if !filepath.IsAbs(*flags.Assets) {
+		ex, err := os.Executable()
+		if err != nil {
+			panic(err)
+		}
+		*flags.Assets = filepath.Join(filepath.Dir(ex), *flags.Assets)
+	}
+
 	return flags, nil
 }
 

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -5,7 +5,7 @@ package cli
 const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "/data"
-	defaultAssetsDirectory = "/"
+	defaultAssetsDirectory = "./"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -3,7 +3,7 @@ package cli
 const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "C:\\data"
-	defaultAssetsDirectory = "/"
+	defaultAssetsDirectory = "./"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/portainer/http/security"
 
 	"net/http"
+	"path/filepath"
 )
 
 // Server implements the portainer.Server interface
@@ -42,7 +43,7 @@ func (server *Server) Start() error {
 	requestBouncer := security.NewRequestBouncer(server.JWTService, server.TeamMembershipService, server.AuthDisabled)
 	proxyManager := proxy.NewManager(server.ResourceControlService, server.TeamMembershipService, server.SettingsService)
 
-	var fileHandler = handler.NewFileHandler(server.AssetsPath)
+	var fileHandler = handler.NewFileHandler(filepath.Join(server.AssetsPath, "public"))
 	var authHandler = handler.NewAuthHandler(requestBouncer, server.AuthDisabled)
 	authHandler.UserService = server.UserService
 	authHandler.CryptoService = server.CryptoService

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    distdir: 'dist',
+    distdir: 'dist/public',
     shippedDockerVersion: '17.09.0-ce',
     pkg: grunt.file.readJSON('package.json'),
     config: {
@@ -72,8 +72,8 @@ module.exports = function (grunt) {
       css: ['assets/css/app.css']
     },
     clean: {
-      all: ['<%= distdir %>/*'],
-      app: ['<%= distdir %>/*', '!<%= distdir %>/portainer*', '!<%= distdir %>/docker*'],
+      all: ['<%= distdir %>/../*'],
+      app: ['<%= distdir %>/*', '!<%= distdir %>/../portainer*', '!<%= distdir %>/../docker*'],
       tmpl: ['<%= distdir %>/templates'],
       tmp: ['<%= distdir %>/js/*', '!<%= distdir %>/js/app.*.js', '<%= distdir %>/css/*', '!<%= distdir %>/css/app.*.css']
     },
@@ -93,7 +93,8 @@ module.exports = function (grunt) {
       release: {
         src: '<%= src.html %>',
         options: {
-          root: '<%= distdir %>'
+          root: '<%= distdir %>',
+          dest: '<%= distdir %>'
         }
       }
     },
@@ -187,7 +188,7 @@ module.exports = function (grunt) {
       run: {
         command: [
           'docker rm -f portainer',
-          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer portainer/base /app/portainer-linux-' + arch + ' --no-analytics -a /app'
+          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer portainer/base /app/portainer-linux-' + arch + ' --no-analytics'
         ].join(';')
       },
       downloadDockerBinary: {


### PR DESCRIPTION
Fixes #1286.

`defaultAssetsDirectory` is made relative to the location of portainer executable. After the flags are parsed, if `*flags.Assets` is not absolute the location of the portainer executable is prepended. This allows portainer to be called from anywhere in the system, not necessarily from the root of the extracted tarball.

Note that this does not allow to provide the location of assets as a path relative to where portainer is called from. I am not sure about it, but I think that this behaviour may be different for `DataDirectory`, `SSLCertPath`, etc. which would be relative to `os.Args[0]`. @deviantony, are relative paths supported for any of those?