### PR TITLE
feat(stacks): allow to use images from private registries in stacks

### DIFF
--- a/api/http/security/filter.go
+++ b/api/http/security/filter.go
@@ -61,7 +61,7 @@ func FilterUsers(users []portainer.User, context *RestrictedRequestContext) []po
 }
 
 // FilterRegistries filters registries based on user role and team memberships.
-// Non administrator users only have access to authorized endpoints.
+// Non administrator users only have access to authorized registries.
 func FilterRegistries(registries []portainer.Registry, context *RestrictedRequestContext) ([]portainer.Registry, error) {
 
 	filteredRegistries := registries

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -93,6 +93,8 @@ func (server *Server) Start() error {
 	stackHandler.ResourceControlService = server.ResourceControlService
 	stackHandler.StackManager = server.StackManager
 	stackHandler.GitService = server.GitService
+	stackHandler.RegistryService = server.RegistryService
+	stackHandler.DockerHubService = server.DockerHubService
 
 	server.Handler = &handler.Handler{
 		AuthHandler:           authHandler,

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -379,6 +379,8 @@ type (
 
 	// StackManager represents a service to manage stacks.
 	StackManager interface {
+		Login(dockerhub *DockerHub, registries []Registry, endpoint *Endpoint) error
+		Logout(endpoint *Endpoint) error
 		Deploy(stack *Stack, endpoint *Endpoint) error
 		Remove(stack *Stack, endpoint *Endpoint) error
 	}


### PR DESCRIPTION
This PR brings support for private registries when deploying stacks.

**NOTE**: the user deploying the stack must have access to the registry/registries for authentication to work (see Portainer settings > Registries > Manage accesses).

Closes #1313