### PR TITLE
Update registry select box option with typed name(alias) or URL

### DIFF
--- a/app/helpers/imageHelper.js
+++ b/app/helpers/imageHelper.js
@@ -5,24 +5,16 @@ angular.module('portainer.helpers')
   var helper = {};
 
   helper.extractImageAndRegistryFromRepository = function(repository) {
-    var slashCount = _.countBy(repository)['/'];
-    var registry = null;
-    var image = repository;
-    if (slashCount >= 1) {
-      // assume something/something[/...]
-      registry = repository.substr(0, repository.indexOf('/'));
-      // assume valid DNS name or IP (contains at least one '.')
-      if (_.countBy(registry)['.'] > 0) {
-        image = repository.substr(repository.indexOf('/') + 1);
-      } else {
-        registry = null;
+    return (_.countBy(repository)['/'] > 1) ?
+      { // assume <registry>/[<repo>/<name>:<tag>]
+        registry: repository.substr(0, repository.indexOf('/')),
+        image: repository.substr(repository.indexOf('/') + 1)
       }
-    }
-
-    return {
-      registry: registry,
-      image: image
-    };
+    :
+      {
+        registry: null,
+        image: repository
+      };
   };
 
   function extractNameAndTag(imageName, registry) {

--- a/app/services/api/registryService.js
+++ b/app/services/api/registryService.js
@@ -88,5 +88,36 @@ angular.module('portainer.services')
     return deferred.promise;
   };
 
+  service.matchTypedRegistry = function(typedRegistry, activeRegistry) {
+    // assume valid DNS name or IP (contains at least one '.')
+    var field = (_.countBy(typedRegistry)['.'] === 0) ? 'Name' : 'URL';
+    //Does the typed registry match the selected option in the registry select box?
+    var msg = '';
+    if (typedRegistry!==activeRegistry[field]) {
+      msg = 'Warning: unknown typed registry, defaulting to select box';
+
+      var registries = {};
+
+      $q.all({ registries: service.registries() })
+      .then(function success(data) {
+        registries = data;
+      })
+      .catch(function error(err) {
+        console.log(err);
+        //Notifications.error('Failure', err, 'Unable to retrieve registries');
+      });
+
+      for (var k in registries) {
+        if (registries.hasOwnProperty(k)) {
+          if (registries[k][field]===typedRegistry) {
+            msg = 'Warning: typed registry does not match the one in the select box';
+            return { registry:registries[k], msg:msg };
+          }
+        }
+      }
+    }
+    return { registry:activeRegistry, msg:msg };
+  };
+
   return service;
 }]);

--- a/app/services/docker/imageService.js
+++ b/app/services/docker/imageService.js
@@ -121,6 +121,16 @@ angular.module('portainer.services')
 
   service.pullImage = function(image, registry, ignoreErrors) {
     var imageDetails = ImageHelper.extractImageAndRegistryFromRepository(image);
+
+    // Did the user type any registry?
+    if (imageDetails.registry!==null) {
+      var matchResp = RegistryService.matchTypedRegistry(imageDetails.registry, registry);
+      registry = matchResp.registry;
+    }
+
+//if msg!='' show notification
+//if msg includes 'does not match' then Change select box option automatically
+
     var imageConfiguration = ImageHelper.createImageConfigForContainer(imageDetails.image, registry.URL);
     var authenticationDetails = registry.Authentication ? RegistryService.encodedCredentials(registry) : '';
     HttpRequestHelper.setRegistryAuthenticationHeader(authenticationDetails);


### PR DESCRIPTION
The first commit is #1439. This PR should not be analized until #1439 is merged.

---

The objective of the second commit is to make the "registry" field extracted from the text input box (aka `typedregistry`) useful when triggering a pull. At now, it is ignored and the option is directly taken from the select box. This means that, writting `myregistry.mydomain.tld/myrepo/image:latest` requires a registry with URL `myregistry.mydomain.tld` to be chosen in the select box. If not `<selected_domain>/myrepo/image:latest` is pulled.

This commit overrides the selected option with the typed URL, if possible:

- If typedregistry is null, the select box is used. Go on.
- If typedregistry is not null, it is compared to the URL of the option selected in the box.
  - If they match, everything is OK, go on.
  - If they don't, check if any of the registries matches.
    - If a match is found, update the select box with the typedregistry and show a *notification* (info or warning). Go on.
    - If no match is found, show *notification*: "do you want to add this registry?". Anyway, just pull from the "unknown" remote.

Note that the proposed implementation checks if the typed registry contains any period. If it does, the URL field of the registries is used for matching. If it does not, the Name is used. This allows to use the names of the registries as an alias. That is, given a registry in the select list named "mynamedregistry", the  `myregistry/myrepo/image:latest` is supported and forwards to `myregistry.mydomain.tld/myrepo/image:latest`.

---

- [ ] With [registryService.js#L99-L107](https://github.com/1138-4EB/portainer/blob/367f66ebafacaee80de9ae3ce7b439f1f1ab3992/app/services/api/registryService.js#L99-L107) I am trying to get something similar to `var registries = service.registries()` in order to use `registries` inmediately: [registryService.js#L109-L117](https://github.com/1138-4EB/portainer/blob/367f66ebafacaee80de9ae3ce7b439f1f1ab3992/app/services/api/registryService.js#L109-L117). Promises drive me mad :S.
- [ ] [imageService.js#L132-L133](https://github.com/1138-4EB/portainer/blob/fcbbba557ad1fcb43d315d92f8b2aa3b77f82cd4/app/services/docker/imageService.js#L132-L133) are the placeholders for the notifications and modifying the value of the select box.