### PR TITLE
fix(service-details): avoid sending unmodified restart policy setting…

### DIFF
--- a/app/components/service/serviceController.js
+++ b/app/components/service/serviceController.js
@@ -277,12 +277,14 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       Order: service.UpdateOrder
     };
 
-    config.TaskTemplate.RestartPolicy = {
-      Condition: service.RestartCondition,
-      Delay: ServiceHelper.translateHumanDurationToNanos(service.RestartDelay) || 5000000000,
-      MaxAttempts: service.RestartMaxAttempts,
-      Window: ServiceHelper.translateHumanDurationToNanos(service.RestartWindow) || 0
-    };
+    if ($scope.hasChanges(service, ['RestartCondition', 'RestartDelay', 'RestartMaxAttempts', 'RestartWindow'])){
+      config.TaskTemplate.RestartPolicy = {
+        Condition: service.RestartCondition,
+        Delay: ServiceHelper.translateHumanDurationToNanos(service.RestartDelay) || 5000000000,
+        MaxAttempts: service.RestartMaxAttempts,
+        Window: ServiceHelper.translateHumanDurationToNanos(service.RestartWindow) || 0
+      };
+    }
 
     config.TaskTemplate.LogDriver = null;
     if (service.LogDriverName) {


### PR DESCRIPTION
Work-around #1569 

It seems that sending Portainer restart policy settings to the API when updating a service that was created in the CLI without restart policy settings, forces Docker to think that the policy has changed and it must force tasks to be restarted. This happens even if we sent to the API the same default settings that were assigned to the service by Docker when it was created (delay: 5ns, condition: any, maxattempts: 0). Docker API has no information about this issue. 

This fix checks if the restart policy settings have changed in Portainer in the same way that the Apply changes button is enabled when any of the input controls have been modified. In this way we avoid sending the restart policy settings through the API's service update action, which seems to do the trick.

I've performed these manual tests:

- I've tried to scale in Portainer a service created using the CLI and no task is restarted.
- I've tried to scale in Portainer a service that was created with a --restart-window set to 1s and no task is restarted, and the restart policy remains intact.
- I've tried to create a service in Portainer with the default values and scaled the service in the CLI. No task have been restarted.
- I've tried to scale in Portainer a service created usind the CLI changing the restart window setting. Previous tasks have been restarted as expected.
- I've created a service in Portainer and scaled in Portainer without updating any policy settings. No tasks are restarted as expected.

