### PR TITLE
feat(container-creation): add support for mac assignments (#1524)

### DIFF
--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -401,7 +401,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     }
   }
 
-  function loadFromContainerEnvrionmentVariables(d) {
+  function loadFromContainerEnvironmentVariables(d) {
     var envArr = [];
     for (var e in $scope.config.Env) {
       if ({}.hasOwnProperty.call($scope.config.Env, e)) {
@@ -483,7 +483,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       loadFromContainerPortBindings(d);
       loadFromContainerVolumes(d);
       loadFromContainerNetworkConfig(d);
-      loadFromContainerEnvrionmentVariables(d);
+      loadFromContainerEnvironmentVariables(d);
       loadFromContainerLabels(d);
       loadFromContainerConsole(d);
       loadFromContainerDevices(d);

--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -195,6 +195,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       config.Hostname = '';
     }
     config.HostConfig.NetworkMode = networkMode;
+    config.MacAddress = $scope.formValues.MacAddress;
 
     config.NetworkingConfig.EndpointsConfig[networkMode] = {
       IPAMConfig: {
@@ -255,7 +256,6 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
   function prepareConfiguration() {
     var config = angular.copy($scope.config);
     config.Cmd = ContainerHelper.commandStringToArray(config.Cmd);
-    config.MacAddress = $scope.formValues.MacAddress;
     prepareNetworkConfig(config);
     prepareImageConfig(config);
     preparePortBindings(config);
@@ -390,6 +390,8 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       }
     }
     $scope.config.NetworkingConfig.EndpointsConfig[$scope.config.HostConfig.NetworkMode] = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode];
+    // Mac Address
+    $scope.formValues.MacAddress = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode].MacAddress;
     // ExtraHosts
     for (var h in $scope.config.HostConfig.ExtraHosts) {
       if ({}.hasOwnProperty.call($scope.config.HostConfig.ExtraHosts, h)) {
@@ -397,10 +399,6 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
         $scope.config.HostConfig.ExtraHosts = [];
       }
     }
-  }
-
-  function loadFromContainerMacAddress(d) {
-    $scope.formValues.MacAddress = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode].MacAddress;
   }
 
   function loadFromContainerEnvrionmentVariables(d) {
@@ -485,7 +483,6 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       loadFromContainerPortBindings(d);
       loadFromContainerVolumes(d);
       loadFromContainerNetworkConfig(d);
-      loadFromContainerMacAddress(d);
       loadFromContainerEnvrionmentVariables(d);
       loadFromContainerLabels(d);
       loadFromContainerConsole(d);

--- a/app/components/createContainer/createContainerController.js
+++ b/app/components/createContainer/createContainerController.js
@@ -11,6 +11,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     NetworkContainer: '',
     Labels: [],
     ExtraHosts: [],
+    MacAddress: '',
     IPv4: '',
     IPv6: '',
     AccessControlData: new AccessControlFormData(),
@@ -34,6 +35,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     Image: '',
     Env: [],
     Cmd: '',
+    MacAddress: '',
     ExposedPorts: {},
     HostConfig: {
       RestartPolicy: {
@@ -253,6 +255,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
   function prepareConfiguration() {
     var config = angular.copy($scope.config);
     config.Cmd = ContainerHelper.commandStringToArray(config.Cmd);
+    config.MacAddress = $scope.formValues.MacAddress;
     prepareNetworkConfig(config);
     prepareImageConfig(config);
     preparePortBindings(config);
@@ -396,6 +399,10 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     }
   }
 
+  function loadFromContainerMacAddress(d) {
+    $scope.formValues.MacAddress = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode].MacAddress;
+  }
+
   function loadFromContainerEnvrionmentVariables(d) {
     var envArr = [];
     for (var e in $scope.config.Env) {
@@ -478,6 +485,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       loadFromContainerPortBindings(d);
       loadFromContainerVolumes(d);
       loadFromContainerNetworkConfig(d);
+      loadFromContainerMacAddress(d);
       loadFromContainerEnvrionmentVariables(d);
       loadFromContainerLabels(d);
       loadFromContainerConsole(d);

--- a/app/components/createContainer/createcontainer.html
+++ b/app/components/createContainer/createcontainer.html
@@ -332,6 +332,14 @@
                 </div>
               </div>
               <!-- !domainname -->
+              <!-- mac-address-input -->
+              <div class="form-group">
+                <label for="container_macaddress" class="col-sm-2 col-lg-1 control-label text-left">Mac Address</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control" ng-model="formValues.MacAddress" id="container_macaddress" placeholder="e.g. 12-34-56-78-9a-bc">
+                </div>
+              </div>
+              <!-- !mac-address-input -->
               <!-- ipv4-input -->
               <div class="form-group">
                 <label for="container_ipv4" class="col-sm-2 col-lg-1 control-label text-left">IPv4 Address</label>


### PR DESCRIPTION
Added in a field to the networks area on the container creation page to allow for assigning a custom mac address to a container.

Also populates the mac address field with the currently assigned address when using the recreate function.

Related to feature request: (#1524)