### PR TITLE
Allow repo names with periods, set portainer constraints for image names

### DIFF
--- a/app/docker/helpers/imageHelper.js
+++ b/app/docker/helpers/imageHelper.js
@@ -5,24 +5,16 @@ angular.module('portainer.docker')
   var helper = {};
 
   helper.extractImageAndRegistryFromRepository = function(repository) {
-    var slashCount = _.countBy(repository)['/'];
-    var registry = null;
-    var image = repository;
-    if (slashCount >= 1) {
-      // assume something/something[/...]
-      registry = repository.substr(0, repository.indexOf('/'));
-      // assume valid DNS name or IP (contains at least one '.')
-      if (_.countBy(registry)['.'] > 0) {
-        image = repository.substr(repository.indexOf('/') + 1);
-      } else {
-        registry = null;
+    return (_.countBy(repository)['/'] > 1) ?
+      { // assume <registry>/[<repo>/<name>:<tag>]
+        registry: repository.substr(0, repository.indexOf('/')),
+        image: repository.substr(repository.indexOf('/') + 1)
       }
-    }
-
-    return {
-      registry: registry,
-      image: image
-    };
+    :
+      {
+        registry: null,
+        image: repository
+      };
   };
 
   function extractNameAndTag(imageName, registry) {


### PR DESCRIPTION
The first commit in this PR modifies `app/helpers/imageHelper.js`, in order to support image repo names with periods. At now, these are considered to be the registry, and thus discarded. The workaround is to always prepend the registry URL when the repository contains periods. See #1434.

I am not confident with my proposal, because the style is different, but the functionality is the same as the previous version. That is, it reverts #1099.

Both the [old](https://github.com/portainer/portainer/blob/08c5a5a4f65878fff82e6dc98a875a6d443f4cdf/app/helpers/imageHelper.js#L8-L21) implementation and my proposal support these formats:

1. `myregistry.mydomain.tld/myrepo/image:latest`
  - registry: `"myregistry.mydomain.tld"`
  - image: `"myrepo/image:latest"`
2. `myregistry.mydomain.tld/my.repo/image:latest`
  - registry: `"myregistry.mydomain.tld"`
  - image: `"my.repo/image:latest"`
3. `myrepo/image:latest`:
  - registry: `null` (registry must be selected in the select box)
  - image: `"myrepo/image:latest"`
4. `my.repo/image:latest`:
  - registry: `null` (registry must be selected in the select box)
  - image: `"my.repo/image:latest"`
5. `myregistry.mydomain.tld/image:latest`
  - registry: `null`
  - image: `"myregistry.mydomain.tld/image:latest"`

The [current](https://github.com/portainer/portainer/blob/d7769dec33434c0ffbe64bd35f0536d49178c27d/app/helpers/imageHelper.js#L8-L26) implementation is the same with 1, 2, 3. However, 4 and 5 produce different results:

4b. `my.repo/image:latest`
  - registry: `"my.repo"`
  - image: `"image:latest"`
5b. `myregistry.mydomain.tld/image:latest`
  - registry: `"myregistry.mydomain.tld"`
  - image: `"image:latest"`

The last modification was introduced to support 5b, producing 4b as an unwanted bug. However, I am not sure about 5b being valid, so I'd like to discuss it, prior to trying to cover all the cases.

In 5b `<repo>` is interpreted as an optional field, and the image name is allowed to be appended directly to the registry. Although it is not explicitly stated in the [docs](https://docs.docker.com/engine/reference/commandline/tag/), I have seen no example which ommits the repo name.This can be a missunderstanding because `docker pull hello-world` is valid. However, it should be noted that it is just an alias for `docker pull library/hello-world`.

@deviantony, what was the motivation to support such a case? I feel that currently the "proper" way to achieve 5b should be to write `"image:latest"` and select the registry in the select box.