### PR TITLE
feat(health) Add flag to GET /api/status instead of initializing port…

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -33,7 +33,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	flags := &portainer.CLIFlags{
 		Addr:              kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
 		Assets:            kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
-		CheckHealth:       kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default("false").Short('c').Bool(),
+		CheckHealth:       kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default(defaultCheckHeath).Short('c').Bool(),
 		Data:              kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
 		Endpoint:          kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
 		ExternalEndpoints: kingpin.Flag("external-endpoints", "Path to a file defining available endpoints").String(),

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -31,12 +31,12 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	kingpin.Version(version)
 
 	flags := &portainer.CLIFlags{
-		Endpoint:          kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
-		ExternalEndpoints: kingpin.Flag("external-endpoints", "Path to a file defining available endpoints").String(),
-		SyncInterval:      kingpin.Flag("sync-interval", "Duration between each synchronization via the external endpoints source").Default(defaultSyncInterval).String(),
 		Addr:              kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
 		Assets:            kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
+		CheckHealth:       kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default("false").Short('c').Bool(),
 		Data:              kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
+		Endpoint:          kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
+		ExternalEndpoints: kingpin.Flag("external-endpoints", "Path to a file defining available endpoints").String(),
 		NoAuth:            kingpin.Flag("no-auth", "Disable authentication").Default(defaultNoAuth).Bool(),
 		NoAnalytics:       kingpin.Flag("no-analytics", "Disable Analytics in app").Default(defaultNoAnalytics).Bool(),
 		TLSVerify:         kingpin.Flag("tlsverify", "TLS support").Default(defaultTLSVerify).Bool(),
@@ -46,6 +46,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		SSL:               kingpin.Flag("ssl", "Secure Portainer instance using SSL").Default(defaultSSL).Bool(),
 		SSLCert:           kingpin.Flag("sslcert", "Path to the SSL certificate used to secure the Portainer instance").Default(defaultSSLCertPath).String(),
 		SSLKey:            kingpin.Flag("sslkey", "Path to the SSL key used to secure the Portainer instance").Default(defaultSSLKeyPath).String(),
+		SyncInterval:      kingpin.Flag("sync-interval", "Duration between each synchronization via the external endpoints source").Default(defaultSyncInterval).String(),
 		AdminPassword:     kingpin.Flag("admin-password", "Hashed admin password").String(),
 		AdminPasswordFile: kingpin.Flag("admin-password-file", "Path to the file containing the password for the admin user").String(),
 		// Deprecated flags

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -6,6 +6,7 @@ const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "/data"
 	defaultAssetsDirectory = "./"
+	defaultCheckHeath      = "false"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -4,6 +4,7 @@ const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "C:\\data"
 	defaultAssetsDirectory = "./"
+	defaultCheckHeath      = "false"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -173,9 +173,9 @@ func main() {
 	flags := initCLI()
 
 	if *flags.CheckHealth {
-		statuscode, err := http.HealthCheck("localhost" + *flags.Addr)
+		statuscode, err := http.HealthCheck(*flags.Addr)
 		if err == nil {
-			if statuscode < 400 {
+			if statuscode == 200 {
 				log.Println(*flags.Addr, ": Online - response:", statuscode)
 				os.Exit(0)
 			} else {

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/portainer/portainer/ldap"
 
 	"log"
+	"os"
 )
 
 func initCLI() *portainer.CLIFlags {
@@ -172,7 +173,16 @@ func main() {
 	flags := initCLI()
 
 	if *flags.CheckHealth {
-		http.GetHealth("localhost" + *flags.Addr)
+		statuscode, err := http.HealthCheck("localhost" + *flags.Addr)
+		if err == nil {
+			if statuscode < 400 {
+				log.Println(*flags.Addr, ": Online - response:", statuscode)
+				os.Exit(0)
+			} else {
+				log.Fatal(*flags.Addr, ": Error - response:", statuscode)
+			}
+		}
+		log.Fatal("Connection error:", err.Error())
 	}
 
 	fileService := initFileService(*flags.Data)

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -171,6 +171,10 @@ func retrieveFirstEndpointFromDatabase(endpointService portainer.EndpointService
 func main() {
 	flags := initCLI()
 
+	if *flags.CheckHealth {
+		http.GetHealth("localhost" + *flags.Addr)
+	}
+
 	fileService := initFileService(*flags.Data)
 
 	store := initStore(*flags.Data)

--- a/api/http/health_check.go
+++ b/api/http/health_check.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"net/http"
+)
+
+// HealthCheck GETs /api/status
+func HealthCheck(addr string) (int, error) {
+	resp, err := http.Get("http://" + addr + "/api/status")
+	return resp.StatusCode, err
+}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -6,9 +6,7 @@ import (
 	"github.com/portainer/portainer/http/proxy"
 	"github.com/portainer/portainer/http/security"
 
-	"log"
 	"net/http"
-	"os"
 	"path/filepath"
 )
 
@@ -122,21 +120,4 @@ func (server *Server) Start() error {
 		return http.ListenAndServeTLS(server.BindAddress, server.SSLCert, server.SSLKey, server.Handler)
 	}
 	return http.ListenAndServe(server.BindAddress, server.Handler)
-}
-
-// GetHealth checks the response of GET /api/status and exits
-func GetHealth(addr string) {
-	addr = "http://" + addr + "/api/status"
-	resp, err := http.Get(addr)
-	if err == nil {
-		s := "Error"
-		if resp.StatusCode < 400 {
-			s = "Online"
-		}
-		log.Println(addr, ":", s, "- response:", resp.StatusCode)
-		os.Exit(0)
-	} else {
-		log.Println("Connection error:", err.Error())
-		os.Exit(1)
-	}
 }

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -6,7 +6,9 @@ import (
 	"github.com/portainer/portainer/http/proxy"
 	"github.com/portainer/portainer/http/security"
 
+	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 )
 
@@ -120,4 +122,21 @@ func (server *Server) Start() error {
 		return http.ListenAndServeTLS(server.BindAddress, server.SSLCert, server.SSLKey, server.Handler)
 	}
 	return http.ListenAndServe(server.BindAddress, server.Handler)
+}
+
+// GetHealth checks the response of GET /api/status and exits
+func GetHealth(addr string) {
+	addr = "http://" + addr + "/api/status"
+	resp, err := http.Get(addr)
+	if err == nil {
+		s := "Error"
+		if resp.StatusCode < 400 {
+			s = "Online"
+		}
+		log.Println(addr, ":", s, "- response:", resp.StatusCode)
+		os.Exit(0)
+	} else {
+		log.Println("Connection error:", err.Error())
+		os.Exit(1)
+	}
 }

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -13,10 +13,10 @@ type (
 	CLIFlags struct {
 		Addr              *string
 		Assets            *string
+		CheckHealth       *bool
 		Data              *string
-		ExternalEndpoints *string
-		SyncInterval      *string
 		Endpoint          *string
+		ExternalEndpoints *string
 		NoAuth            *bool
 		NoAnalytics       *bool
 		TLSVerify         *bool
@@ -26,12 +26,13 @@ type (
 		SSL               *bool
 		SSLCert           *string
 		SSLKey            *string
+		SyncInterval      *string
 		AdminPassword     *string
 		AdminPasswordFile *string
 		// Deprecated fields
+		Labels    *[]Pair
 		Logo      *string
 		Templates *string
-		Labels    *[]Pair
 	}
 
 	// Status represents the application status.

--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -8,4 +8,9 @@ WORKDIR /
 
 EXPOSE 9000
 
-ENTRYPOINT ["/portainer"]
+ENTRYPOINT ["./portainer"]
+
+HEALTHCHECK --start-period=10ms --interval=30s --timeout=5s --retries=3 CMD ["./portainer", "-c"]
+
+#ADD portainer-1.15.0-linux-amd64.tar.gz /
+#`build.sh` requires this file to end with an empty line

--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -8,9 +8,6 @@ WORKDIR /
 
 EXPOSE 9000
 
-ENTRYPOINT ["./portainer"]
+ENTRYPOINT ["/portainer"]
 
-HEALTHCHECK --start-period=10ms --interval=30s --timeout=5s --retries=3 CMD ["./portainer", "-c"]
-
-#ADD portainer-1.15.0-linux-amd64.tar.gz /
-#`build.sh` requires this file to end with an empty line
+HEALTHCHECK --start-period=10ms --interval=30s --timeout=5s --retries=3 CMD ["/portainer", "-c"]


### PR DESCRIPTION
…ainer (fix #1364)

Boolean flag `--check-health | --no-check-health | -c` is added, which fully overrides the execution of the backend. If the flag is true, the reponse to `http.Get("http://localhost:<port>/api/status)` is checked and the program exits. This allows for basic health check functionality:

```
version: '2.1'
services:
  portainer:
    image: portainer/portainer
    command: --host=unix:///var/run/docker.sock
    healthcheck: { test: ["CMD", "./portainer", "-c"] , interval: 30s , timeout: 5s , retries: 3 }
    ports: [ "127.0.0.1:9000:9000" ]
    volumes: [ "//var/run/docker.sock:/var/run/docker.sock" ]
```

However, note that the `healthcheck` line above is not required, because the second commit in this PR adds it to the Dockerfile.