### PR TITLE
chore(build-system) Scripts to build portainer/factory image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine
+
+WORKDIR /portainer-build
+
+ADD portainer-godeps.tar /portainer-deps/
+COPY package.json bower.json /portainer/
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+ && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+ && apk add -U --no-cache ca-certificates wget perl-utils nodejs nodejs-npm git dos2unix \
+ && cd /portainer \
+ && dos2unix $(ls) \
+ && npm install \
+ && ./node_modules/bower/bin/bower install --allow-root \
+ && mv node_modules /portainer-deps/ && mv bower_components /portainer-deps/ \
+ && apk del git nodejs-npm \
+ && cd .. && rm -rf portainer /var/cache/apk/* ~/.cache/* /tmp/* \
+ && ln -s /portainer-deps/node_modules/grunt-cli/bin/grunt /usr/bin/grunt \
+ && ln -s /portainer-deps/node_modules/bower/bin/bower /usr/bin/bower

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+# [mainPath=<path_to_mainpath>] [mainPackagePath=<path_to_package>] [DEPSONLY=true] [COMPRESS_BINARY=true] builder.sh
+
+#---
+
+build_env() {
+  echo "Building environment setting up..."
+
+  if [ -z "$mainPath" ]; then mainPath="$(realpath .)"; fi
+
+  [ "$(ls -A $mainPath)" ] || ( echo "Error: Must mount Go source code into <mainPath> directory [$mainPath]"; exit 990 )
+
+  mainPackagePath="${mainPath}/${mainPackagePath}"
+
+  # Grab Go package name
+  iComment() { go list -e -f '{{.ImportComment}}' 2>/dev/null || true; }
+  if [[ ! -z "${mainPackagePath}" ]]; then
+    pkgName="$(cd $mainPackagePath && iComment)"
+  else
+    pkgName="$(iComment)"
+  fi
+
+  if [ -z "$pkgName" ]; then
+    echo "Error: Must add canonical import path to root package"
+    exit 992
+  fi
+
+  # Grab just first path listed in GOPATH, and construct Go package path
+  pkgPath="${GOPATH%%:*}/src/$pkgName"
+
+  # Set-up src directory tree in GOPATH, and link source dir into GOPATH
+  mkdir -p "$(dirname "$pkgPath")"
+  ln -sf "$mainPath" "$pkgPath"
+
+  # Enable vendor experiment, else add local godeps dir to GOPATH, else get all package dependencies
+  if [ -e "$pkgPath/vendor" ]; then export GO15VENDOREXPERIMENT=1;
+  elif [ -e "$pkgPath/Godeps/_workspace" ]; then GOPATH="$pkgPath/Godeps/_workspace:$GOPATH";
+  else goget;
+  fi
+}
+
+#---
+
+dobuild() { # Compile statically linked version of package
+  # Optional OUTPUT env var to use the "-o" go build switch forces build to write the resulting executable or object to the named output file
+  CGO_ENABLED=${CGO_ENABLED:-0} \
+  GOOS="$GOOS" GOARCH="$GOARCH" go build -a --installsuffix cgo --ldflags="${LDFLAGS:--s}" \
+  $(if [[ ! -z "${OUTPUT}" ]]; then echo "-o ${OUTPUT}"; else echo ""; fi);
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+  if [[ "$COMPRESS_BINARY" == "true" ]]; then upx -v -9 ${OUTPUT}; fi
+}
+
+#---
+
+if [ -z ${BUILD_GOOS+x} ]; then
+  goget() { go get -t -d -v ./...; }
+  build_pkg() { echo "Building $pkgName...";  dobuild; }
+else
+  goget() { `GOOS=${BUILD_GOOS:-""} GOARCH=${BUILD_GOARCH:-""} go get -t -d -v ./...`; }
+  build_pkg() {
+    for GOOS in ${BUILD_GOOS:-"darwin linux windows"}; do
+      for GOARCH in ${BUILD_GOARCH:-"386 amd64 arm"}; do
+        echo "Building $pkgName for $GOOS-$GOARCH..."
+        OUTPUT="${pkgName##*/}-$GOOS-$GOARCH"
+        if [ "$GOOS" = "windows" ]; then OUTPUT="$OUTPUT.exe"; fi
+        dobuild
+      done
+    done
+  }
+fi
+
+#---
+
+godep_save() {
+  missing_package="start"
+  while [ "$missing_package" != "" ]; do
+    missing_package=$(godep save $@ 2>&1 | egrep '^godep: Package (.*) not found' | sed 's/.*(\(.*\)).*/\1/');
+   [ "$missing_package" != "" ] && { echo "Installing missing package: ${missing_package}"; go get -u "${missing_package}"; }
+  done
+  godep save $@
+}
+
+#---
+
+save_pkg_deps() {
+  echo "Saving dependencies with godep"
+
+  echo "Remove symlink to '$mainPath'; mkdir, cp and cd instead"
+  rm -rf "$(dirname "$pkgPath")"
+  mkdir -p "$pkgPath"
+  cp -r "$mainPath/"* "$pkgPath/"
+  cd "$pkgPath"
+
+  echo "Get tools/godep"
+  go get github.com/tools/godep
+  godep_save ./...
+
+  mkdir -pv /tmp/targodeps
+
+  echo "Copy vendor and Godeps"
+  cp -r vendor /tmp/targodeps/
+  cp -r Godeps /tmp/targodeps/
+
+  echo "Save tar to /godeps"
+  mkdir -pv /godeps
+  tar -vcf "/godeps/$(echo $pkgName | cut -d \/ -f 3)-godeps.tar" -C /tmp/targodeps/ .
+}
+
+#---
+
+build_env
+
+if [[ ! -z "${mainPackagePath}" ]]; then cd ${mainPackagePath}; fi
+
+if [ -z ${DEPSONLY+x} ]; then
+  build_pkg
+else
+  save_pkg_deps
+fi

--- a/build/factory_create.sh
+++ b/build/factory_create.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Dependencies: cat, docker, dos2unix
+
+buildscripts="$(realpath $(dirname $0))"
+
+exitcode() {
+  if [ "$1" -ne "0" ]; then
+    echo "$2! $1"
+    exit "$1"
+  fi
+}
+
+echo ""
+echo "[FACTORY] Building portainer/builder..."
+
+mkdir -pv tmp && cd tmp
+
+echo 'FROM golang:alpine' > Dockerfile
+echo 'RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories' \
+      '&& apk add -U --no-cache git upx' >> Dockerfile
+
+docker build -t portainer/builder .
+exitcode "$?" "Building portainer/builder failed"
+
+cd .. && rm -rf tmp
+
+echo ""
+echo "[FACTORY] Getting golang dependencies..."
+
+if [ -d "godeps" ]; then rm -rf godeps; fi
+mkdir -vp godeps
+dos2unix "$buildscripts"/builder.sh;
+docker run --rm -t \
+           -w //src \
+           -v "/$(dirname $buildscripts)"/api:/src \
+           -v "/$(dirname $buildscripts)"/godeps:/godeps \
+           portainer/builder sh -c "mainPath=//src mainPackagePath=/cmd/portainer; DEPSONLY=true `cat $buildscripts/builder.sh`"
+exitcode "$?" "Getting dependencies failed"
+
+echo ""
+echo "[FACTORY] Building portainer/factory..."
+
+if [ -d "tmp" ]; then rm -rf tmp; fi
+mkdir -pv tmp && cd tmp
+
+cp "$buildscripts/Dockerfile" ./ && dos2unix Dockerfile
+cp "$(dirname "$buildscripts")/package.json" ./
+cp "$(dirname "$buildscripts")/bower.json" ./
+
+mv "$(dirname $buildscripts)/godeps/portainer-godeps.tar" ./
+
+docker build -t portainer/factory --no-cache --squash .
+exitcode "$?" "Building portainer/factory failed"
+
+cd .. && rm -rf tmp
+
+echo ""
+echo "[FACTORY] Cleaning dangling images..."
+
+docker rmi $(docker images -q -f dangling=true)


### PR DESCRIPTION
Focus on #1330 and #1331 first.
---

close? #1476

This PR includes partial modifications towards the integration of #938 to develop.

- [golang/builder](https://github.com/portainer/golang-builder), which is based on [CenturyLinkLabs/golang-builder](https://github.com/CenturyLinkLabs/golang-builder) does not support downloading dependencies only, without building the package/app.
  - A script is added in this PR which is the result of merging [build_environment.sh](https://github.com/portainer/golang-builder/blob/master/builder/build_environment.sh) and [build.sh](https://github.com/portainer/golang-builder/blob/master/builder/build.sh), replacing `goupx` with `upx`, and adding [tools/godep](https://github.com/tools/godep). Furthermore, the same script is used for any architecture.
- `factory_create.sh` is a script which depends on `golang:alpine` and `alpine` to produce two images:
  - `portainer/builder`: based on `golang:alpine`, with `git` and `upx`.
  - `portainer/factory`: based on `alpine`, with nodejs and all required dependencies for the frontend and backend.

This PR provides a portable system to allow building the frontend when #1330 is merged. Still, although the dependencies will be packed, it will lack a script to automate it's usage. This will be added after #1331, #1334 and #1335 are merged.