### PR TITLE
feat(logs) show logs with xterm.js POC (#317)

### DIFF
--- a/app/components/containerLogs/containerLogsController.js
+++ b/app/components/containerLogs/containerLogsController.js
@@ -4,9 +4,11 @@ function ($scope, $transition$, $anchorScroll, ContainerLogs, Container, Notific
   $scope.state = {};
   $scope.state.displayTimestampsOut = false;
   $scope.state.displayTimestampsErr = false;
-  $scope.stdout = '';
-  $scope.stderr = '';
-  $scope.tailLines = 2000;
+  $scope.state.both = false;
+  $scope.state.StdOut = { data: '', last: '0', chunk: 0, scrollback: 1000, page: 2000 };
+  $scope.state.StdErr = { data: '', last: '0', chunk: 0, scrollback: 1000, page: 2000 };
+  $scope.termStdOut = 'empty';
+  $scope.termStdErr = 'empty';
 
   Container.get({id: $transition$.params().id}, function (d) {
     $scope.container = d;
@@ -14,57 +16,101 @@ function ($scope, $transition$, $anchorScroll, ContainerLogs, Container, Notific
     Notifications.error('Failure', e, 'Unable to retrieve container info');
   });
 
-  function getLogs() {
-    getLogsStdout();
-    getLogsStderr();
+  function updateLogs() { updateLogStd('Out'); if ( $scope.state.both === true ) { updateLogStd('Err'); } else { ErrDestroy(); } }
+
+  function ErrDestroy() { if ( $scope.termStdErr !== 'empty' ) {
+    $scope.termStdErr.destroy();
+    $scope.termStdErr = 'empty';
+  }}
+
+  function getLogsStd (std, since, f) {
+    var n = [1 , ($scope.state.both) ? 1 : 0 ];
+    if ( (std === 'Err') && !$scope.state.both) { n = [ 0, 1]; }
+    ContainerLogs.get($transition$.params().id, {
+      stdout: n[0],
+      stderr: n[1],
+      timestamps: true,
+      tail: 'all',
+      since: $scope.state['Std'+std].last
+    }, f );
   }
 
-  function getLogsStderr() {
-    ContainerLogs.get($transition$.params().id, {
-      stdout: 0,
-      stderr: 1,
-      timestamps: $scope.state.displayTimestampsErr,
-      tail: $scope.tailLines
-    }, function (data, status, headers, config) {
-      // Replace carriage returns with newlines to clean up output
-      data = data.replace(/[\r]/g, '\n');
-      // Strip 8 byte header from each line of output
-      data = data.substring(8);
-      data = data.replace(/\n(.{8})/g, '\n');
-      $scope.stderr = data;
+  function truncateLogPage (std) {
+    var data = $scope.state['Std'+std].data;
+    d = data.split('\n');
+    var l = $scope.state['Std'+std].page;
+    if (d.length > l) { d = d.slice(d.length-l); }
+    $scope.state['Std'+std].data = d.join('\n');
+  }
+
+  function updateLogStd (std) {
+    if ( $scope['termStd'+std] === 'empty' ) { $scope['termStd'+std] = NewTerm('std'+std+'-terminal'); }
+    getLogsStd(std, $scope.state['Std'+std].last, function (data, status, headers, config) {
+      var stdvar = $scope.state['Std'+std];
+      stdvar.data += data;
+      var d = data.split('\n');
+      if (d.length>1) {
+        stdvar.chunk += d.length;
+        // To get full timestamp substring(0,30)
+        stdvar.last = new Date(d[d.length-2].substring(0,30)).getTime(); // RFC to UNIX Timestamp
+        logView(std,data);
+      }
+      $scope.state['Std'+std] = stdvar;
+      truncateLogPage(std);
     });
   }
 
-  function getLogsStdout() {
-    ContainerLogs.get($transition$.params().id, {
-      stdout: 1,
-      stderr: 0,
-      timestamps: $scope.state.displayTimestampsOut,
-      tail: $scope.tailLines
-    }, function (data, status, headers, config) {
-      // Replace carriage returns with newlines to clean up output
-      data = data.replace(/[\r]/g, '\n');
-      // Strip 8 byte header from each line of output
-      data = data.substring(8);
-      data = data.replace(/\n(.{8})/g, '\n');
-      $scope.stdout = data;
-    });
+  function logView(std, data) {
+    var d = data.split('\n');
+    var l = $scope.state['Std'+std].scrollback;
+    if (d.length > l) { d = d.slice(d.length-l); }
+    for (var i = 0 ; i < d.length ; i++ ) {
+      // Custom data format and output to terminal YYYYMMDD-HH:MM:SS
+      d[i] = (($scope.state['displayTimestamps'+std]) ?
+       (d[i].substring(0, 4) + d[i].substring(5, 7) + d[i].substring(8, 10) + '-' + d[i].substring(11, 19)) : '' )
+       + d[i].substring(30);
+    }
+    // Join and write to terminal
+    $scope['termStd'+std].write(d.join('\n'));
   }
 
-  // initial call
-  getLogs();
-  var logIntervalId = window.setInterval(getLogs, 5000);
+  function displayTimeLogStd (std) {
+    $scope['termStd'+std].clear();
+    logView(std, $scope.state['Std'+std].data);
+  }
+
+  function readLogsStd(std) {
+    return encodeURIComponent($scope.state['Std'+std].data.split('\n'));
+  }
 
   $scope.$on('$destroy', function () {
-    // clearing interval when view changes
-    clearInterval(logIntervalId);
+    clearInterval(logIntervalId); // clearing interval when view changes
+    $scope.termStdOut.destroy();
+    ErrDestroy();
   });
 
-  $scope.toggleTimestampsOut = function () {
-    getLogsStdout();
+  var NewTerm = function(id) {
+    var term = new Terminal();
+    term.open(document.getElementById(id), true);
+    term.fit();
+    return term;
   };
 
-  $scope.toggleTimestampsErr = function () {
-    getLogsStderr();
-  };
+  $scope.readLogsStd = readLogsStd;
+  $scope.displayTimeLogStd = displayTimeLogStd;
+  $scope.$watchGroup(['state.both','state.StdOut.scrollback','state.StdOut.page','state.StdErr.scrollback','state.StdErr.page'],function () {
+    $.each( { 'Out':'', 'Err':'' } , function (std) {
+      if ( $scope['termStd'+std] !== 'empty' ) {
+        $scope.state['Std'+std].last = 0;
+        $scope.state['Std'+std].chunk = 0;
+        $scope.state['Std'+std].data = '';
+        $scope['termStd'+std].clear();
+      }
+    });
+    updateLogs();
+  });
+
+  window.setTimeout(updateLogs,200); // initial call
+  var logIntervalId = window.setInterval(updateLogs, 5000);
+
 }]);

--- a/app/components/containerLogs/containerlogs.html
+++ b/app/components/containerLogs/containerlogs.html
@@ -8,46 +8,45 @@
 <div class="row">
   <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
-      <rd-widget-body>
-        <div class="widget-icon grey pull-left">
-          <i class="fa fa-server"></i>
-        </div>
-        <div class="title">{{ container.Name|trimcontainername }}</div>
-        <div class="comment">Name</div>
-      </rd-widget-body>
-    </rd-widget>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-lg-12 col-md-12 col-xs-12">
-    <rd-widget>
-      <rd-widget-header icon="fa-info-circle" title="Stdout logs"></rd-widget-header>
-      <rd-widget-taskbar>
-        <input type="checkbox" ng-model="state.displayTimestampsOut" id="displayAllTsOut" ng-change="toggleTimestampsOut()"/>
+      <rd-widget-header icon="fa-info-circle" title="Std logs [{{ state.StdOut.chunk }} lines]">
+        <span class="btn-group btn-group-sm">
+          <label class="btn btn-primary" ng-click="state.both=!state.both"><i ng-if="!state.both" class="fa fa-toggle-on space-right" aria-hidden="true"></i><i ng-if="state.both" class="fa fa-toggle-off space-right" aria-hidden="true"></i>Err</label>
+          <label class="btn btn-primary" ng-click="termStdOut.scrollToTop()"><i class="fa fa-arrow-up space-right" aria-hidden="true"></i>Top</label>
+          <label class="btn btn-primary" ng-click="termStdOut.scrollToBottom()"><i class="fa fa-arrow-down space-right" aria-hidden="true"></i>Bottom</label>
+          <label class="btn btn-primary" ng-click="termStdOut.clear()"><i class="fa fa-eraser space-right" aria-hidden="true"></i>Clear</label>
+          <a role="label" class="btn btn-primary" href="data:text/plain;charset=utf-8,{{ readLogsStd ('Out') }}" download="{{container.Id.slice(0,12)}}-{{ container.Name|trimcontainername }}-stdout.log"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>
+          <input title="Scrollback length (lines)" type="number" step="50" min="50" max="2000"  ng-model="state.StdOut.scrollback" class="form-control log-input">
+          </input><input title="Page length (lines)" type="number" step="50" min="50" max="10000" ng-model="state.StdOut.page" class="form-control log-input">
+          </input>
+        </span>
+        <input type="checkbox" ng-model="state.displayTimestampsOut" id="displayAllTsOut" ng-change="displayTimeLogStd('Out')"/>
         <label for="displayAllTsOut">Display timestamps</label>
-      </rd-widget-taskbar>
+      </rd-widget-header>
       <rd-widget-body classes="no-padding">
-        <div class="panel-body">
-          <pre id="stdoutLog" class="pre-scrollable pre-x-scrollable">{{stdout}}</pre>
-        </div>
+        <div id="stdOut-terminal" class="terminal-container"></div>
       </rd-widget-body>
     </rd-widget>
   </div>
 </div>
 
-<div class="row">
+<div ng-if="state.both" class="row">
   <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
-      <rd-widget-header icon="fa-exclamation-triangle" title="Stderr logs"></rd-widget-header>
-      <rd-widget-taskbar>
-        <input type="checkbox" ng-model="state.displayTimestampsErr" id="displayAllTsErr" ng-change="toggleTimestampsErr()"/>
+      <rd-widget-header icon="fa-exclamation-triangle" title="Err logs [{{ state.StdErr.chunk }} lines]">
+        <span class="btn-group btn-group-sm">
+          <label class="btn btn-primary" ng-click="termStdErr.scrollToTop()"><i class="fa fa-arrow-up space-right" aria-hidden="true"></i>Top</label>
+          <label class="btn btn-primary" ng-click="termStdErr.scrollToBottom()"><i class="fa fa-arrow-down space-right" aria-hidden="true"></i>Bottom</label>
+          <label class="btn btn-primary" ng-click="termStdErr.clear()"><i class="fa fa-eraser space-right" aria-hidden="true"></i>Clear</label>
+          <a role="label" class="btn btn-primary" href="data:text/plain;charset=utf-8,{{ readLogsStd ('Err') }}" download="{{container.Id.slice(0,12)}}-{{ container.Name|trimcontainername }}-stderr.log"><i class="fa fa-download space-right" aria-hidden="true"></i>Save</a>
+          <input title="Scrollback length (lines)" type="number" step="50" min="50" max="2000"  ng-model="state.StdErr.scrollback" class="form-control log-input">
+          </input><input title="Page length (lines)" type="number" step="50" min="50" max="10000" ng-model="state.StdErr.page" class="form-control log-input">
+          </input>
+        </span>
+        <input type="checkbox" ng-model="state.displayTimestampsErr" id="displayAllTsErr" ng-change="displayTimeLogStd('Err')"/>
         <label for="displayAllTsErr">Display timestamps</label>
-      </rd-widget-taskbar>
+      </rd-widget-header>
       <rd-widget-body classes="no-padding">
-        <div class="panel-body">
-          <pre id="stderrLog" class="pre-scrollable pre-x-scrollable">{{stderr}}</pre>
-        </div>
+        <div id="stdErr-terminal" class="terminal-container"></div>
       </rd-widget-body>
     </rd-widget>
   </div>

--- a/app/rest/docker/containerLogs.js
+++ b/app/rest/docker/containerLogs.js
@@ -10,7 +10,8 @@ angular.module('portainer.rest')
           'stdout': params.stdout || 0,
           'stderr': params.stderr || 0,
           'timestamps': params.timestamps || 0,
-          'tail': params.tail || 'all'
+          'tail': params.tail || 'all',
+          'since': params.since || '0'
         },
         ignoreLoadingBar: true
       }).success(callback).error(function (data, status, headers, config) {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -210,6 +210,11 @@ a[ng-click]{
   padding: 10px 5px;
 }
 
+#stdOut-terminal,
+#stdErr-terminal {
+  height: 350px;
+}
+
 .interactive {
   cursor: pointer;
 }
@@ -770,4 +775,14 @@ json-tree .branch-preview {
 
 .row.header .meta .page {
   padding-top: 7px;
+}
+
+/* container logs */
+
+.log-input {
+  display: contents;
+  width: 90px;
+  height: 30px;
+  text-align: center;
+  padding: 4px 4px;
 }


### PR DESCRIPTION
This PR is just a Proof Of Concept to see if we can leverage `xterm.js` to enhance the actual implementation of container logs view and, hopefully, provide a clean base to fullfill all the requirements in #317.

- [x] Support ANSI colors in container logs [#524]. `xterm.js` supports colors by default.
- [x] Remove the large header which shows redundant information and is outdated compared with other views. It leaves more space for the terminal output.
- [x] Replace `<div class="panel-body"><pre.../pre></div>` with `<div id="stdout-terminal" class="terminal-container"></div>` and `<div id="stderr-terminal" class="terminal-container"></div>`
- [x] Use a single function to be called twice with a parameter, instead of two nearly identical functions.
- [x] Create a timeout so that container divs are created prior to the execution of `NewTerm`. Destroy them on `$scope.$on('$destroy'`.
- [x] Docker API's `since` option is used when retrieving logs. Actually, the is a raw object which holds up to `pages` lines (which defaults to `2000`). On top of that, the terminal has its own buffer, which defaults to `1000` lines. Both, the object and the buffer are updated incrementally. To do so, timestamps are always retrieved and the one corresponding to the last line is saved.
  - [x] Add integer input box to let the user set `scrollback`.
  - [x] Add integer input box to let the user set `page`.
- Buttons:
  - [x] Scroll to the top of the log. `xterm.js` supports `scrollToTop()`.
  - [x] Scroll to the end of the log [#1281]. `xterm.js` supports `scrollToBottom()`.
  - [x] Clear the log [#588]. `xterm.js` supports `clear()`. Clears the xterm buffer.
    - [ ] Should also clear the object but keep `last`?
  - [x] Save. Saves the string containing the full log (not related to `xtem.js`) to a file. The content is saved raw, so `cat *.log` in a local terminal will keep the colours.
    - [ ] Add dropdown to save the scrollback, the page, or the full log.
  - [ ] "Raw log" as in travis-ci. `?deansi=true` [strip-ansi](https://www.npmjs.com/package/strip-ansi)
- [x] The display timestamps feature does not work correctly. The timestamps aren't useful since they appear to be rubbish at first sight (e.g "30T15:25:10.797977346Z"), and not having them on trims away valuable information from the logs. [#834]
  - [ ] Add dropdown list of data formats.
  - [ ] [moment.js](https://momentjs.com/) is already included in the frontend. It can be used to let the user choose a format.

That format comes from the docker API: https://docs.docker.com/engine/reference/commandline/logs/#extended-description. However, since timestamps are always retrieved and they are extracted in case the use does not check the box, any modification can be applied to the format. See example: `YYYYMMDD-HH:MM:SS`. When the box is (un)checked, the terminal is cleared and the last `scrollback` lines from the object are retrieved and parsed.

- [ ] The height of the `div` containing each terminal is fixed. It would be better if the user could drag the bottom to set it. https://gist.github.com/ayapi/9ecee21a70c2d56516799fdcceaa26db
- [ ] 'Copy all' for logs (both stdout and stderr) [#427]

A function such as the one used in the `Save` button is enough. A procedure to copy the content to the clipboard is required.

On top of that, `xterm.js` supports `selectAll()` to extract the content of the buffer. I don't know what the behaviour of 'Copy all' should be.

- [ ] Since the page is larger than the scrollback buffer, buttons can be added to "move the scrollback window along the page".

- [ ] When a user access the logs view for a container, the app will start polling the containers. When the user leaves the view, the app will continue polling logs for that container in the background. [#221]

This might be solved before this PR. The logs are updated through an interval `var logIntervalId = window.setInterval(getLogs, 5000);` and it is cleared:

- [x] [@deviantony] Also, I think that we should the logs (stderr+stdout) into a single container/terminal. A filter both | stdin | stderr should be added.

- [x] Reverse sort the log, such that the new stuff is at the top. [#430]

I don't think that `xterm.js` supports this option. It could be tricked, clearing and writing again, but performance might be much worse. Anyway, I think that the issue in #430 is solved by calling `scrolltoBottom()` to make sure that the newer content is shown.

## Bugs with the previous implementation, hopefully solved in this PR:

- [x] When a container logs heavily, log views sometimes (a few times per minute) become completely empty, then they refresh with latest lines again. Scroll is reset to the top when this happens. [#315]

This is probably related to the fact that up to 2000 lines were/are retrieved every five seconds. The incremental implementation should reduce this to the first load. `scrollToTop()` and `scrollToBottom()` can be used to move the scroll.

- [x] When certain strings are logged, the logging window shows them only partially when timestamps are not shown, but completely when timestamps are on. [#966]
- [x] The container logs contains encoding data errors but i don't know why [#1020]
- [x] The text with gray background is removed [#1238]
