### PR TITLE
feat(container-details) show image tag used to create the container (…

### DIFF
--- a/app/components/container/container.html
+++ b/app/components/container/container.html
@@ -184,7 +184,16 @@
             <tbody>
               <tr>
                 <td>Image</td>
-                <td><a ui-sref="image({id: container.Image})">{{ container.Image }}</a></td>
+                <td>
+                  <table class="table table-bordered table-condensed">
+                    <tr>
+                      <td>Tag</td>
+                      <td><i title="This tag does not belong to image {{ (container.Image || '' ).slice(7)|truncate:23 }} anymore" class="fa fa-warning space-right red-icon" ng-if="state.ChangedTag"></i>{{ container.Config.Image }}</td>
+                      <td>ID</td>
+                      <td><a title="{{state.RepoTags}}" ui-sref="image({id: container.Image})">{{ (container.Image || '' ).slice(7)|truncate:23 }}</a></td>
+                    </tr>
+                  </table>
+                </td>
               </tr>
               <tr ng-if="portBindings.length > 0">
                 <td>Port configuration</td>

--- a/app/components/container/containerController.js
+++ b/app/components/container/containerController.js
@@ -41,6 +41,20 @@ function ($q, $scope, $state, $transition$, $filter, Container, ContainerCommit,
           }
         });
       }
+
+      $q.all({img: ImageService.image($scope.container.Image)})
+      .then(function success(data) {
+        var r = data.img.RepoTags;
+        $scope.state.RepoTags = 'Tags: ' + ((r.length > 0) ? r : '<none>');
+        $scope.state.ChangedTag = true;
+        var img = $scope.container.Config.Image.replace(':latest', '');
+        for (var x=0; x < r.length; x++) {
+          if ( r[x].replace(':latest', '') === img ) { $scope.state.ChangedTag = false; break; }
+        }
+      })
+      .catch(function error(err) {
+        Notifications.error('Failure', err, 'Unable to retrieve image details');
+      });
     }, function (e) {
       Notifications.error('Failure', e, 'Unable to retrieve container info');
     });

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -768,6 +768,12 @@ json-tree .branch-preview {
   opacity: .5;
 }
 
+/**/
+
 .row.header .meta .page {
   padding-top: 7px;
+}
+
+.table {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
close #1369

This PR:

- Adds `container.Config.Image` to the "Image" row of section "Container details" in "Container" page.
- Adds the current tags of image `container.Image` as the "title" of the link. Therefore, these are shown when the mouse is left over it.
- Checks if `container.Config.Image` is present in the tag list. If not, a warning symbol is shown with the following "title": `This tag does not belong to image <ID> anymore`.