### PR TITLE
Add check for files listed in vendor.yml, fix location of Chart.min.js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -55,6 +55,29 @@ module.exports = function (grunt) {
   grunt.registerTask('run-dev', ['build', 'shell:run', 'watch:build']);
   grunt.registerTask('clear', ['clean:app']);
 
+  // Load content of `vendor.yml` to src.jsVendor, src.cssVendor and src.angularVendor
+  grunt.registerTask('vendor', 'vendor:<minified|regular>', function(min) {
+      // Argument `min` defaults to 'minified'
+      var minification = (min === '') ? 'minified' : min;
+      var vendorFile = grunt.file.readYAML('vendor.yml');
+      for (var filelist in vendorFile) {
+          if (vendorFile.hasOwnProperty(filelist)) {
+              var list = vendorFile[filelist][minification];
+              // Check if any of the files is missing
+              for (var itemIndex in list) {
+                  if (list.hasOwnProperty(itemIndex)) {
+                      var item = list[itemIndex];
+                      if (!grunt.file.exists(item)) {
+                          grunt.fail.warn('Dependency file ' + item + ' not found.');
+                      }
+                  }
+              }
+              // If none is missing, save the list
+              grunt.config('src.' + filelist + 'Vendor', list);
+          }
+      }
+  });
+
   // Project configuration.
   grunt.initConfig({
     distdir: 'dist/public',
@@ -232,13 +255,4 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('vendor', 'vendor:<min|reg>', function(min) {
-    // The content of `vendor.yml` is loaded to src.jsVendor, src.cssVendor and src.angularVendor
-    // Argument `min` selects between the 'regular' or 'minified' sets
-    var m = ( min === '' ) ? 'minified' : min;
-    var v = grunt.file.readYAML('vendor.yml');
-    for (type in v) { if (v.hasOwnProperty(type)) {
-      grunt.config('src.'+type+'Vendor',v[type][m]);
-    }}
-  });
 };

--- a/vendor.yml
+++ b/vendor.yml
@@ -21,7 +21,6 @@ js:
   - bower_components/jquery/dist/jquery.min.js
   - bower_components/bootstrap/dist/js/bootstrap.min.js
   - bower_components/bootbox.js/bootbox.js
-  - bower_components/Chart.js/Chart.min.js
   - bower_components/filesize/lib/filesize.min.js
   - bower_components/lodash/dist/lodash.min.js
   - bower_components/moment/min/moment.min.js


### PR DESCRIPTION
At now the build system does not check whether vendor files listed in `vendor.yml` actually exist. This PR adds a check before populating `src.jsVendor`, `src.cssVendor` or `src.angularVendor`. If any of the dependencies is missing, the build fails.

Note that the `vendor` task is moved from the bottom of the gruntfile and placed before the project configuration. The real modification is that [lines 64-68](https://github.com/1138-4EB/portainer/blob/83060326d0527a1a5f22d4150955d703742527e2/gruntfile.js#L64-L68) are added.

This log shows the (errored) output when adding the check (first commit): https://travis-ci.org/1138-4EB/portainer/builds/303310565 (line 4887)

The second commit removes a duplicated incorrect location for `Chart.min.js`. See [vendor.yml#L27](https://github.com/1138-4EB/portainer/blob/83060326d0527a1a5f22d4150955d703742527e2/vendor.yml#L27). The build is correct: https://travis-ci.org/1138-4EB/portainer/builds/303315058

Close #1410 
