### PR TITLE
feat(container-inspect) add angular-json-tree view and download button

### DIFF
--- a/app/components/containerInspect/containerInspect.html
+++ b/app/components/containerInspect/containerInspect.html
@@ -11,11 +11,9 @@
     <rd-widget>
       <rd-widget-header icon="fa-icon-circle" title="Inspect">
         <div class="btn-group" role="group" aria-label="...">
-          <button class="btn btn-sm btn-success" ng-click="toggle()">
-            <span ng-show="TextView"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</span>
-            <span ng-hide="TextView"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</span>
-          </button>
-          <a role="button" class="btn btn-sm btn-success" href="data:text/json;charset=utf-8,{{ EncodeJSON(containerInfo.object) }}" download="{{containerInfo.date | date:'yyyyMMddhhmm'}}-inspect-{{containerInfo.object.Id.slice(0,12)}}-{{containerInfo.object.Name|trimcontainername}}.json"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>
+          <button class="btn btn-sm btn-success" ng-click="toggle()" ng-disabled="!TextView"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</button>
+          <button class="btn btn-sm btn-success" ng-click="toggle()" ng-disabled="TextView"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</button>
+          <!---<a role="button" class="btn btn-sm btn-success" href="data:text/json;charset=utf-8,{{ EncodeJSON(containerInfo.object) }}" download="{{containerInfo.date | date:'yyyyMMddhhmm'}}-inspect-{{containerInfo.object.Id.slice(0,12)}}-{{containerInfo.object.Name|trimcontainername}}.json"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>-->
         </div>
       </rd-widget-header>
       <rd-widget-body>

--- a/app/components/containerInspect/containerInspect.html
+++ b/app/components/containerInspect/containerInspect.html
@@ -2,7 +2,7 @@
   <rd-header-title title="Container inspect">
   </rd-header-title>
   <rd-header-content>
-    <a ui-sref="containers">Containers</a> &gt; <a ui-sref="container({id: containerInfo.Id})">{{ containerInfo.Name|trimcontainername }}</a> &gt; Inspect
+    <a ui-sref="containers">Containers</a> &gt; <a ui-sref="container({id: containerInfo.object.Id})">{{ containerInfo.object.Name|trimcontainername }}</a> &gt; Inspect
   </rd-header-content>
 </rd-header>
 
@@ -10,9 +10,17 @@
   <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
       <rd-widget-header icon="fa-icon-circle" title="Inspect">
+        <div class="btn-group" role="group" aria-label="...">
+          <button class="btn btn-sm btn-success" ng-click="toggle()">
+            <span ng-show="TextView"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</span>
+            <span ng-hide="TextView"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</span>
+          </button>
+          <a role="button" class="btn btn-sm btn-success" href="data:text/json;charset=utf-8,{{ EncodeJSON(containerInfo.object) }}" download="{{containerInfo.date | date:'yyyyMMddhhmm'}}-inspect-{{containerInfo.object.Id.slice(0,12)}}-{{containerInfo.object.Name|trimcontainername}}.json"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>
+        </div>
       </rd-widget-header>
       <rd-widget-body>
-        <pre>{{ containerInfo|json:4 }}</pre>
+        <pre ng-show="TextView">{{ containerInfo.object|json:4 }}</pre>
+        <json-tree ng-hide="TextView" object="containerInfo.object" root-name="containerInfo.object.Id" start-expanded="true"></json-tree>
       </rd-widget-body>
     </rd-widget>
   </div>

--- a/app/components/containerInspect/containerInspect.html
+++ b/app/components/containerInspect/containerInspect.html
@@ -2,7 +2,7 @@
   <rd-header-title title="Container inspect">
   </rd-header-title>
   <rd-header-content>
-    <a ui-sref="containers">Containers</a> &gt; <a ui-sref="container({id: containerInfo.object.Id})">{{ containerInfo.object.Name|trimcontainername }}</a> &gt; Inspect
+    <a ui-sref="containers">Containers</a> &gt; <a ui-sref="container({id: containerInfo.Id})">{{ containerInfo.Name|trimcontainername }}</a> &gt; Inspect
   </rd-header-content>
 </rd-header>
 
@@ -10,14 +10,14 @@
   <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
       <rd-widget-header icon="fa-icon-circle" title="Inspect">
-        <div class="btn-group" role="group" aria-label="...">
-          <button class="btn btn-sm btn-success" ng-model="state.TextView" uib-btn-radio="false"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</button>
-          <button class="btn btn-sm btn-success" ng-model="state.TextView" uib-btn-radio="true"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</button>
-        </div>
+        <span class="btn-group btn-group-sm">
+          <label class="btn btn-primary" ng-model="state.DisplayTextView" uib-btn-radio="false"><i class="fa fa-code space-right" aria-hidden="true"></i>Tree</label>
+          <label class="btn btn-primary" ng-model="state.DisplayTextView" uib-btn-radio="true"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</label>
+        </span>
       </rd-widget-header>
       <rd-widget-body>
-        <pre ng-show="state.TextView">{{ containerInfo.object|json:4 }}</pre>
-        <json-tree ng-hide="state.TextView" object="containerInfo.object" root-name="containerInfo.object.Id" start-expanded="true"></json-tree>
+        <pre ng-show="state.DisplayTextView">{{ containerInfo|json:4 }}</pre>
+        <json-tree ng-hide="state.DisplayTextView" object="containerInfo" root-name="containerInfo.Id" start-expanded="true"></json-tree>
       </rd-widget-body>
     </rd-widget>
   </div>

--- a/app/components/containerInspect/containerInspect.html
+++ b/app/components/containerInspect/containerInspect.html
@@ -11,14 +11,13 @@
     <rd-widget>
       <rd-widget-header icon="fa-icon-circle" title="Inspect">
         <div class="btn-group" role="group" aria-label="...">
-          <button class="btn btn-sm btn-success" ng-click="toggle()" ng-disabled="!TextView"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</button>
-          <button class="btn btn-sm btn-success" ng-click="toggle()" ng-disabled="TextView"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</button>
-          <!---<a role="button" class="btn btn-sm btn-success" href="data:text/json;charset=utf-8,{{ EncodeJSON(containerInfo.object) }}" download="{{containerInfo.date | date:'yyyyMMddhhmm'}}-inspect-{{containerInfo.object.Id.slice(0,12)}}-{{containerInfo.object.Name|trimcontainername}}.json"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>-->
+          <button class="btn btn-sm btn-success" ng-model="state.TextView" uib-btn-radio="false"><i class="fa fa-hand-pointer-o space-right" aria-hidden="true"></i>Tree</button>
+          <button class="btn btn-sm btn-success" ng-model="state.TextView" uib-btn-radio="true"><i class="fa fa-file-text-o space-right" aria-hidden="true"></i>Text</button>
         </div>
       </rd-widget-header>
       <rd-widget-body>
-        <pre ng-show="TextView">{{ containerInfo.object|json:4 }}</pre>
-        <json-tree ng-hide="TextView" object="containerInfo.object" root-name="containerInfo.object.Id" start-expanded="true"></json-tree>
+        <pre ng-show="state.TextView">{{ containerInfo.object|json:4 }}</pre>
+        <json-tree ng-hide="state.TextView" object="containerInfo.object" root-name="containerInfo.object.Id" start-expanded="true"></json-tree>
       </rd-widget-body>
     </rd-widget>
   </div>

--- a/app/components/containerInspect/containerInspectController.js
+++ b/app/components/containerInspect/containerInspectController.js
@@ -1,12 +1,16 @@
 angular.module('containerInspect', ['angular-json-tree'])
 .controller('ContainerInspectController', ['$scope', '$transition$', 'Notifications', 'ContainerService',
 function ($scope, $transition$, Notifications, ContainerService) {
+
+  $scope.state = { DisplayTextView: false };
+  $scope.containerInfo = {};
+
   function initView() {
     $('#loadingViewSpinner').show();
 
     ContainerService.inspect($transition$.params().id)
     .then(function success(d) {
-      $scope.containerInfo.object = d;
+      $scope.containerInfo = d;
     })
     .catch(function error(e) {
       Notifications.error('Failure', e, 'Unable to inspect container');
@@ -16,7 +20,5 @@ function ($scope, $transition$, Notifications, ContainerService) {
     });
   }
 
-  $scope.containerInfo = { object: {} };
-  $scope.state = { TextView: false };
   initView();
 }]);

--- a/app/components/containerInspect/containerInspectController.js
+++ b/app/components/containerInspect/containerInspectController.js
@@ -7,7 +7,6 @@ function ($scope, $transition$, Notifications, ContainerService) {
     ContainerService.inspect($transition$.params().id)
     .then(function success(d) {
       $scope.containerInfo.object = d;
-      //$scope.containerInfo.date = new Date();
     })
     .catch(function error(e) {
       Notifications.error('Failure', e, 'Unable to inspect container');
@@ -18,8 +17,6 @@ function ($scope, $transition$, Notifications, ContainerService) {
   }
 
   $scope.containerInfo = { object: {} };
-  $scope.TextView = false;
-  $scope.toggle = function() { $scope.TextView = !$scope.TextView; };
-  //$scope.EncodeJSON = function(obj){ return encodeURIComponent(JSON.stringify(obj, null, 2)); };
+  $scope.state = { TextView: false };
   initView();
 }]);

--- a/app/components/containerInspect/containerInspectController.js
+++ b/app/components/containerInspect/containerInspectController.js
@@ -1,12 +1,13 @@
-angular.module('containerInspect', [])
+angular.module('containerInspect', ['angular-json-tree'])
 .controller('ContainerInspectController', ['$scope', '$transition$', 'Notifications', 'ContainerService',
 function ($scope, $transition$, Notifications, ContainerService) {
   function initView() {
     $('#loadingViewSpinner').show();
-    
+
     ContainerService.inspect($transition$.params().id)
     .then(function success(d) {
-      $scope.containerInfo = d;
+      $scope.containerInfo.object = d;
+      $scope.containerInfo.date = new Date();
     })
     .catch(function error(e) {
       Notifications.error('Failure', e, 'Unable to inspect container');
@@ -15,6 +16,10 @@ function ($scope, $transition$, Notifications, ContainerService) {
       $('#loadingViewSpinner').hide();
     });
   }
-  
+
+  $scope.containerInfo = { object: {} };
+  $scope.TextView = false;
+  $scope.toggle = function() { $scope.TextView = !$scope.TextView; };
+  $scope.EncodeJSON = function(obj){ return encodeURIComponent(JSON.stringify(obj, null, 2)); };
   initView();
 }]);

--- a/app/components/containerInspect/containerInspectController.js
+++ b/app/components/containerInspect/containerInspectController.js
@@ -7,7 +7,7 @@ function ($scope, $transition$, Notifications, ContainerService) {
     ContainerService.inspect($transition$.params().id)
     .then(function success(d) {
       $scope.containerInfo.object = d;
-      $scope.containerInfo.date = new Date();
+      //$scope.containerInfo.date = new Date();
     })
     .catch(function error(e) {
       Notifications.error('Failure', e, 'Unable to inspect container');
@@ -20,6 +20,6 @@ function ($scope, $transition$, Notifications, ContainerService) {
   $scope.containerInfo = { object: {} };
   $scope.TextView = false;
   $scope.toggle = function() { $scope.TextView = !$scope.TextView; };
-  $scope.EncodeJSON = function(obj){ return encodeURIComponent(JSON.stringify(obj, null, 2)); };
+  //$scope.EncodeJSON = function(obj){ return encodeURIComponent(JSON.stringify(obj, null, 2)); };
   initView();
 }]);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,12 +7,6 @@ html, body, #content-wrapper, .page-content, #view {
   white-space: normal !important;
 }
 
-.btn-group button,
-.btn-group [role="button"] {
-  margin-right: 3px;
-  margin-left: 3px;
-}
-
 .messages {
   max-height: 50px;
   overflow-x: hidden;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,8 +7,10 @@ html, body, #content-wrapper, .page-content, #view {
   white-space: normal !important;
 }
 
-.btn-group button {
-  margin: 3px;
+.btn-group button,
+.btn-group [role="button"] {
+  margin-right: 3px;
+  margin-left: 3px;
 }
 
 .messages {
@@ -614,4 +616,21 @@ ul.sidebar .sidebar-list .sidebar-sublist a.active {
 .monospaced {
   font-family: monospace;
   font-weight: 600;
+}
+
+/* json-tree */
+
+json-tree {
+  font-size: 13px;
+  color: #30426a;
+}
+json-tree .key {
+  color: #738bc0;
+  padding-right: 5px;
+}
+
+json-tree .branch-preview {
+  font-style: normal;
+  font-size: 11px;
+  opacity: .5;
 }

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "angular-utils-pagination": "~0.11.1",
     "angular-local-storage": "~0.5.2",
     "angular-jwt": "~0.1.8",
+    "angular-json-tree": "1.0.1",
     "angular-google-analytics": "~1.1.9",
     "bootstrap": "~3.3.6",
     "filesize": "~3.3.0",

--- a/vendor.yml
+++ b/vendor.yml
@@ -47,6 +47,7 @@ css:
   - bower_components/angularjs-slider/dist/rzslider.css
   - bower_components/codemirror/lib/codemirror.css
   - bower_components/codemirror/addon/lint/lint.css
+  - bower_components/angular-json-tree/dist/angular-json-tree.css
   minified:
   - bower_components/bootstrap/dist/css/bootstrap.min.css
   - bower_components/rdash-ui/dist/css/rdash.min.css
@@ -58,6 +59,7 @@ css:
   - bower_components/angularjs-slider/dist/rzslider.min.css
   - bower_components/codemirror/lib/codemirror.css
   - bower_components/codemirror/addon/lint/lint.css
+  - bower_components/angular-json-tree/dist/angular-json-tree.css
 angular:
   regular:
   - bower_components/angular/angular.js
@@ -74,6 +76,7 @@ angular:
   - bower_components/ng-file-upload/ng-file-upload.js
   - bower_components/angularjs-slider/dist/rzslider.js
   - bower_components/angular-multi-select/isteven-multi-select.js
+  - bower_components/angular-json-tree/dist/angular-json-tree.js
   minified:
   - bower_components/angular/angular.min.js
   - bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js
@@ -89,3 +92,4 @@ angular:
   - bower_components/ng-file-upload/ng-file-upload.min.js
   - bower_components/angularjs-slider/dist/rzslider.min.js
   - bower_components/angular-multi-select/isteven-multi-select.js
+  - bower_components/angular-json-tree/dist/angular-json-tree.min.js


### PR DESCRIPTION
Enhances #1279 providing an interactive tree view of the JSON get from `docker inspect`. [awendland/angular-json-tree](https://github.com/awendland/angular-json-tree) ([demo](https://blog.alexwendland.com/angular-json-tree/)) is used, installed through bower. A button is added to the header of the widget, to allow the user to toggle between tree and text/raw views. Another button is added to download the JSON file.