### PR TITLE
style(network-datatable): Show untruncated network name as link title

### DIFF
--- a/app/directives/ui/datatables/networks-datatable/networksDatatable.html
+++ b/app/directives/ui/datatables/networks-datatable/networksDatatable.html
@@ -97,7 +97,7 @@
                   <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)"/>
                   <label for="select_{{ $index }}"></label>
                 </span>
-                <a ui-sref="network({id: item.Id})">{{ item.Name | truncate:40 }}</a>
+                <a ui-sref="network({id: item.Id})" title="{{ item.Name }}">{{ item.Name | truncate:40 }}</a>
               </td>
               <td>{{ item.StackName ? item.StackName : '-' }}</td>
               <td>{{ item.Scope }}</td>


### PR DESCRIPTION
If the network name was truncated (at 40 characters) we cannot see the whole network name inside the networks-table. This pull request shows tje untruncated network name as title on the link.