### PR TITLE
feat(volumes): check if volumes are used in service definitions

### DIFF
--- a/app/helpers/volumeHelper.js
+++ b/app/helpers/volumeHelper.js
@@ -11,5 +11,20 @@ angular.module('portainer.helpers')
     return options;
   };
 
+  service.isVolumeUsedByAService = function(volume, services) {
+    for (var i = 0; i < services.length; i++) {
+      var service = services[i];
+      var mounts = service.Mounts;
+      for (var j = 0; j < mounts.length; j++) {
+        var mount = mounts[j];
+        if (mount.Source === volume.Id) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
   return helper;
 }]);

--- a/app/helpers/volumeHelper.js
+++ b/app/helpers/volumeHelper.js
@@ -11,7 +11,7 @@ angular.module('portainer.helpers')
     return options;
   };
 
-  service.isVolumeUsedByAService = function(volume, services) {
+  helper.isVolumeUsedByAService = function(volume, services) {
     for (var i = 0; i < services.length; i++) {
       var service = services[i];
       var mounts = service.Mounts;


### PR DESCRIPTION
This PR upgrades the current mechanism to check if volumes are in use.

When connected to a Swarm cluster, the list of services is now retrieved, then we check that each volume declared as dangling is not actually used by any service. If the volume is used by a service, the dangling tag is removed.

Close #1599 