### PR TITLE
Fixed typo in new check health cli flag

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -33,7 +33,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 	flags := &portainer.CLIFlags{
 		Addr:              kingpin.Flag("bind", "Address and port to serve Portainer").Default(defaultBindAddress).Short('p').String(),
 		Assets:            kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
-		CheckHealth:       kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default(defaultCheckHeath).Short('c').Bool(),
+		CheckHealth:       kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default(defaultCheckHealth).Short('c').Bool(),
 		Data:              kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
 		Endpoint:          kingpin.Flag("host", "Dockerd endpoint").Short('H').String(),
 		ExternalEndpoints: kingpin.Flag("external-endpoints", "Path to a file defining available endpoints").String(),

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -6,7 +6,7 @@ const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "/data"
 	defaultAssetsDirectory = "./"
-	defaultCheckHeath      = "false"
+	defaultCheckHealth     = "false"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -4,7 +4,7 @@ const (
 	defaultBindAddress     = ":9000"
 	defaultDataDirectory   = "C:\\data"
 	defaultAssetsDirectory = "./"
-	defaultCheckHeath      = "false"
+	defaultCheckHealth     = "false"
 	defaultNoAuth          = "false"
 	defaultNoAnalytics     = "false"
 	defaultTLSVerify       = "false"


### PR DESCRIPTION
Hi !
Fixed a typo in new check health cli flag default value: `defaultCheckHeath`. It should be `defaultCheckHealth`.