### PR TITLE
check for actual arch instead of hard-coding amd64

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,6 +1,9 @@
 var autoprefixer = require('autoprefixer');
 var cssnano = require('cssnano');
 var loadGruntTasks = require('load-grunt-tasks');
+var os = require('os');
+var arch = os.arch();
+if ( arch === 'x64' ) arch = 'amd64';
 
 module.exports = function (grunt) {
 
@@ -34,8 +37,8 @@ module.exports = function (grunt) {
   grunt.registerTask('build', [
     'config:dev',
     'clean:app',
-    'shell:buildBinary:linux:amd64',
-    'shell:downloadDockerBinary:linux:amd64',
+    'shell:buildBinary:linux:' + arch,
+    'shell:downloadDockerBinary:linux:' + arch,
     'vendor:regular',
     'html2js',
     'useminPrepare:dev',
@@ -184,7 +187,7 @@ module.exports = function (grunt) {
       run: {
         command: [
           'docker rm -f portainer',
-          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer portainer/base /app/portainer-linux-amd64 --no-analytics -a /app'
+          'docker run -d -p 9000:9000 -v $(pwd)/dist:/app -v /tmp/portainer:/data -v /var/run/docker.sock:/var/run/docker.sock:z --name portainer portainer/base /app/portainer-linux-' + arch + ' --no-analytics -a /app'
         ].join(';')
       },
       downloadDockerBinary: {


### PR DESCRIPTION
Dynamically evaluating the architecture simplifies natively building portainer on other platforms.

os.arch is used for that. It will return x64 (at least on my x86 system), so in that case is mapped to the expected value of amd64. On other platforms, the value is not modified, and that works at least on my s390x system.