### PR TITLE
feat(nodes): add engine labels info in the swarm nodes view

### DIFF
--- a/app/components/node/node.html
+++ b/app/components/node/node.html
@@ -146,6 +146,33 @@
 <div class="row" ng-if="node">
   <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
     <rd-widget>
+      <rd-widget-header icon="fa-object-group" title="Engine labels"></rd-widget-header>
+      <rd-widget-body ng-if="!node.EngineLabels || node.EngineLabels.length === 0">
+        <p>There are no engine labels for this node.</p>
+      </rd-widget-body>
+      <rd-widget-body classes="no-padding" ng-if="node.EngineLabels && node.EngineLabels.length > 0"> 
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="engineLabel in node.EngineLabels">
+              <td>{{ engineLabel.key }}</td>
+              <td>{{ engineLabel.value }}</td>                
+            </tr>
+          </tbody>
+        </table>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+</div>
+
+<div class="row" ng-if="node">
+  <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+    <rd-widget>
       <rd-widget-header icon="fa-tasks" title="Node labels">
         <div class="nopadding">
           <a class="btn btn-default btn-sm pull-right" ng-click="addLabel(node)">

--- a/app/models/docker/node.js
+++ b/app/models/docker/node.js
@@ -17,13 +17,21 @@ function NodeViewModel(data) {
     this.Labels = [];
   }
 
+  var engineLabels = data.Description.Engine.Labels;
+  if (engineLabels) {
+    this.EngineLabels = Object.keys(engineLabels).map(function(key) {
+      return { key: key, value: engineLabels[key] };
+    });
+  } else {
+    this.EngineLabels = [];
+  }
+
   this.Hostname = data.Description.Hostname;
   this.PlatformArchitecture = data.Description.Platform.Architecture;
   this.PlatformOS = data.Description.Platform.OS;
   this.CPUs = data.Description.Resources.NanoCPUs;
   this.Memory = data.Description.Resources.MemoryBytes;
   this.EngineVersion = data.Description.Engine.EngineVersion;
-  this.EngineLabels = data.Description.Engine.Labels;
   this.Plugins = data.Description.Engine.Plugins;
   this.Status = data.Status.State;
 


### PR DESCRIPTION
A new section is added showing the node's engine labels. These labels cannot be modified as they are added to dockerd when it is started so they are shown as cells in a table.

![portainer_node_engine_labels](https://user-images.githubusercontent.com/30386061/33336124-4896666a-d46f-11e7-8743-f4a03dcddb47.png)

Close #1374 