### PR TITLE
fix(cache): add a cache validity mechanism

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -11,4 +11,5 @@ angular.module('portainer')
 .constant('API_ENDPOINT_TEAM_MEMBERSHIPS', 'api/team_memberships')
 .constant('API_ENDPOINT_TEMPLATES', 'api/templates')
 .constant('DEFAULT_TEMPLATES_URL', 'https://raw.githubusercontent.com/portainer/templates/master/templates.json')
-.constant('PAGINATION_MAX_ITEMS', 10);
+.constant('PAGINATION_MAX_ITEMS', 10)
+.constant('APPLICATION_CACHE_VALIDITY', 3600);

--- a/app/services/stateManager.js
+++ b/app/services/stateManager.js
@@ -1,5 +1,5 @@
 angular.module('portainer.services')
-.factory('StateManager', ['$q', 'SystemService', 'InfoHelper', 'LocalStorage', 'SettingsService', 'StatusService', function StateManagerFactory($q, SystemService, InfoHelper, LocalStorage, SettingsService, StatusService) {
+.factory('StateManager', ['$q', 'SystemService', 'InfoHelper', 'LocalStorage', 'SettingsService', 'StatusService', 'APPLICATION_CACHE_VALIDITY', function StateManagerFactory($q, SystemService, InfoHelper, LocalStorage, SettingsService, StatusService, APPLICATION_CACHE_VALIDITY) {
   'use strict';
 
   var manager = {};
@@ -34,6 +34,37 @@ angular.module('portainer.services')
     LocalStorage.storeApplicationState(state.application);
   };
 
+  function loadApplicationState() {
+    var deferred = $q.defer();
+
+    $q.all({
+      settings: SettingsService.publicSettings(),
+      status: StatusService.status()
+    })
+    .then(function success(data) {
+      var status = data.status;
+      var settings = data.settings;
+      state.application.authentication = status.Authentication;
+      state.application.analytics = status.Analytics;
+      state.application.endpointManagement = status.EndpointManagement;
+      state.application.version = status.Version;
+      state.application.logo = settings.LogoURL;
+      state.application.displayDonationHeader = settings.DisplayDonationHeader;
+      state.application.displayExternalContributors = settings.DisplayExternalContributors;
+      state.application.validity = moment().unix();
+      LocalStorage.storeApplicationState(state.application);
+      deferred.resolve(state);
+    })
+    .catch(function error(err) {
+      deferred.reject({msg: 'Unable to retrieve server settings and status', err: err});
+    })
+    .finally(function final() {
+      state.loading = false;
+    });
+
+    return deferred.promise;
+  }
+
   manager.initialize = function () {
     var deferred = $q.defer();
 
@@ -44,32 +75,28 @@ angular.module('portainer.services')
 
     var applicationState = LocalStorage.getApplicationState();
     if (applicationState) {
-      state.application = applicationState;
-      state.loading = false;
-      deferred.resolve(state);
+      var now = moment().unix();
+      var cacheValidity = now - applicationState.validity;
+      if (cacheValidity > APPLICATION_CACHE_VALIDITY) {
+        loadApplicationState()
+        .then(function success(data) {
+          deferred.resolve(state);
+        })
+        .catch(function error(err) {
+          deferred.reject(err);
+        });
+      } else {
+        state.application = applicationState;
+        state.loading = false;
+        deferred.resolve(state);
+      }
     } else {
-      $q.all({
-        settings: SettingsService.publicSettings(),
-        status: StatusService.status()
-      })
+      loadApplicationState()
       .then(function success(data) {
-        var status = data.status;
-        var settings = data.settings;
-        state.application.authentication = status.Authentication;
-        state.application.analytics = status.Analytics;
-        state.application.endpointManagement = status.EndpointManagement;
-        state.application.version = status.Version;
-        state.application.logo = settings.LogoURL;
-        state.application.displayDonationHeader = settings.DisplayDonationHeader;
-        state.application.displayExternalContributors = settings.DisplayExternalContributors;
-        LocalStorage.storeApplicationState(state.application);
         deferred.resolve(state);
       })
       .catch(function error(err) {
-        deferred.reject({msg: 'Unable to retrieve server settings and status', err: err});
-      })
-      .finally(function final() {
-        state.loading = false;
+        deferred.reject(err);
       });
     }
 

--- a/app/services/stateManager.js
+++ b/app/services/stateManager.js
@@ -34,6 +34,18 @@ angular.module('portainer.services')
     LocalStorage.storeApplicationState(state.application);
   };
 
+
+ function assignStateFromStatusAndSettings(status, settings) {
+   state.application.authentication = status.Authentication;
+   state.application.analytics = status.Analytics;
+   state.application.endpointManagement = status.EndpointManagement;
+   state.application.version = status.Version;
+   state.application.logo = settings.LogoURL;
+   state.application.displayDonationHeader = settings.DisplayDonationHeader;
+   state.application.displayExternalContributors = settings.DisplayExternalContributors;
+   state.application.validity = moment().unix();
+ }
+
   function loadApplicationState() {
     var deferred = $q.defer();
 
@@ -44,14 +56,7 @@ angular.module('portainer.services')
     .then(function success(data) {
       var status = data.status;
       var settings = data.settings;
-      state.application.authentication = status.Authentication;
-      state.application.analytics = status.Analytics;
-      state.application.endpointManagement = status.EndpointManagement;
-      state.application.version = status.Version;
-      state.application.logo = settings.LogoURL;
-      state.application.displayDonationHeader = settings.DisplayDonationHeader;
-      state.application.displayExternalContributors = settings.DisplayExternalContributors;
-      state.application.validity = moment().unix();
+      assignStateFromStatusAndSettings(status, settings);
       LocalStorage.storeApplicationState(state.application);
       deferred.resolve(state);
     })


### PR DESCRIPTION
This PR introduces a cache validity check for the application state. Application state will now be cached for one hour max before being reloaded.

Fix #1258 