### PR TITLE
feat(ldap): add default port when not set in url

### DIFF
--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -54,23 +54,12 @@ func searchUser(username string, conn *ldap.Conn, settings []portainer.LDAPSearc
 
 func createConnection(settings *portainer.LDAPSettings) (*ldap.Conn, error) {
 
-	url := strings.Split(settings.URL, ":")
-
-	// Add default port to url if :port is not set
-	if len(url) == 1 {
-		if settings.TLSConfig.TLS {
-			settings.URL += ":636"
-		} else {
-			settings.URL += ":389"
-		}
-	}
-
 	if settings.TLSConfig.TLS || settings.StartTLS {
 		config, err := crypto.CreateTLSConfiguration(&settings.TLSConfig)
 		if err != nil {
 			return nil, err
 		}
-		config.ServerName = url[0]
+		config.ServerName = strings.Split(settings.URL, ":")[0]
 
 		if settings.TLSConfig.TLS {
 			return ldap.DialTLS("tcp", settings.URL, config)

--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -54,12 +54,23 @@ func searchUser(username string, conn *ldap.Conn, settings []portainer.LDAPSearc
 
 func createConnection(settings *portainer.LDAPSettings) (*ldap.Conn, error) {
 
+	url := strings.Split(settings.URL, ":")
+
+	// Add default port to url if :port is not set
+	if len(url) == 1 {
+		if settings.TLSConfig.TLS {
+			settings.URL += ":636"
+		} else {
+			settings.URL += ":389"
+		}
+	}
+
 	if settings.TLSConfig.TLS || settings.StartTLS {
 		config, err := crypto.CreateTLSConfiguration(&settings.TLSConfig)
 		if err != nil {
 			return nil, err
 		}
-		config.ServerName = strings.Split(settings.URL, ":")[0]
+		config.ServerName = url[0]
 
 		if settings.TLSConfig.TLS {
 			return ldap.DialTLS("tcp", settings.URL, config)

--- a/app/components/settingsAuthentication/settingsAuthenticationController.js
+++ b/app/components/settingsAuthentication/settingsAuthenticationController.js
@@ -22,8 +22,8 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
     $scope.LDAPSettings.SearchSettings.splice(index, 1);
   };
 
-  $scope.LDAPConnectivityCheck = function() {
-    var settings = $scope.settings;
+  $scope.LDAPConnectivityCheck = function() {    
+    var settings = $scope.settings;    
     var TLSCAFile = $scope.formValues.TLSCACert !== settings.LDAPSettings.TLSConfig.TLSCACert ? $scope.formValues.TLSCACert : null;
 
     var uploadRequired = ($scope.LDAPSettings.TLSConfig.TLS || $scope.LDAPSettings.StartTLS) && !$scope.LDAPSettings.TLSConfig.TLSSkipVerify;
@@ -32,6 +32,7 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
     $scope.state.connectivityCheckInProgress = true;
     $q.when(!uploadRequired || FileUploadService.uploadLDAPTLSFiles(TLSCAFile, null, null))
     .then(function success(data) {
+      addLDAPDefaultPort(settings, $scope.LDAPSettings.TLSConfig.TLS);
       return SettingsService.checkLDAPConnectivity(settings);
     })
     .then(function success(data) {
@@ -60,6 +61,7 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
     $scope.state.actionInProgress = true;
     $q.when(!uploadRequired || FileUploadService.uploadLDAPTLSFiles(TLSCAFile, null, null))
     .then(function success(data) {
+      addLDAPDefaultPort(settings, $scope.LDAPSettings.TLSConfig.TLS);
       return SettingsService.update(settings);
     })
     .then(function success(data) {
@@ -73,6 +75,13 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
       $scope.state.actionInProgress = false;
     });
   };
+
+  // Add default port if :port is not defined in URL
+  function addLDAPDefaultPort(settings, tlsEnabled) {
+    if (settings.LDAPSettings.URL.split(':').length === 1) {
+      settings.LDAPSettings.URL += tlsEnabled ? ':636' : ':389';      
+    }
+  }
 
   function initView() {
     SettingsService.settings()

--- a/app/components/settingsAuthentication/settingsAuthenticationController.js
+++ b/app/components/settingsAuthentication/settingsAuthenticationController.js
@@ -78,7 +78,7 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
 
   // Add default port if :port is not defined in URL
   function addLDAPDefaultPort(settings, tlsEnabled) {
-    if (settings.LDAPSettings.URL.split(':').length === 1) {
+    if (settings.LDAPSettings.URL.indexOf(":") === -1) {      
       settings.LDAPSettings.URL += tlsEnabled ? ':636' : ':389';      
     }
   }

--- a/app/components/settingsAuthentication/settingsAuthenticationController.js
+++ b/app/components/settingsAuthentication/settingsAuthenticationController.js
@@ -78,7 +78,7 @@ function ($q, $scope, Notifications, SettingsService, FileUploadService) {
 
   // Add default port if :port is not defined in URL
   function addLDAPDefaultPort(settings, tlsEnabled) {
-    if (settings.LDAPSettings.URL.indexOf(":") === -1) {      
+    if (settings.LDAPSettings.URL.indexOf(':') === -1) {      
       settings.LDAPSettings.URL += tlsEnabled ? ':636' : ':389';      
     }
   }


### PR DESCRIPTION
As discussed in https://github.com/portainer/portainer/issues/1116 Portainer expect that a port is included in the ldap url to be used for authentication purposes.
![portainer_ldap_port_common_url](https://user-images.githubusercontent.com/30386061/33519202-73c18352-d7a2-11e7-8ff4-1f13e6026bfd.png)
If no port is added, an error will warn us about this issue:
![portainer_ldap_port_not_set](https://user-images.githubusercontent.com/30386061/33519207-9629fc08-d7a2-11e7-9441-b3b265ad48ad.png)
Code in this commit adds a default port to the url if the user forgets to include a port in the LDAP url (hostname or IP address) after a colon. If plain LDAP or StartTLS is used, 389 will be the default port. If TLS is used, 636 port will be the default port.

First test. Adding LDAP url without port, 389 port will be added in the backend. Works fine.
![portainer_ldap_port_not_set_ok](https://user-images.githubusercontent.com/30386061/33519227-15f713b2-d7a3-11e7-9d58-2111190a568b.png)
Second test. Adding LDAP url. Url includes the port (the previous behaviour). Works fine.
![portainer_ldap_port_set_ok](https://user-images.githubusercontent.com/30386061/33519231-4ae231e2-d7a3-11e7-837a-1a869e4d48df.png)
Third test. Adding url for TLS without port. 636 port will be added in the backend. Works fine.
![portainer_ldap_port_tls_not_set_ok](https://user-images.githubusercontent.com/30386061/33519250-8e4d3e7c-d7a3-11e7-9de7-cf8ae957b9b9.png)
Fourth test. Adding url for TLS. Url includes the port  (the previous behaviour). Works fine.
![portainer_ldap_port_tls_set_ok](https://user-images.githubusercontent.com/30386061/33519255-b4c9fe14-d7a3-11e7-980b-0774e016a712.png)

 Close #1116 