### PR TITLE
feat(service): add force update in service list/detail

### DIFF
--- a/app/components/service/service.html
+++ b/app/components/service/service.html
@@ -38,6 +38,7 @@
               <td>ID</td>
               <td>
                 {{ service.Id }}
+                <button class="btn btn-xs btn-primary" ng-click="forceUpdateService(service)"><i class="fa fa-refresh space-right" aria-hidden="true" ng-disabled="isUpdating" ng-if="applicationState.endpoint.apiVersion >= 1.25"></i>Force update this service</button>
                 <button class="btn btn-xs btn-danger" ng-click="removeService()"><i class="fa fa-trash space-right" aria-hidden="true" ng-disabled="isUpdating"></i>Delete this service</button>
               </td>
             </tr>

--- a/app/components/service/serviceController.js
+++ b/app/components/service/serviceController.js
@@ -168,7 +168,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     }
   };
 
-  $scope.addLogDriverOpt = function addLogDriverOpt(service) {    
+  $scope.addLogDriverOpt = function addLogDriverOpt(service) {
     service.LogDriverOpts.push({ key: '', value: '', originalValue: '' });
     updateServiceArray(service, 'LogDriverOpts', service.LogDriverOpts);
   };
@@ -182,16 +182,16 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     if (variable.value !== variable.originalValue || variable.key !== variable.originalKey) {
       updateServiceArray(service, 'LogDriverOpts', service.LogDriverOpts);
     }
-  };   
-  $scope.updateLogDriverName = function updateLogDriverName(service) {    
-    updateServiceArray(service, 'LogDriverName', service.LogDriverName);    
-  };    
+  };
+  $scope.updateLogDriverName = function updateLogDriverName(service) {
+    updateServiceArray(service, 'LogDriverName', service.LogDriverName);
+  };
 
   $scope.addHostsEntry = function (service) {
     if (!service.Hosts) {
       service.Hosts = [];
     }
-    service.Hosts.push({ hostname: '', ip: '' });    
+    service.Hosts.push({ hostname: '', ip: '' });
   };
   $scope.removeHostsEntry = function(service, index) {
     var removedElement = service.Hosts.splice(index, 1);
@@ -199,9 +199,9 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       updateServiceArray(service, 'Hosts', service.Hosts);
     }
   };
-  $scope.updateHostsEntry = function(service, entry) {  
+  $scope.updateHostsEntry = function(service, entry) {
     updateServiceArray(service, 'Hosts', service.Hosts);
-  };  
+  };
 
   $scope.cancelChanges = function cancelChanges(service, keys) {
     if (keys) { // clean out the keys only from the list of modified keys
@@ -239,7 +239,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     config.TaskTemplate.ContainerSpec.Secrets = service.ServiceSecrets ? service.ServiceSecrets.map(SecretHelper.secretConfig) : [];
     config.TaskTemplate.ContainerSpec.Configs = service.ServiceConfigs ? service.ServiceConfigs.map(ConfigHelper.configConfig) : [];
     config.TaskTemplate.ContainerSpec.Hosts = service.Hosts ? ServiceHelper.translateHostnameIPToHostsEntries(service.Hosts) : [];
-    
+
     if (service.Mode === 'replicated') {
       config.Mode.Replicated.Replicas = service.Replicas;
     }
@@ -279,17 +279,17 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       MaxAttempts: service.RestartMaxAttempts,
       Window: ServiceHelper.translateHumanDurationToNanos(service.RestartWindow) || 0
     };
-    
+
     config.TaskTemplate.LogDriver = null;
-    if (service.LogDriverName) {      
+    if (service.LogDriverName) {
       config.TaskTemplate.LogDriver = { Name: service.LogDriverName };
       if (service.LogDriverName !== 'none') {
         var logOpts = ServiceHelper.translateKeyValueToLogDriverOpts(service.LogDriverOpts);
         if (Object.keys(logOpts).length !== 0 && logOpts.constructor === Object) {
           config.TaskTemplate.LogDriver.Options = logOpts;
         }
-      }      
-    }    
+      }
+    }
 
     if (service.Ports) {
       service.Ports.forEach(function (binding) {
@@ -339,7 +339,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   }
 
   $scope.forceUpdateService = function(service) {
-    ModalService.confirmForceUpdate(
+    ModalService.confirmServiceForceUpdate(
       'Do you want to force update this service? All the tasks associated to the selected service(s) will be recreated.',
       function onConfirm(confirmed) {
         if(!confirmed) { return; }
@@ -351,18 +351,18 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   function forceUpdateService(service) {
     var config = ServiceHelper.serviceToConfig(service.Model);
     // As explained in https://github.com/docker/swarmkit/issues/2364 ForceUpdate can accept a random
-    // value or an increment of the counter value to force an update.          
+    // value or an increment of the counter value to force an update.
     config.TaskTemplate.ForceUpdate++;
     ServiceService.update(service, config)
     .then(function success(data) {
-      Notifications.success('Service successfully updated with --force', service.Name);
+      Notifications.success('Service successfully updated', service.Name);
       $scope.cancelChanges({});
       initView();
     })
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to force update service', service.Name);
     });
-  }  
+  }
 
   function translateServiceArrays(service) {
     service.ServiceSecrets = service.Secrets ? service.Secrets.map(SecretHelper.flattenSecret) : [];
@@ -391,7 +391,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   }
 
   function initView() {
-    var apiVersion = $scope.applicationState.endpoint.apiVersion;  
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;
 
     ServiceService.service($transition$.params().id)
     .then(function success(data) {

--- a/app/components/services/services.html
+++ b/app/components/services/services.html
@@ -18,6 +18,7 @@
     scale-action="scaleAction"
     force-update-action="forceUpdateAction"
     swarm-manager-ip="swarmManagerIP"
+    show-force-update-button="applicationState.endpoint.apiVersion >= 1.25"
     ></services-datatable>
   </div>
 </div>

--- a/app/components/services/services.html
+++ b/app/components/services/services.html
@@ -16,6 +16,7 @@
     show-ownership-column="applicationState.application.authentication"
     remove-action="removeAction"
     scale-action="scaleAction"
+    force-update-action="forceUpdateAction"
     swarm-manager-ip="swarmManagerIP"
     ></services-datatable>
   </div>

--- a/app/components/services/servicesController.js
+++ b/app/components/services/servicesController.js
@@ -18,19 +18,13 @@ function ($q, $scope, $state, Service, ServiceService, ServiceHelper, Notificati
   };
 
   $scope.forceUpdateAction = function(selectedItems) {
-    if ($scope.applicationState.endpoint.apiVersion <= 1.24) {
-      var notSupported = 'Force update is not supported for API version <= 1.24';
-      var e = new Error(notSupported);
-      Notifications.error('Not supported', e, notSupported);        
-    } else {
-      ModalService.confirmForceUpdate(
-        'Do you want to force update of selected service(s)? All the tasks associated to the selected service(s) will be recreated.',
-        function onConfirm(confirmed) {
-          if(!confirmed) { return; }
-          forceUpdateServices(selectedItems);
-        }
-      );
-    }    
+    ModalService.confirmServiceForceUpdate(
+      'Do you want to force update of selected service(s)? All the tasks associated to the selected service(s) will be recreated.',
+      function onConfirm(confirmed) {
+        if(!confirmed) { return; }
+        forceUpdateServices(selectedItems);
+      }
+    );
   };
 
   function forceUpdateServices(services) {
@@ -38,21 +32,21 @@ function ($q, $scope, $state, Service, ServiceService, ServiceHelper, Notificati
     angular.forEach(services, function (service) {
       var config = ServiceHelper.serviceToConfig(service.Model);
       // As explained in https://github.com/docker/swarmkit/issues/2364 ForceUpdate can accept a random
-      // value or an increment of the counter value to force an update.          
-      config.TaskTemplate.ForceUpdate++;      
+      // value or an increment of the counter value to force an update.
+      config.TaskTemplate.ForceUpdate++;
       ServiceService.update(service, config)
       .then(function success(data) {
-        Notifications.success('Service successfully updated with --force', service.Name);        
+        Notifications.success('Service successfully updated', service.Name);
       })
       .catch(function error(err) {
-        Notifications.error('Failure', err, 'Unable to force update service', service.Name);        
+        Notifications.error('Failure', err, 'Unable to force update service', service.Name);
       })
       .finally(function final() {
         --actionCount;
         if (actionCount === 0) {
           $state.reload();
         }
-      });      
+      });
     });
   }
 

--- a/app/components/services/servicesController.js
+++ b/app/components/services/servicesController.js
@@ -17,6 +17,45 @@ function ($q, $scope, $state, Service, ServiceService, ServiceHelper, Notificati
     });
   };
 
+  $scope.forceUpdateAction = function(selectedItems) {
+    if ($scope.applicationState.endpoint.apiVersion <= 1.24) {
+      var notSupported = 'Force update is not supported for API version <= 1.24';
+      var e = new Error(notSupported);
+      Notifications.error('Not supported', e, notSupported);        
+    } else {
+      ModalService.confirmForceUpdate(
+        'Do you want to force update of selected service(s)? All the tasks associated to the selected service(s) will be recreated.',
+        function onConfirm(confirmed) {
+          if(!confirmed) { return; }
+          forceUpdateServices(selectedItems);
+        }
+      );
+    }    
+  };
+
+  function forceUpdateServices(services) {
+    var actionCount = services.length;
+    angular.forEach(services, function (service) {
+      var config = ServiceHelper.serviceToConfig(service.Model);
+      // As explained in https://github.com/docker/swarmkit/issues/2364 ForceUpdate can accept a random
+      // value or an increment of the counter value to force an update.          
+      config.TaskTemplate.ForceUpdate++;      
+      ServiceService.update(service, config)
+      .then(function success(data) {
+        Notifications.success('Service successfully updated with --force', service.Name);        
+      })
+      .catch(function error(err) {
+        Notifications.error('Failure', err, 'Unable to force update service', service.Name);        
+      })
+      .finally(function final() {
+        --actionCount;
+        if (actionCount === 0) {
+          $state.reload();
+        }
+      });      
+    });
+  }
+
   $scope.removeAction = function(selectedItems) {
     ModalService.confirmDeletion(
       'Do you want to remove the selected service(s)? All the containers associated to the selected service(s) will be removed too.',

--- a/app/directives/ui/datatables/services-datatable/servicesDatatable.html
+++ b/app/directives/ui/datatables/services-datatable/servicesDatatable.html
@@ -15,6 +15,10 @@
         <button type="button" class="btn btn-sm btn-danger"
           ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
           <i class="fa fa-trash space-right" aria-hidden="true"></i>Remove
+        </button>        
+        <button type="button" class="btn btn-sm btn-primary" 
+          ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.forceUpdateAction($ctrl.state.selectedItems)">
+          <i class="fa fa-refresh space-right" aria-hidden="true"></i>Force update
         </button>
         <button type="button" class="btn btn-sm btn-primary" ui-sref="actions.create.service">
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add service

--- a/app/directives/ui/datatables/services-datatable/servicesDatatable.html
+++ b/app/directives/ui/datatables/services-datatable/servicesDatatable.html
@@ -15,8 +15,8 @@
         <button type="button" class="btn btn-sm btn-danger"
           ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
           <i class="fa fa-trash space-right" aria-hidden="true"></i>Remove
-        </button>        
-        <button type="button" class="btn btn-sm btn-primary" 
+        </button>
+        <button ng-if="$ctrl.showForceUpdateButton" type="button" class="btn btn-sm btn-primary"
           ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.forceUpdateAction($ctrl.state.selectedItems)">
           <i class="fa fa-refresh space-right" aria-hidden="true"></i>Force update
         </button>

--- a/app/directives/ui/datatables/services-datatable/servicesDatatable.js
+++ b/app/directives/ui/datatables/services-datatable/servicesDatatable.js
@@ -10,9 +10,10 @@ angular.module('ui').component('servicesDatatable', {
     reverseOrder: '<',
     showTextFilter: '<',
     showOwnershipColumn: '<',
-    removeAction: '<',    
+    removeAction: '<',
     scaleAction: '<',
     swarmManagerIp: '<',
-    forceUpdateAction: '<'
+    forceUpdateAction: '<',
+    showForceUpdateButton: '<'
   }
 });

--- a/app/directives/ui/datatables/services-datatable/servicesDatatable.js
+++ b/app/directives/ui/datatables/services-datatable/servicesDatatable.js
@@ -10,8 +10,9 @@ angular.module('ui').component('servicesDatatable', {
     reverseOrder: '<',
     showTextFilter: '<',
     showOwnershipColumn: '<',
-    removeAction: '<',
+    removeAction: '<',    
     scaleAction: '<',
-    swarmManagerIp: '<'
+    swarmManagerIp: '<',
+    forceUpdateAction: '<'
   }
 });

--- a/app/services/modalService.js
+++ b/app/services/modalService.js
@@ -156,5 +156,19 @@ angular.module('portainer.services')
     });
   };
 
+  service.confirmForceUpdate = function(message, callback) {
+    service.confirm({
+      title: 'Are you sure ?',
+      message: message,
+      buttons: {
+        confirm: {
+          label: 'Update',
+          className: 'btn-primary'
+        }
+      },
+      callback: callback
+    });
+  };
+
   return service;
 }]);

--- a/app/services/modalService.js
+++ b/app/services/modalService.js
@@ -156,7 +156,7 @@ angular.module('portainer.services')
     });
   };
 
-  service.confirmForceUpdate = function(message, callback) {
+  service.confirmServiceForceUpdate = function(message, callback) {
     service.confirm({
       title: 'Are you sure ?',
       message: message,


### PR DESCRIPTION
Close #859 

A new button called Force update has been added next to the Remove button in the Services list view. That button will cause the tasks to be recreated anyway in the same way as if we use the --force option with the docker service update command. The button will be disabled until we select one or more services.
![force_update_button_service_list](https://user-images.githubusercontent.com/30386061/34379293-d058aa44-eafa-11e7-8038-4f460ea9906a.png)

A dialog will show once we click the Force update button so we are informed about what is going to happen.
![force_update_confirmation_dialog](https://user-images.githubusercontent.com/30386061/34379304-e99f1cae-eafa-11e7-8375-e6c165580166.png)

Now, the service will be updated using the ForceUpdate member of the TaskTemplate config option. The ForceUpdate value is a counter that we increment to tell Docker that the tasks must be recreated as suggested [here](https://github.com/docker/swarmkit/issues/2364).

If the service is updated successfully we will see a message.
![success_dialog](https://user-images.githubusercontent.com/30386061/34614737-bf4200e0-f232-11e7-83da-96de6326e296.png)

Also we can check that the global or replicated number next to the service name will be 0 which means that the service's tasks are being recreated. 
![service_update_forced_deploying](https://user-images.githubusercontent.com/30386061/34379312-f56e43fc-eafa-11e7-9d8c-14b65210af07.png)

After some time we'll see that the service has new running tasks according to the desired state.
![service_update_forced_deployed](https://user-images.githubusercontent.com/30386061/34379316-f9c783dc-eafa-11e7-92a3-10988bda7f0d.png)

If the API version is < 1.25 the force update button won't be displayed.

The same Force update action will be displayed next to the service name in the Service details view. If we click the button a dialog will inform us about the action. If the action is successful we'll see a notification and if we wait some time and refresh the service list we'll see the new running tasks.
![force_update_button_service_view](https://user-images.githubusercontent.com/30386061/34379320-009c5e08-eafb-11e7-8810-0645d91f6ccd.png)

A confirmation dialog will be displayed if we click on the Force update button. 
![force_update_confirmation_dialog](https://user-images.githubusercontent.com/30386061/34379472-adbdf600-eafb-11e7-9862-13fc46bd0fa3.png)

Also, in the Service details view, the Force update button will not be shown if the API version is < 1.25.

In the CLI we can check that the service's tasks have been shutdown and started:
![docker_service_ps](https://user-images.githubusercontent.com/30386061/34379266-af22d020-eafa-11e7-9dd7-e298bd1baa29.png)
  