### PR TITLE
fix(images) prevent unused label breaking to multiple lines

### DIFF
--- a/app/components/images/images.html
+++ b/app/components/images/images.html
@@ -125,10 +125,7 @@
                 <td><input type="checkbox" ng-model="image.Checked" ng-change="selectItem(image)" /></td>
                 <td>
                   <a class="monospaced" ui-sref="image({id: image.Id})">{{ image.Id|truncate:20}}</a>
-                  <span style="margin-left: 10px;" class="label label-warning image-tag"
-                    ng-if="::image.ContainerCount === 0">
-                    Unused
-                  </span>
+                  <span style="margin-left: 10px;" class="label label-warning image-tag" ng-if="::image.ContainerCount === 0">Unused</span>
                 </td>
                 <td>
                   <span class="label label-primary image-tag" ng-repeat="tag in (image|repotags)">{{ tag }}</span>


### PR DESCRIPTION
White spaces inside the `<span>` allows the label to be breaken to multiple lines:

![untitled](https://user-images.githubusercontent.com/6628437/31883751-2981d0de-b7eb-11e7-8e55-227d17ae1c7e.png)

This PR removes those white spaces, so that the label is always shown in a block.