### PR TITLE
feat(service): add logging driver config in service create/update

### DIFF
--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -492,11 +492,9 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
       $scope.availableVolumes = data.volumes;
       $scope.availableNetworks = data.networks;
       $scope.availableSecrets = data.secrets;
-      $scope.availableConfigs = data.configs;
-      var nodes = data.nodes;
-      initSlidersMaxValuesBasedOnNodeData(nodes);
-      var settings = data.settings;
-      $scope.allowBindMounts = settings.AllowBindMountsForRegularUsers;
+      $scope.availableConfigs = data.configs;      
+      initSlidersMaxValuesBasedOnNodeData(data.nodes);      
+      $scope.allowBindMounts = data.settings.AllowBindMountsForRegularUsers;
       var userDetails = Authentication.getUserDetails();
       $scope.isAdmin = userDetails.role === 1;
       retrieveLoggingDrivers(apiVersion);

--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -494,7 +494,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
 
   function initView() {
     var apiVersion = $scope.applicationState.endpoint.apiVersion;
-    var provider = $scope.applicationState.endpoint.mode.provider;   
+    var provider = $scope.applicationState.endpoint.mode.provider;
 
     $q.all({
       volumes: VolumeService.volumes(),
@@ -514,7 +514,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
       initSlidersMaxValuesBasedOnNodeData(data.nodes);      
       $scope.allowBindMounts = data.settings.AllowBindMountsForRegularUsers;
       var userDetails = Authentication.getUserDetails();
-      $scope.isAdmin = userDetails.role === 1;      
+      $scope.isAdmin = userDetails.role === 1;
     })
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to initialize view');

--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -466,10 +466,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     }
   }
 
-  function initView() {
-    var apiVersion = $scope.applicationState.endpoint.apiVersion;
-    var provider = $scope.applicationState.endpoint.mode.provider;
-
+  function retrieveLoggingDrivers(apiVersion) {
     PluginService.loggingPlugins(apiVersion < 1.25)
     .then(function success(data){
         $scope.availableLoggingDrivers = data;
@@ -477,6 +474,11 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to retrieve logging drivers');
     });    
+  }
+
+  function initView() {
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;
+    var provider = $scope.applicationState.endpoint.mode.provider;   
 
     $q.all({
       volumes: VolumeService.volumes(),
@@ -497,6 +499,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
       $scope.allowBindMounts = settings.AllowBindMountsForRegularUsers;
       var userDetails = Authentication.getUserDetails();
       $scope.isAdmin = userDetails.role === 1;
+      retrieveLoggingDrivers(apiVersion);
     })
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to initialize view');

--- a/app/components/createService/createServiceController.js
+++ b/app/components/createService/createServiceController.js
@@ -492,16 +492,6 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     }
   }
 
-  function retrieveLoggingDrivers(apiVersion) {
-    PluginService.loggingPlugins(apiVersion < 1.25)
-    .then(function success(data){
-        $scope.availableLoggingDrivers = data;
-    })
-    .catch(function error(err) {
-      Notifications.error('Failure', err, 'Unable to retrieve logging drivers');
-    });    
-  }
-
   function initView() {
     var apiVersion = $scope.applicationState.endpoint.apiVersion;
     var provider = $scope.applicationState.endpoint.mode.provider;   
@@ -512,18 +502,19 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
       secrets: apiVersion >= 1.25 ? SecretService.secrets() : [],
       configs: apiVersion >= 1.30 ? ConfigService.configs() : [],
       nodes: NodeService.nodes(),
-      settings: SettingsService.publicSettings()
+      settings: SettingsService.publicSettings(),
+      availableLoggingDrivers: PluginService.loggingPlugins(apiVersion < 1.25)
     })
     .then(function success(data) {
       $scope.availableVolumes = data.volumes;
       $scope.availableNetworks = data.networks;
       $scope.availableSecrets = data.secrets;
       $scope.availableConfigs = data.configs;      
+      $scope.availableLoggingDrivers = data.availableLoggingDrivers;
       initSlidersMaxValuesBasedOnNodeData(data.nodes);      
       $scope.allowBindMounts = data.settings.AllowBindMountsForRegularUsers;
       var userDetails = Authentication.getUserDetails();
-      $scope.isAdmin = userDetails.role === 1;
-      retrieveLoggingDrivers(apiVersion);
+      $scope.isAdmin = userDetails.role === 1;      
     })
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to initialize view');

--- a/app/components/createService/createservice.html
+++ b/app/components/createService/createservice.html
@@ -126,7 +126,7 @@
     <rd-widget>
       <rd-widget-body>
         <ul class="nav nav-pills nav-justified">
-          <li class="active interactive"><a data-target="#command" data-toggle="tab">Command</a></li>
+          <li class="active interactive"><a data-target="#command" data-toggle="tab">Command & Logging</a></li>
           <li class="interactive"><a data-target="#volumes" data-toggle="tab">Volumes</a></li>
           <li class="interactive"><a data-target="#network" data-toggle="tab">Network</a></li>
           <li class="interactive"><a data-target="#labels" data-toggle="tab">Labels</a></li>
@@ -140,6 +140,9 @@
           <!-- tab-command -->
           <div class="tab-pane active" id="command">
             <form class="form-horizontal" style="margin-top: 15px;">
+              <div class="col-sm-12 form-section-title">
+                Command
+              </div>                    
               <!-- command-input -->
               <div class="form-group">
                 <label for="service_command" class="col-sm-2 col-lg-1 control-label text-left">Command</label>
@@ -195,6 +198,59 @@
                 <!-- !environment-variable-input-list -->
               </div>
               <!-- !environment-variables -->
+
+              <div class="col-sm-12 form-section-title">
+                Logging
+              </div>
+              <!-- logging-driver -->              
+              <div class="form-group">
+                <label for="log-driver" class="col-sm-2 col-lg-1 control-label text-left">Driver</label>
+                <div class="col-sm-4">
+                  <select class="form-control" ng-model="formValues.LogDriverName" id="log-driver">
+                    <option selected value="">Default logging driver</option>                    
+                    <option ng-repeat="driver in availableLoggingDrivers" ng-value="driver">{{ driver }}</option>
+                    <option value="none">none</option>
+                  </select>
+                </div>
+                <div class="col-sm-5">
+                  <p class="small text-muted">
+                    Logging driver for service that will override the default docker daemon driver. Select Default logging driver if you don't want to override it. Supported logging drivers can be found <a href="https://docs.docker.com/engine/admin/logging/overview/#supported-logging-drivers" target="_blank">in the Docker documentation</a>.
+                  </p>
+                </div>
+              </div>
+              <!-- !logging-driver -->
+              <!-- logging-opts -->
+              <div class="form-group">
+                <div class="col-sm-12" style="margin-top: 5px;">
+                  <label class="control-label text-left">
+                    Options
+                    <portainer-tooltip position="top" message="Add button is disabled unless a driver other than none or default is selected. Options are specific to the selected driver, refer to the driver documentation."></portainer-tooltip>
+                  </label>
+                  <span class="label label-default interactive" style="margin-left: 10px;" ng-click="!formValues.LogDriverName || formValues.LogDriverName === 'none' || addLogDriverOpt(formValues.LogDriverName)">
+                    <i class="fa fa-plus-circle" aria-hidden="true"></i> add logging driver option
+                  </span>
+                </div>
+                <!-- logging-opts-input-list -->
+                <div class="col-sm-12 form-inline" style="margin-top: 10px;">
+                  <div ng-repeat="opt in formValues.LogDriverOpts" style="margin-top: 2px;">
+                    <div class="input-group col-sm-5 input-group-sm">
+                      <span class="input-group-addon">option</span>
+                      <input type="text" class="form-control" ng-model="opt.name" placeholder="e.g. FOO">
+                    </div>
+                    <div class="input-group col-sm-5 input-group-sm">
+                      <span class="input-group-addon">value</span>
+                      <input type="text" class="form-control" ng-model="opt.value" placeholder="e.g. bar">
+                    </div>
+                    <button class="btn btn-sm btn-danger" type="button" ng-click="removeLogDriverOpt($index)">
+                      <i class="fa fa-trash" aria-hidden="true"></i>
+                    </button>
+                  </div>
+                </div>
+                <!-- logging-opts-input-list -->
+              </div>              
+              <!-- !logging-opts -->
+                                        
+                  
             </form>
           </div>
           <!-- !tab-command -->

--- a/app/components/service/includes/logging.html
+++ b/app/components/service/includes/logging.html
@@ -1,0 +1,65 @@
+<div id="service-logging-driver">
+    <rd-widget>
+      <rd-widget-header icon="fa-tasks" title="Logging driver">        
+      </rd-widget-header>      
+      <rd-widget-body classes="no-padding">
+        <div class="form-inline" style="padding: 10px;">
+          Driver:
+          <select class="form-control" ng-model="service.LogDriverName" ng-change="updateLogDriverName(service)" ng-disabled="isUpdating">
+            <option selected value="">Default logging driver</option>  
+            <option ng-repeat="driver in availableLoggingDrivers" ng-value="driver">{{ driver }}</option>                              
+            <option value="none">none</option>
+          </select>
+          <a class="btn btn-default btn-sm" ng-click="!service.LogDriverName || service.LogDriverName === 'none' || addLogDriverOpt(service)">
+            <i class="fa fa-plus-circle" aria-hidden="true"></i> add logging driver option
+          </a>
+        </div>
+        <table class="table" >
+          <thead>
+            <tr>
+              <th>Option</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="option in service.LogDriverOpts">
+              <td>
+                <div class="input-group input-group-sm">
+                  <span class="input-group-addon fit-text-size">name</span>
+                  <input type="text" class="form-control" ng-model="option.key" ng-disabled="option.added || isUpdating" placeholder="e.g. FOO">
+                </div>
+              </td>
+              <td>
+                <div class="input-group input-group-sm">
+                  <span class="input-group-addon fit-text-size">value</span>
+                  <input type="text" class="form-control" ng-model="option.value" ng-change="updateLogDriverOpt(service, option)" placeholder="e.g. bar" ng-disabled="isUpdating">
+                  <span class="input-group-btn">
+                    <button class="btn btn-sm btn-danger" type="button" ng-click="removeLogDriverOpt(service, $index)" ng-disabled="isUpdating">
+                      <i class="fa fa-trash" aria-hidden="true"></i>
+                    </button>
+                  </span>
+                </div>
+              </td>
+            </tr>
+            <tr ng-if="service.LogDriverOpts.length === 0">
+                <td colspan="6" class="text-center text-muted">No options associated to this logging driver.</td>
+              </tr>
+          </tbody>
+        </table>
+      </rd-widget-body>
+      <rd-widget-footer>
+        <div class="btn-toolbar" role="toolbar">
+          <div class="btn-group" role="group">
+            <button type="button" class="btn btn-primary btn-sm" ng-disabled="!hasChanges(service, ['LogDriverName', 'LogDriverOpts'])" ng-click="updateService(service)">Apply changes</button>
+            <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a ng-click="cancelChanges(service, ['LogDriverName', 'LogDriverOpts'])">Reset changes</a></li>
+              <li><a ng-click="cancelChanges(service)">Reset all changes</a></li>
+            </ul>
+          </div>
+        </div>
+      </rd-widget-footer>
+    </rd-widget>
+  </div>

--- a/app/components/service/service.html
+++ b/app/components/service/service.html
@@ -116,6 +116,7 @@
           <li ng-if="applicationState.endpoint.apiVersion >= 1.30"><a href ng-click="goToItem('service-placement-preferences')">Placement preferences</a></li>
           <li><a href ng-click="goToItem('service-restart-policy')">Restart policy</a></li>
           <li><a href ng-click="goToItem('service-update-config')">Update configuration</a></li>
+          <li><a href ng-click="goToItem('service-logging')">Logging</a></li>
           <li><a href ng-click="goToItem('service-labels')">Service labels</a></li>
           <li><a href ng-click="goToItem('service-configs')">Configs</a></li>
           <li ng-if="applicationState.endpoint.apiVersion >= 1.25"><a href ng-click="goToItem('service-secrets')">Secrets</a></li>
@@ -164,6 +165,7 @@
     <div id="service-placement-preferences" ng-if="applicationState.endpoint.apiVersion >= 1.30" class="padding-top" ng-include="'app/components/service/includes/placementPreferences.html'"></div>
     <div id="service-restart-policy" class="padding-top" ng-include="'app/components/service/includes/restart.html'"></div>
     <div id="service-update-config" class="padding-top" ng-include="'app/components/service/includes/updateconfig.html'"></div>
+    <div id="service-logging" class="padding-top" ng-include="'app/components/service/includes/logging.html'"></div>
     <div id="service-labels" class="padding-top" ng-include="'app/components/service/includes/servicelabels.html'"></div>
     <div id="service-configs" class="padding-top" ng-include="'app/components/service/includes/configs.html'"></div>
     <div id="service-secrets" ng-if="applicationState.endpoint.apiVersion >= 1.25" class="padding-top" ng-include="'app/components/service/includes/secrets.html'"></div>

--- a/app/components/service/serviceController.js
+++ b/app/components/service/serviceController.js
@@ -365,15 +365,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   }
 
   function initView() {
-    var apiVersion = $scope.applicationState.endpoint.apiVersion;
-
-    PluginService.loggingPlugins(apiVersion < 1.25)
-    .then(function success(data){
-        $scope.availableLoggingDrivers = data;
-    })
-    .catch(function error(err) {
-      Notifications.error('Failure', err, 'Unable to retrieve logging drivers');
-    });        
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;  
 
     ServiceService.service($transition$.params().id)
     .then(function success(data) {
@@ -394,7 +386,8 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
         nodes: NodeService.nodes(),
         secrets: apiVersion >= 1.25 ? SecretService.secrets() : [],
         configs: apiVersion >= 1.30 ? ConfigService.configs() : [],
-        availableImages: ImageService.images()
+        availableImages: ImageService.images(),
+        availableLoggingDrivers: PluginService.loggingPlugins(apiVersion < 1.25)
       });
     })
     .then(function success(data) {
@@ -403,6 +396,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       $scope.configs = data.configs;
       $scope.secrets = data.secrets;
       $scope.availableImages = ImageService.getUniqueTagListFromImages(data.availableImages);
+      $scope.availableLoggingDrivers = data.availableLoggingDrivers;
 
       // Set max cpu value
       var maxCpus = 0;

--- a/app/components/service/serviceController.js
+++ b/app/components/service/serviceController.js
@@ -412,7 +412,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       }
 
       // Default values
-      $scope.state.addSecret = {override: false};      
+      $scope.state.addSecret = {override: false};
 
       $timeout(function() {
         $anchorScroll();

--- a/app/helpers/serviceHelper.js
+++ b/app/helpers/serviceHelper.js
@@ -191,5 +191,33 @@ angular.module('portainer.helpers').factory('ServiceHelper', [function ServiceHe
     return humanDuration;
   };
 
+  helper.translateLogDriverOptsToKeyValue = function(logOptions) {
+    var options = [];
+    if (logOptions) {      
+      Object.keys(logOptions).forEach(function(key) {
+        options.push({
+          key: key,
+          value: logOptions[key],
+          originalKey: key,
+          originalValue: logOptions[key],
+          added: true
+        });
+      });            
+    }
+    return options;
+  };
+
+  helper.translateKeyValueToLogDriverOpts = function(keyValueLogDriverOpts) {
+    var options = {};
+    if (keyValueLogDriverOpts) {      
+      keyValueLogDriverOpts.forEach(function(option) {
+        if (option.key && option.key !== '' && option.value && option.value !== '') {
+          options[option.key] = option.value;
+        }
+      });
+    }
+    return options;    
+  };    
+
   return helper;
 }]);

--- a/app/helpers/serviceHelper.js
+++ b/app/helpers/serviceHelper.js
@@ -172,8 +172,7 @@ angular.module('portainer.helpers').factory('ServiceHelper', [function ServiceHe
   // e.g 3600000000000 nanoseconds = 1h
 
   helper.translateNanosToHumanDuration = function(nanos) {          
-    var humanDuration = '0s';
-    
+    var humanDuration = '0s';    
     var conversionFromNano = {};
     conversionFromNano['ns'] = 1;
     conversionFromNano['us'] = conversionFromNano['ns'] * 1000;
@@ -186,8 +185,7 @@ angular.module('portainer.helpers').factory('ServiceHelper', [function ServiceHe
       if ( nanos % conversionFromNano[unit] === 0 && (nanos / conversionFromNano[unit]) > 0) {
         humanDuration = (nanos / conversionFromNano[unit]) + unit;
       }
-    });
-    
+    });    
     return humanDuration;
   };
 

--- a/app/models/docker/service.js
+++ b/app/models/docker/service.js
@@ -41,6 +41,15 @@ function ServiceViewModel(data, runningTasks, allTasks, nodes) {
     this.RestartMaxAttempts = 0;
     this.RestartWindow = 0;
   }
+
+  if (data.Spec.TaskTemplate.LogDriver) {
+    this.LogDriverName = data.Spec.TaskTemplate.LogDriver.Name || '';
+    this.LogDriverOpts = data.Spec.TaskTemplate.LogDriver.Options || [];
+  } else {
+    this.LogDriverName = '';
+    this.LogDriverOpts = [];
+  }
+    
   this.Constraints = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Constraints || [] : [];
   this.Preferences = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Preferences || [] : [];
   this.Platforms = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Platforms || [] : [];

--- a/app/services/docker/pluginService.js
+++ b/app/services/docker/pluginService.js
@@ -60,5 +60,9 @@ angular.module('portainer.services')
     return servicePlugins(systemOnly, 'Network', 'docker.networkdriver/1.0');
   };
 
+  service.loggingPlugins = function(systemOnly) {
+    return servicePlugins(systemOnly, 'Log', 'docker.logdriver/1.0');
+  };
+
   return service;
 }]);

--- a/app/services/docker/pluginService.js
+++ b/app/services/docker/pluginService.js
@@ -61,7 +61,15 @@ angular.module('portainer.services')
   };
 
   service.loggingPlugins = function(systemOnly) {
-    return servicePlugins(systemOnly, 'Log', 'docker.logdriver/1.0');
+    var deferred = $q.defer();
+    servicePlugins(systemOnly, 'Log', 'docker.logdriver/1.0')    
+    .then(function success(data){    
+      deferred.resolve(data);
+    })
+    .catch(function error(err) {
+      deferred.reject({ msg: 'Unable to retrieve logging drivers', err: err });
+    });    
+    return deferred.promise;
   };
 
   return service;

--- a/app/services/docker/pluginService.js
+++ b/app/services/docker/pluginService.js
@@ -61,15 +61,7 @@ angular.module('portainer.services')
   };
 
   service.loggingPlugins = function(systemOnly) {
-    var deferred = $q.defer();
-    servicePlugins(systemOnly, 'Log', 'docker.logdriver/1.0')    
-    .then(function success(data){    
-      deferred.resolve(data);
-    })
-    .catch(function error(err) {
-      deferred.reject({ msg: 'Unable to retrieve logging drivers', err: err });
-    });    
-    return deferred.promise;
+    return servicePlugins(systemOnly, 'Log', 'docker.logdriver/1.0');        
   };
 
   return service;


### PR DESCRIPTION
Close #1131

The Command tab is renamed Command & Logging. A new section called Logging is added where the user can select a logging driver from a dropdown menu. The dropdown menu is populated with the logging plugins retrieved from Docker and two more values are added: none and Default logging driver. 

![new_option](https://user-images.githubusercontent.com/30386061/34155289-054ce3ca-e4b9-11e7-9d58-b0709efa65b1.png)

Default logging driver is the default value which will be ignored if selected as it means that the default docker daemon logging options are used. 

The add logging driver button will not work unless a driver other than none or the default driver is selected.

If a driver is selected, we can add options to the logging driver. Options will be ignored if none is the selected driver. For example with json-file we can add the max-file and max-size options.
![create_service_with_logging_opts](https://user-images.githubusercontent.com/30386061/34155301-17b79320-e4b9-11e7-8bac-639c5881e537.png)

Once we create the service we can inspect it and find the logging driver configuration.
![docker_service_inspect](https://user-images.githubusercontent.com/30386061/34155323-315b23be-e4b9-11e7-8d84-f7af8165b7b0.png)

In the same way, we can add a logging driver configuration when we edit a service. We have now a quick menu entry for logging.
![logging_quick_menu](https://user-images.githubusercontent.com/30386061/34155331-3749cd52-e4b9-11e7-97af-0d1d8f87ed47.png)

User has a dropdown where she can select the right driver. If no driver was selected when the service was created Default loggingd driver will be the selected value and in this case the LogDriver attribute will be set to null. If a driver was selected, it will be displayed as the selected driver in the dropdown meny. Also if logging driver options were specified they will be listed in a table.
![edit_service_existing_driver_and_options](https://user-images.githubusercontent.com/30386061/34155346-42101642-e4b9-11e7-8e1d-72c2f9a4f86b.png)

In the following example the service has no logging driver and no logging driver options.
![edit_service_nologging_no_opts](https://user-images.githubusercontent.com/30386061/34155363-4919c92e-e4b9-11e7-9288-9b68e87a3c61.png)

If I edit the max-file option from 3 to 5 and save the service we can check that the edited value has been updated.
![edit_service_update_log_driver_opt](https://user-images.githubusercontent.com/30386061/34155366-4d62a050-e4b9-11e7-8d2a-fd8794fd7a3b.png)

If I remove the max-file option the option is removed from the service.
![edit_service_remove_log_driver_opt](https://user-images.githubusercontent.com/30386061/34155371-5190d50c-e4b9-11e7-92ea-c610abc69f76.png)
