### PR TITLE
feat(service): change update delay format to a time string in service…

### DIFF
--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -24,7 +24,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     Parallelism: 1,
     PlacementConstraints: [],
     PlacementPreferences: [],
-    UpdateDelay: 0,
+    UpdateDelay: '0s',
     UpdateOrder: 'stop-first',
     FailureAction: 'pause',
     Secrets: [],
@@ -243,7 +243,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
   function prepareUpdateConfig(config, input) {
     config.UpdateConfig = {
       Parallelism: input.Parallelism || 0,
-      Delay: input.UpdateDelay * 1000000000 || 0,
+      Delay: ServiceHelper.translateHumanDurationToNanos(input.UpdateDelay),
       FailureAction: input.FailureAction,
       Order: input.UpdateOrder
     };

--- a/app/components/createService/createservice.html
+++ b/app/components/createService/createservice.html
@@ -389,13 +389,16 @@
               <!-- !parallelism-input -->
               <!-- delay-input -->
               <div class="form-group">
-                <label for="update-delay" class="col-sm-3 col-lg-1 control-label text-left">Delay</label>
+                <label for="update-delay" class="col-sm-3 col-lg-1 control-label text-left">
+                  Delay
+                  <portainer-tooltip position="bottom" message="Supported format examples: 1h, 5m, 10s, 1000ms, 15us, 60ns."></portainer-tooltip>
+                </label>                
                 <div class="col-sm-4 col-lg-3">
-                  <input type="number" class="form-control" ng-model="formValues.UpdateDelay" id="update-delay" placeholder="e.g. 10">
+                  <input type="text" class="form-control" ng-model="formValues.UpdateDelay" id="update-delay" placeholder="e.g. 1m" ng-pattern="/^([0-9]+)(h|m|s|ms|us|ns)$/i">
                 </div>
                 <div class="col-sm-5">
                   <p class="small text-muted">
-                    Amount of time between updates. Time in seconds.
+                    Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h) e.g: 1m.
                   </p>
                 </div>
               </div>

--- a/app/components/createService/createservice.html
+++ b/app/components/createService/createservice.html
@@ -398,7 +398,7 @@
                 </div>
                 <div class="col-sm-5">
                   <p class="small text-muted">
-                    Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h) e.g: 1m.
+                    Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h). Example: 1m.
                   </p>
                 </div>
               </div>

--- a/app/components/service/includes/updateconfig.html
+++ b/app/components/service/includes/updateconfig.html
@@ -19,11 +19,11 @@
           <tr>
             <td>Update Delay</td>
             <td>
-              <input class="input-sm" type="number" ng-model="service.UpdateDelay" ng-change="updateServiceAttribute(service, 'UpdateDelay')" ng-disabled="isUpdating"/>
+              <input class="input-sm" type="text" ng-model="service.UpdateDelay" ng-change="updateServiceAttribute(service, 'UpdateDelay')" ng-pattern="/^([0-9]+)(h|m|s|ms|us|ns)$/i" ng-disabled="isUpdating"/>
             </td>
             <td>
               <p class="small text-muted" style="margin-top: 10px;">
-                Amount of time between updates. Time in seconds.
+                Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h) e.g: 1m.
               </p>
             </td>
           </tr>

--- a/app/components/service/includes/updateconfig.html
+++ b/app/components/service/includes/updateconfig.html
@@ -23,7 +23,7 @@
             </td>
             <td>
               <p class="small text-muted" style="margin-top: 10px;">
-                Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h) e.g: 1m.
+                Amount of time between updates expressed by a number followed by unit (ns|us|ms|s|m|h). Example: 1m.
               </p>
             </td>
           </tr>

--- a/app/components/service/serviceController.js
+++ b/app/components/service/serviceController.js
@@ -244,7 +244,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
 
     config.UpdateConfig = {
       Parallelism: service.UpdateParallelism,
-      Delay: service.UpdateDelay * 1000000000,
+      Delay: ServiceHelper.translateHumanDurationToNanos(service.UpdateDelay),
       FailureAction: service.UpdateFailureAction,
       Order: service.UpdateOrder
     };
@@ -324,7 +324,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   function transformDurations(service) {
     service.RestartDelay = service.RestartDelay / 1000000000 || 5;
     service.RestartWindow = service.RestartWindow / 1000000000 || 0;
-    service.UpdateDelay = service.UpdateDelay / 1000000000 || 0;
+    service.UpdateDelay = ServiceHelper.translateNanosToHumanDuration(service.UpdateDelay) || '0s';
   }
 
   function initView() {

--- a/app/helpers/serviceHelper.js
+++ b/app/helpers/serviceHelper.js
@@ -141,5 +141,55 @@ angular.module('portainer.helpers').factory('ServiceHelper', [function ServiceHe
     }
   };
 
+  helper.translateHumanDurationToNanos = function(humanDuration) {    
+    var nanos = 0;
+    var regex = /^([0-9]+)(h|m|s|ms|us|ns)$/i;
+    var matches = humanDuration.match(regex);
+
+    if (matches !== null && matches.length === 3) {
+      var duration = parseInt(matches[1], 10);
+      var unit = matches[2];      
+      // Moment.js cannot use micro or nanoseconds
+      switch (unit) {
+        case 'ns': 
+          nanos = duration;
+          break;
+        case 'us':
+          nanos = duration * 1000;
+          break;
+        default:
+          nanos = moment.duration(duration, unit).asMilliseconds() * 1000000;
+      }      
+    }
+    return nanos;
+  };
+
+  // Convert nanoseconds to the higher unit possible
+  // e.g 1840 nanoseconds = 1804ns
+  // e.g 300000000000 nanoseconds = 5m
+  // e.g 3510000000000 nanoseconds = 3510s
+  // e.g 3540000000000 nanoseconds = 59m
+  // e.g 3600000000000 nanoseconds = 1h
+
+  helper.translateNanosToHumanDuration = function(nanos) {          
+    var humanDuration = '0s';
+    
+    var conversionFromNano = {};
+    conversionFromNano['ns'] = 1;
+    conversionFromNano['us'] = conversionFromNano['ns'] * 1000;
+    conversionFromNano['ms'] = conversionFromNano['us'] * 1000;
+    conversionFromNano['s'] = conversionFromNano['ms'] * 1000;
+    conversionFromNano['m'] = conversionFromNano['s'] * 60;
+    conversionFromNano['h'] = conversionFromNano['m'] * 60;
+    
+    Object.keys(conversionFromNano).forEach(function(unit) {  
+      if ( nanos % conversionFromNano[unit] === 0 && (nanos / conversionFromNano[unit]) > 0) {
+        humanDuration = (nanos / conversionFromNano[unit]) + unit;
+      }
+    });
+    
+    return humanDuration;
+  };
+
   return helper;
 }]);


### PR DESCRIPTION
Close https://github.com/portainer/portainer/issues/825

Currently, the UpdateConfig Delay value expects a number of seconds.
![current_update_delay_in_seconds](https://user-images.githubusercontent.com/30386061/33614261-21114a7a-d9d7-11e7-8c7c-9700d6b3dcc3.png)

With the new suggested code, the Update config tab shows a default 0s value when we create a service. 
![default_0s](https://user-images.githubusercontent.com/30386061/33614028-79d7a6e6-d9d6-11e7-84c3-af0192351d29.png)

A tooltip shows some examples about the supported format and a new description message has been added.
![tooltip](https://user-images.githubusercontent.com/30386061/33614046-89e853c8-d9d6-11e7-9f3a-c9348981a33e.png)
![new_update_delay_message](https://user-images.githubusercontent.com/30386061/33614056-90c55146-d9d6-11e7-9f97-d744226815e8.png)

If we don't set any value for the Update config, the UpdateConfig.Delay value has no value set as we can check in the CLI.
![default_cli_0s](https://user-images.githubusercontent.com/30386061/33614069-965af282-d9d6-11e7-954a-9b577b73c21e.png)

If we try to update a service that has no value for the UpdateConfig delay, we'll see that 0s is used as default.
![default_0_update](https://user-images.githubusercontent.com/30386061/33614081-9d713518-d9d6-11e7-9400-a8726d85c744.png)

We can use a new value e.g 1h and update the service.
![updated_1h_ui](https://user-images.githubusercontent.com/30386061/33614413-9c45b9ce-d9d7-11e7-9720-63555846a299.png)

The CLI shows the new value 3600000000000 in nanoseconds.
![updated_1h](https://user-images.githubusercontent.com/30386061/33614194-ef4c6722-d9d6-11e7-8fb0-f1430ddfbcff.png)

We can create a new service and use a value like 50m = 3000000000000 nanos.
![new_service_50m](https://user-images.githubusercontent.com/30386061/33614200-f3c6cf36-d9d6-11e7-95fd-51bdb87a495e.png)

If we try to edit the service we'll see the nanoseconds transformed in the higher unit available 50m in this case.
![new_service_50m_edit](https://user-images.githubusercontent.com/30386061/33614209-f825372a-d9d6-11e7-8c49-5a0f0f63216d.png)

We can check in the CLI that the UpdateConfig delay value shows 3000000000000 nanos.
![new_service_50m_cli](https://user-images.githubusercontent.com/30386061/33614231-045c597e-d9d7-11e7-912e-8d53cf97cd83.png)

The Update Delay input box has changed from a number input field to a text field, where a ng-pattern has been added so we expect a number followed by the unit.

The acceptable unit values are specified in [Docker docs](https://docs.docker.com/engine/reference/commandline/service_update/#examples).

The moment.js library has been used for one of the helper functions.

If this behavior is acceptable, changes can be applied to the restart delay value.