### PR TITLE
feat(templates): add support for the name property

### DIFF
--- a/app/docker/models/stackTemplate.js
+++ b/app/docker/models/stackTemplate.js
@@ -1,5 +1,6 @@
 function StackTemplateViewModel(data) {
   this.Type = data.type;
+  this.Name = data.name;
   this.Title = data.title;
   this.Description = data.description;
   this.Note = data.note;

--- a/app/docker/models/template.js
+++ b/app/docker/models/template.js
@@ -1,5 +1,6 @@
 function TemplateViewModel(data) {
   this.Type = data.type;
+  this.Name = data.name;
   this.Title = data.title;
   this.Description = data.description;
   this.Note = data.note;
@@ -45,5 +46,5 @@ function TemplateViewModel(data) {
       };
     });
   }
-  this.Hosts = data.hosts ? data.hosts : []; 
+  this.Hosts = data.hosts ? data.hosts : [];
 }

--- a/app/docker/views/templates/templatesController.js
+++ b/app/docker/views/templates/templatesController.js
@@ -178,6 +178,12 @@ function ($scope, $q, $state, $transition$, $anchorScroll, $filter, ContainerSer
       $scope.formValues.network = _.find($scope.availableNetworks, function(o) { return o.Name === 'bridge'; });
     }
 
+    if (selectedTemplate.Name) {
+      $scope.formValues.name = selectedTemplate.Name;
+    } else {
+      $scope.formValues.name = '';
+    }
+
     $anchorScroll('view-top');
   }
 


### PR DESCRIPTION
This PR introduces support for the `name` property in a template definition. Container/stack name input value will automatically default to that property value when specified.