### PR TITLE
feat(stack-details): add stack deploy prune option

### DIFF
--- a/api/exec/stack_manager.go
+++ b/api/exec/stack_manager.go
@@ -54,11 +54,11 @@ func (manager *StackManager) Logout(endpoint *portainer.Endpoint) error {
 }
 
 // Deploy executes the docker stack deploy command.
-func (manager *StackManager) Deploy(stack *portainer.Stack, endpoint *portainer.Endpoint) error {
+func (manager *StackManager) Deploy(stack *portainer.Stack, prune bool, endpoint *portainer.Endpoint) error {
 	stackFilePath := path.Join(stack.ProjectPath, stack.EntryPoint)
 	command, args := prepareDockerCommandAndArgs(manager.binaryPath, endpoint)
 
-	if stack.Prune {
+	if prune {
 		args = append(args, "stack", "deploy", "--prune", "--with-registry-auth", "--compose-file", stackFilePath, stack.Name)
 	} else {
 		args = append(args, "stack", "deploy", "--with-registry-auth", "--compose-file", stackFilePath, stack.Name)

--- a/api/exec/stack_manager.go
+++ b/api/exec/stack_manager.go
@@ -57,7 +57,12 @@ func (manager *StackManager) Logout(endpoint *portainer.Endpoint) error {
 func (manager *StackManager) Deploy(stack *portainer.Stack, endpoint *portainer.Endpoint) error {
 	stackFilePath := path.Join(stack.ProjectPath, stack.EntryPoint)
 	command, args := prepareDockerCommandAndArgs(manager.binaryPath, endpoint)
-	args = append(args, "stack", "deploy", "--with-registry-auth", "--compose-file", stackFilePath, stack.Name)
+
+	if stack.Prune {
+		args = append(args, "stack", "deploy", "--prune", "--with-registry-auth", "--compose-file", stackFilePath, stack.Name)
+	} else {
+		args = append(args, "stack", "deploy", "--with-registry-auth", "--compose-file", stackFilePath, stack.Name)
+	}
 
 	env := make([]string, 0)
 	for _, envvar := range stack.Env {

--- a/api/http/handler/stack.go
+++ b/api/http/handler/stack.go
@@ -37,6 +37,14 @@ type StackHandler struct {
 	StackManager           portainer.StackManager
 }
 
+type stackDeploymentConfig struct {
+	endpoint   *portainer.Endpoint
+	stack      *portainer.Stack
+	prune      bool
+	dockerhub  *portainer.DockerHub
+	registries []portainer.Registry
+}
+
 // NewStackHandler returns a new instance of StackHandler.
 func NewStackHandler(bouncer *security.RequestBouncer) *StackHandler {
 	h := &StackHandler{
@@ -208,8 +216,14 @@ func (handler *StackHandler) handlePostStacksStringMethod(w http.ResponseWriter,
 		return
 	}
 
-	prune := false
-	err = handler.deployStack(endpoint, stack, prune, dockerhub, filteredRegistries)
+	config := stackDeploymentConfig{
+		stack:      stack,
+		endpoint:   endpoint,
+		dockerhub:  dockerhub,
+		registries: filteredRegistries,
+		prune:      false,
+	}
+	err = handler.deployStack(&config)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -336,8 +350,14 @@ func (handler *StackHandler) handlePostStacksRepositoryMethod(w http.ResponseWri
 		return
 	}
 
-	prune := false
-	err = handler.deployStack(endpoint, stack, prune, dockerhub, filteredRegistries)
+	config := stackDeploymentConfig{
+		stack:      stack,
+		endpoint:   endpoint,
+		dockerhub:  dockerhub,
+		registries: filteredRegistries,
+		prune:      false,
+	}
+	err = handler.deployStack(&config)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -448,8 +468,14 @@ func (handler *StackHandler) handlePostStacksFileMethod(w http.ResponseWriter, r
 		return
 	}
 
-	prune := false
-	err = handler.deployStack(endpoint, stack, prune, dockerhub, filteredRegistries)
+	config := stackDeploymentConfig{
+		stack:      stack,
+		endpoint:   endpoint,
+		dockerhub:  dockerhub,
+		registries: filteredRegistries,
+		prune:      false,
+	}
+	err = handler.deployStack(&config)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -641,7 +667,14 @@ func (handler *StackHandler) handlePutStack(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	err = handler.deployStack(endpoint, stack, req.Prune, dockerhub, filteredRegistries)
+	config := stackDeploymentConfig{
+		stack:      stack,
+		endpoint:   endpoint,
+		dockerhub:  dockerhub,
+		registries: filteredRegistries,
+		prune:      req.Prune,
+	}
+	err = handler.deployStack(&config)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -736,22 +769,22 @@ func (handler *StackHandler) handleDeleteStack(w http.ResponseWriter, r *http.Re
 	}
 }
 
-func (handler *StackHandler) deployStack(endpoint *portainer.Endpoint, stack *portainer.Stack, prune bool, dockerhub *portainer.DockerHub, registries []portainer.Registry) error {
+func (handler *StackHandler) deployStack(config *stackDeploymentConfig) error {
 	handler.stackCreationMutex.Lock()
 
-	err := handler.StackManager.Login(dockerhub, registries, endpoint)
+	err := handler.StackManager.Login(config.dockerhub, config.registries, config.endpoint)
 	if err != nil {
 		handler.stackCreationMutex.Unlock()
 		return err
 	}
 
-	err = handler.StackManager.Deploy(stack, prune, endpoint)
+	err = handler.StackManager.Deploy(config.stack, config.prune, config.endpoint)
 	if err != nil {
 		handler.stackCreationMutex.Unlock()
 		return err
 	}
 
-	err = handler.StackManager.Logout(endpoint)
+	err = handler.StackManager.Logout(config.endpoint)
 	if err != nil {
 		handler.stackCreationMutex.Unlock()
 		return err

--- a/api/http/handler/stack.go
+++ b/api/http/handler/stack.go
@@ -78,6 +78,7 @@ type (
 	putStackRequest struct {
 		StackFileContent string           `valid:"required"`
 		Env              []portainer.Pair `valid:""`
+		Prune						 bool							`valid:"-"`
 	}
 )
 
@@ -600,6 +601,7 @@ func (handler *StackHandler) handlePutStack(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	stack.Env = req.Env
+	stack.Prune = req.Prune
 
 	_, err = handler.FileService.StoreStackFileFromString(string(stack.ID), req.StackFileContent)
 	if err != nil {

--- a/api/http/handler/stack.go
+++ b/api/http/handler/stack.go
@@ -78,7 +78,7 @@ type (
 	putStackRequest struct {
 		StackFileContent string           `valid:"required"`
 		Env              []portainer.Pair `valid:""`
-		Prune						 bool							`valid:"-"`
+		Prune            bool             `valid:"-"`
 	}
 )
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -140,6 +140,7 @@ type (
 		SwarmID     string  `json:"SwarmId"`
 		ProjectPath string
 		Env         []Pair `json:"Env"`
+		Prune				bool `json:"Prune"`
 	}
 
 	// RegistryID represents a registry identifier.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -140,7 +140,6 @@ type (
 		SwarmID     string  `json:"SwarmId"`
 		ProjectPath string
 		Env         []Pair `json:"Env"`
-		Prune       bool   `json:"Prune"`
 	}
 
 	// RegistryID represents a registry identifier.
@@ -384,7 +383,7 @@ type (
 	StackManager interface {
 		Login(dockerhub *DockerHub, registries []Registry, endpoint *Endpoint) error
 		Logout(endpoint *Endpoint) error
-		Deploy(stack *Stack, endpoint *Endpoint) error
+		Deploy(stack *Stack, prune bool, endpoint *Endpoint) error
 		Remove(stack *Stack, endpoint *Endpoint) error
 	}
 )

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -140,7 +140,7 @@ type (
 		SwarmID     string  `json:"SwarmId"`
 		ProjectPath string
 		Env         []Pair `json:"Env"`
-		Prune				bool `json:"Prune"`
+		Prune       bool   `json:"Prune"`
 	}
 
 	// RegistryID represents a registry identifier.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2964,10 +2964,6 @@ definitions:
         description: "A list of environment variables used during stack deployment"
         items:
           $ref: "#/definitions/Stack_Env"
-      Prune:
-        type: "boolean"
-        example: true
-        description: "Prune services that are no longer referenced?"
   StackUpdateRequest:
     type: "object"
     properties:
@@ -2982,8 +2978,8 @@ definitions:
           $ref: "#/definitions/Stack_Env"
       Prune:
         type: "boolean"
-        example: true
-        description: "Prune services that are no longer referenced?"
+        example: false
+        description: "Prune services that are no longer referenced"
   StackFileInspectResponse:
     type: "object"
     properties:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2964,6 +2964,10 @@ definitions:
         description: "A list of environment variables used during stack deployment"
         items:
           $ref: "#/definitions/Stack_Env"
+      Prune:
+        type: "boolean"
+        example: true
+        description: "Prune services that are no longer referenced?"
   StackUpdateRequest:
     type: "object"
     properties:
@@ -2976,10 +2980,14 @@ definitions:
         description: "A list of environment variables used during stack deployment"
         items:
           $ref: "#/definitions/Stack_Env"
+      Prune:
+        type: "boolean"
+        example: true
+        description: "Prune services that are no longer referenced?"
   StackFileInspectResponse:
     type: "object"
     properties:
       StackFileContent:
         type: "string"
         example: "version: 3\n services:\n web:\n image:nginx"
-        description: "Content of the Stack file."          
+        description: "Content of the Stack file."

--- a/app/components/stack/stack.html
+++ b/app/components/stack/stack.html
@@ -90,6 +90,22 @@
             <!-- !environment-variable-input-list -->
           </div>
           <!-- !environment-variables -->
+          <!-- options -->
+          <div class="col-sm-12 form-section-title" ng-if="applicationState.endpoint.apiVersion >= 1.27">
+          Options
+          </div>
+          <div class="form-group" ng-if="applicationState.endpoint.apiVersion >= 1.27">
+            <div class="col-sm-12">
+              <label for="prune" class="control-label text-left">
+                Prune services
+                <portainer-tooltip position="bottom" message="Prune services that are no longer referenced."></portainer-tooltip>
+              </label>
+              <label class="switch" style="margin-left: 20px;">
+                <input name="prune" type="checkbox" ng-model="formValues.Prune"><i></i>
+              </label>
+            </div>
+          </div>
+          <!-- !options -->
           <div class="col-sm-12 form-section-title">
             Actions
           </div>

--- a/app/components/stack/stackController.js
+++ b/app/components/stack/stackController.js
@@ -7,14 +7,19 @@ function ($q, $scope, $state, $transition$, $document, StackService, NodeService
     publicURL: EndpointProvider.endpointPublicURL()
   };
 
+  $scope.formValues = {
+    Prune: false
+  };
+
   $scope.deployStack = function () {
     // The codemirror editor does not work with ng-model so we need to retrieve
     // the value directly from the editor.
     var stackFile = $scope.editor.getValue();
     var env = FormHelper.removeInvalidEnvVars($scope.stack.Env);
+    var prune = $scope.formValues.Prune;
 
     $scope.state.actionInProgress = true;
-    StackService.updateStack($scope.stack.Id, stackFile, env)
+    StackService.updateStack($scope.stack.Id, stackFile, env, prune)
     .then(function success(data) {
       Notifications.success('Stack successfully deployed');
       $state.reload();
@@ -37,6 +42,7 @@ function ($q, $scope, $state, $transition$, $document, StackService, NodeService
 
   function initView() {
     var stackId = $transition$.params().id;
+    var apiVersion = $scope.applicationState.endpoint.apiVersion;
 
     StackService.stack(stackId)
     .then(function success(data) {

--- a/app/services/api/stackService.js
+++ b/app/services/api/stackService.js
@@ -167,8 +167,8 @@ function StackServiceFactory($q, Stack, ResourceControlService, FileUploadServic
     return deferred.promise;
   };
 
-  service.updateStack = function(id, stackFile, env) {
-    return Stack.update({ id: id, StackFileContent: stackFile, Env: env }).$promise;
+  service.updateStack = function(id, stackFile, env, prune) {
+    return Stack.update({ id: id, StackFileContent: stackFile, Env: env, Prune: prune}).$promise;
   };
 
   return service;


### PR DESCRIPTION
Close #1358 
I start with a docker stack that contains two service.
![stack_created_two_services](https://user-images.githubusercontent.com/30386061/34958401-1364552c-fa32-11e7-99e2-21fab5249a59.png)

A new Options section is added to the Docker stack detail view. In this section a new switch named Prune services will be displayed if the API version is >= 1.27. 
![new_option_prune](https://user-images.githubusercontent.com/30386061/34958414-1abd3fd2-fa32-11e7-9410-466783de9124.png)

If the Prune services option is set, it will force [the --prune option ](https://docs.docker.com/engine/reference/commandline/stack_deploy/#options)to be added to the docker stack deploy command which updates a stack from a Docker Compose file removing services that are no longer needed. The prune option is not used by the default value, it has to be explicitely enabled/added when the stack is updated.

I remove the db service from the docker compose file. If I try to update the stack without pruning the services, we'll still have the two services that were created with the stack.
![two_services_wo_pruning](https://user-images.githubusercontent.com/30386061/34958424-2bdff7be-fa32-11e7-8b17-f3aceaea1b56.png)

I enable the "Prune services" switch and update the stack.
![enable_prune_and_update](https://user-images.githubusercontent.com/30386061/34958428-2fe8afb8-fa32-11e7-93ef-516ebc883f39.png)

Now we can check that only one service is remaining, the other service has been pruned.
![service_pruned](https://user-images.githubusercontent.com/30386061/34958451-454dd612-fa32-11e7-869d-fcffff6bd7d7.png)

I can add a new service to the docker compose file and update the stack. Two services will be displayed.
![two_services_again](https://user-images.githubusercontent.com/30386061/34958453-4acc2bac-fa32-11e7-8048-d8ad5b1b37c3.png)

The Swagger API definition and the Go backend code have been updated so the new prune option is accepted when the docker stack is updated.