### PR TITLE
feat(node): add missing task states, set new default state color

### DIFF
--- a/app/filters/filters.js
+++ b/app/filters/filters.js
@@ -55,18 +55,19 @@ angular.module('portainer.filters', [])
   'use strict';
   return function (text) {
     var status = _.toLower(text);
+    var labelStyle = 'default';
     if (includeString(status, ['new', 'allocated', 'assigned', 'accepted', 'preparing', 'ready', 'starting', 'remove'])) {
-      return 'info';
+      labelStyle = 'info';
     } else if (includeString(status, ['pending'])) {
-      return 'warning';
+      labelStyle = 'warning';
     } else if (includeString(status, ['shutdown', 'failed', 'rejected', 'orphaned'])) {
-      return 'danger';
+      labelStyle = 'danger';
     } else if (includeString(status, ['complete'])) {
-      return 'primary';
+      labelStyle = 'primary';
     } else if (includeString(status, ['running'])) {
-      return 'success';
+      labelStyle = 'success';
     }    
-    return 'default';
+    return labelStyle;
   };
 })
 .filter('containerstatusbadge', function () {

--- a/app/filters/filters.js
+++ b/app/filters/filters.js
@@ -55,16 +55,18 @@ angular.module('portainer.filters', [])
   'use strict';
   return function (text) {
     var status = _.toLower(text);
-    if (includeString(status, ['new', 'allocated', 'assigned', 'accepted'])) {
+    if (includeString(status, ['new', 'allocated', 'assigned', 'accepted', 'preparing', 'ready', 'starting', 'remove'])) {
       return 'info';
     } else if (includeString(status, ['pending'])) {
       return 'warning';
-    } else if (includeString(status, ['shutdown', 'failed', 'rejected'])) {
+    } else if (includeString(status, ['shutdown', 'failed', 'rejected', 'orphaned'])) {
       return 'danger';
     } else if (includeString(status, ['complete'])) {
       return 'primary';
-    }
-    return 'success';
+    } else if (includeString(status, ['running'])) {
+      return 'success';
+    }    
+    return 'default';
   };
 })
 .filter('containerstatusbadge', function () {


### PR DESCRIPTION
As discussed in https://github.com/portainer/portainer/issues/766, this code adds missing task states. I've reviewed the tasks listed [here](https://github.com/docker/swarmkit/blob/master/api/types.proto) and explained in the [official docs](https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/).

The following task states have been added and assigned to a css style:
- preparing (info)
- ready (info)
- starting (info)
- remove (info)
- running (success)
- orphaned (danger)

Also, as suggested in the discussion, new states can be added in the future so I've changed the default label from success to the existing default label style (background-color: `#777`) which has a grey color, so users won't assume that a new missing state is ok/green.

Close #766 