### PR TITLE
style(sidebar) Adjust title form-control

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -372,6 +372,10 @@ ul.sidebar .sidebar-list .sidebar-sublist a.active {
   ul.sidebar .sidebar-title {
     line-height: 28px;
   }
+  ul.sidebar .sidebar-title .form-control {
+    height: 28px;
+    padding: 4px 8px;
+  }
   ul.sidebar .sidebar-list {
     height: 28px;
   }
@@ -387,6 +391,10 @@ ul.sidebar .sidebar-list .sidebar-sublist a.active {
 @media(min-height: 684px) and (max-height: 850px) {
   ul.sidebar .sidebar-title {
     line-height: 30px;
+  }
+  ul.sidebar .sidebar-title .form-control {
+    height: 30px;
+    padding: 5px 10px;
   }
   ul.sidebar .sidebar-list {
     height: 30px;


### PR DESCRIPTION
- Automatically adjusts sidebar title form-control elements (endpoint dropdown) font-size based on height. Following the same approach as in #1336.
- Sets the same colors used in other elements of the sidebar (background and font) to title form-control elements in the sidebar.

Enhances #1336 