### PR TITLE
feat(swarm-visualizer): add ram and cpu info to nodes & limits to tasks

### DIFF
--- a/app/components/swarmVisualizer/swarmVisualizer.html
+++ b/app/components/swarmVisualizer/swarmVisualizer.html
@@ -82,7 +82,7 @@
                 <div>Image: {{ task.Spec.ContainerSpec.Image | hideshasum }}</div>
                 <div>Status: {{ task.Status.State }}</div>
                 <div>Update: {{ task.Updated | getisodate }}</div>
-                <div ng-if="task.Spec.Resources.Limits.MemoryBytes">Memory limit: {{ task.Spec.Resources.Limits.MemoryBytes | humansize: 2 }}</div>
+                <div ng-if="task.Spec.Resources.Limits.MemoryBytes">Memory limit: {{ task.Spec.Resources.Limits.MemoryBytes | humansize: 2:2 }}</div>
                 <div ng-if="task.Spec.Resources.Limits.NanoCPUs">CPU limit: {{ task.Spec.Resources.Limits.NanoCPUs / 1000000000 }}</div>
               </div>
             </div>

--- a/app/components/swarmVisualizer/swarmVisualizer.html
+++ b/app/components/swarmVisualizer/swarmVisualizer.html
@@ -73,6 +73,8 @@
                 </div>
               </div>
               <div>{{ node.Role }}</div>
+              <div>CPU: {{ node.CPUs / 1000000000 }}</div>
+              <div>Memory: {{ node.Memory|humansize: 2 }}</div>
             </div>
             <div class="tasks">
               <div class="task task_{{ task.Status.State | visualizerTask }}" ng-repeat="task in node.Tasks | filter: (state.DisplayOnlyRunningTasks || '') && { Status: { State: 'running' } }">
@@ -80,6 +82,8 @@
                 <div>Image: {{ task.Spec.ContainerSpec.Image | hideshasum }}</div>
                 <div>Status: {{ task.Status.State }}</div>
                 <div>Update: {{ task.Updated | getisodate }}</div>
+                <div ng-if="task.Spec.Resources.Limits.MemoryBytes">Memory limit: {{ task.Spec.Resources.Limits.MemoryBytes | humansize: 2 }}</div>
+                <div ng-if="task.Spec.Resources.Limits.NanoCPUs">CPU limit: {{ task.Spec.Resources.Limits.NanoCPUs / 1000000000 }}</div>
               </div>
             </div>
           </div>

--- a/app/filters/filters.js
+++ b/app/filters/filters.js
@@ -174,12 +174,15 @@ angular.module('portainer.filters', [])
 })
 .filter('humansize', function () {
   'use strict';
-  return function (bytes, round) {
+  return function (bytes, round, base) {
     if (!round) {
       round = 1;
     }
+    if (!base) {
+      base = 10;
+    }
     if (bytes || bytes === 0) {
-      return filesize(bytes, {base: 10, round: round});
+      return filesize(bytes, {base: base, round: round});
     }
   };
 })


### PR DESCRIPTION
Close https://github.com/portainer/portainer/issues/1384 

We add CPU and RAM details to Swarm nodes under the role name.
![portainer_memory_cpu_detail](https://user-images.githubusercontent.com/30386061/33525905-5ec18f38-d838-11e7-8b99-ee2cb6798c92.png)
If we add a memory limit to a service (e.g --limit-memory 128M) that info will be shown for each task below the Update time. Note that 128M in Docker means 128MiB which is the equivalent to 134.22 MB.
![portainer_task_memory_detail](https://user-images.githubusercontent.com/30386061/33525928-d4512434-d838-11e7-8bfd-252db9a2cd01.png)
If we also add a CPU limit (e.g --limit-cpu 0.25) that info will be shown for each task below the memory limit or the update time.
![portainer_task_memory_cpu_detail](https://user-images.githubusercontent.com/30386061/33525938-f76b2d98-d838-11e7-8641-49e5a92a447c.png)
