### PR TITLE
feat(swarm-visualizer): add auto-refresh to the cluster visualizer

### DIFF
--- a/app/components/swarmVisualizer/swarmVisualizer.html
+++ b/app/components/swarmVisualizer/swarmVisualizer.html
@@ -50,30 +50,16 @@
             </div>
           </div>
         </form>
-      </rd-widget-body>
-    </rd-widget>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-12">
-    <rd-widget>
-      <rd-widget-header icon="fa-info-circle" title="About Cluster Visualizer">
-      </rd-widget-header>
-      <rd-widget-body>
         <form class="form-horizontal">
-          <div class="form-group">
-            <div class="col-sm-12">
-              <span class="small text-muted">
-                This view displays real-time information about the Swarm.
-              </span>
-            </div>
+          <div class="col-sm-12 form-section-title">
+            Refresh
           </div>
           <div class="form-group">
-            <label for="refreshRate" class="col-sm-3 col-md-2 col-lg-2 margin-sm-top control-label text-left">
-              Refresh rate
+            <label for="refreshRate" class="col-sm-1 margin-sm-top control-label text-left">
+              Rate
+              <i id="refreshRateChange" class="fa fa-check green-icon" aria-hidden="true" style="display: none;"></i>
             </label>
-            <div class="col-sm-3 col-md-2">
+            <div class="col-sm-2">
               <select id="refreshRate" ng-model="state.refreshRate" ng-change="changeUpdateRepeater()" class="form-control">
                 <option value="5">5s</option>
                 <option value="10">10s</option>
@@ -81,9 +67,6 @@
                 <option value="60">60s</option>
               </select>
             </div>
-            <span>
-              <i id="refreshRateChange" class="fa fa-check green-icon" aria-hidden="true" style="margin-top: 7px; display: none;"></i>
-            </span>
           </div>
         </form>
       </rd-widget-body>

--- a/app/components/swarmVisualizer/swarmVisualizer.html
+++ b/app/components/swarmVisualizer/swarmVisualizer.html
@@ -55,6 +55,42 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="col-sm-12">
+    <rd-widget>
+      <rd-widget-header icon="fa-info-circle" title="About Cluster Visualizer">
+      </rd-widget-header>
+      <rd-widget-body>
+        <form class="form-horizontal">
+          <div class="form-group">
+            <div class="col-sm-12">
+              <span class="small text-muted">
+                This view displays real-time information about the Swarm.
+              </span>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="refreshRate" class="col-sm-3 col-md-2 col-lg-2 margin-sm-top control-label text-left">
+              Refresh rate
+            </label>
+            <div class="col-sm-3 col-md-2">
+              <select id="refreshRate" ng-model="state.refreshRate" ng-change="changeUpdateRepeater()" class="form-control">
+                <option value="5">5s</option>
+                <option value="10">10s</option>
+                <option value="30">30s</option>
+                <option value="60">60s</option>
+              </select>
+            </div>
+            <span>
+              <i id="refreshRateChange" class="fa fa-check green-icon" aria-hidden="true" style="margin-top: 7px; display: none;"></i>
+            </span>
+          </div>
+        </form>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+</div>
+
 <div class="row" ng-if="visualizerData">
   <div class="col-sm-12">
     <rd-widget>
@@ -75,6 +111,7 @@
               <div>{{ node.Role }}</div>
               <div>CPU: {{ node.CPUs / 1000000000 }}</div>
               <div>Memory: {{ node.Memory|humansize: 2 }}</div>
+              <div><span class="label label-{{ node.Status | nodestatusbadge }}">{{ node.Status }}</span></div>
             </div>
             <div class="tasks">
               <div class="task task_{{ task.Status.State | visualizerTask }}" ng-repeat="task in node.Tasks | filter: (state.DisplayOnlyRunningTasks || '') && { Status: { State: 'running' } }">


### PR DESCRIPTION
Close #1337 

A new drop-down menu is added above the filter section inside the Cluster Information panel, so we can choose the refresh rate (5, 10, 30, 60 seconds) for the view in the same way as the container statistics view works. 
![refresh_under_filters](https://user-images.githubusercontent.com/30386061/34840245-accfe69e-f704-11e7-8eb1-62fccd4bc6eb.png)

A badge showing the node status has been added in the box which represents each node, so we can track the status of the node.
![swarm_node_status](https://user-images.githubusercontent.com/30386061/34718936-e48527de-f538-11e7-82fd-63ddc90df006.png)

I try to shutdown one of the nodes in the swarm (portainer-node2) and wait for the view to be refreshed.
![swarm_node_status_refreshed_down](https://user-images.githubusercontent.com/30386061/34718942-eaa6b736-f538-11e7-938c-c62dc2ec6977.png)

Then I launch a service from a different tab in my browser.
![new_service_autorefresh_starting](https://user-images.githubusercontent.com/30386061/34718950-f36b93be-f538-11e7-853e-1bd57f07b854.png)

Thanks to the auto-refresh, I can see the service in starting state...
![new_service_autorefresh_starting](https://user-images.githubusercontent.com/30386061/34718958-feca0de4-f538-11e7-8682-783df34b1cde.png)

And then in the running state...
![new_service_autorefresh_running](https://user-images.githubusercontent.com/30386061/34718967-03a19a9e-f539-11e7-8d31-0ee0bf5102d2.png)

I change the refresh update time to 30 seconds and I start the powered off node again. 50 seconds later the node has been refreshed. 
![change_refresh](https://user-images.githubusercontent.com/30386061/34840327-f225d1b8-f704-11e7-8b22-c25ed2e6f60a.png)


The view has now a similar behavior offered by the Docker Swarm Visualizer.
![node_up_again](https://user-images.githubusercontent.com/30386061/34718980-0c79e108-f539-11e7-9325-dd36371397b7.png)

An if I remove the service, it is removed from the view and refreshed...
![service_removed](https://user-images.githubusercontent.com/30386061/34719026-451fa4c0-f539-11e7-93ec-891b29efff38.png)
