### PR TITLE
feat(storidge): add extension check on endpoint switch

### DIFF
--- a/app/docker/views/services/logs/serviceLogsController.js
+++ b/app/docker/views/services/logs/serviceLogsController.js
@@ -44,7 +44,6 @@ function ($scope, $transition$, $interval, ServiceService, Notifications) {
     ServiceService.logs($transition$.params().id, 1, 1, 0, $scope.state.lineCount)
     .then(function success(data) {
       $scope.logs = data;
-      console.log(JSON.stringify(data, null, 4));
       setUpdateRepeater();
     })
     .catch(function error(err) {

--- a/app/portainer/rest/extension.js
+++ b/app/portainer/rest/extension.js
@@ -1,10 +1,11 @@
 angular.module('portainer.app')
 .factory('Extensions', ['$resource', 'EndpointProvider', 'API_ENDPOINT_ENDPOINTS', function Extensions($resource, EndpointProvider, API_ENDPOINT_ENDPOINTS) {
   'use strict';
-  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/extensions', {
+  return $resource(API_ENDPOINT_ENDPOINTS + '/:endpointId/extensions/:type', {
     endpointId: EndpointProvider.endpointID
   },
   {
-    register: { method: 'POST', params: { endpointId: '@endpointId' } }
+    register: { method: 'POST' },
+    deregister: { method: 'DELETE', params: { type: '@type' } }
   });
 }]);

--- a/app/portainer/services/api/endpointService.js
+++ b/app/portainer/services/api/endpointService.js
@@ -1,5 +1,6 @@
 angular.module('portainer.app')
-.factory('EndpointService', ['$q', 'Endpoints', 'FileUploadService', function EndpointServiceFactory($q, Endpoints, FileUploadService) {
+.factory('EndpointService', ['$q', 'Endpoints', 'FileUploadService',
+function EndpointServiceFactory($q, Endpoints, FileUploadService) {
   'use strict';
   var service = {};
 

--- a/app/portainer/services/api/extensionService.js
+++ b/app/portainer/services/api/extensionService.js
@@ -3,14 +3,17 @@ angular.module('portainer.app')
   'use strict';
   var service = {};
 
-  service.registerStoridgeExtension = function(endpointId, url) {
+  service.registerStoridgeExtension = function(url) {
     var payload = {
-      endpointId: endpointId,
       Type: 1,
       URL: url
     };
 
     return Extensions.register(payload).$promise;
+  };
+
+  service.deregisterStoridgeExtension = function() {
+    return Extensions.deregister({ type: 1 }).$promise;
   };
 
   return service;

--- a/app/portainer/services/extensionManager.js
+++ b/app/portainer/services/extensionManager.js
@@ -4,7 +4,7 @@ function ExtensionManagerFactory($q, PluginService, SystemService, ExtensionServ
   'use strict';
   var service = {};
 
-  service.initEndpointExtensions = function(endpointId) {
+  service.initEndpointExtensions = function() {
     var deferred = $q.defer();
 
     SystemService.version()
@@ -12,13 +12,11 @@ function ExtensionManagerFactory($q, PluginService, SystemService, ExtensionServ
       var endpointAPIVersion = parseFloat(data.ApiVersion);
 
       return $q.all([
-        endpointAPIVersion >= 1.25 ? initStoridgeExtension(endpointId): null
+        endpointAPIVersion >= 1.25 ? initStoridgeExtension(): null
       ]);
     })
     .then(function success(data) {
-      var extensions = data.filter(function filterNull(x) {
-        return x;
-      });
+      var extensions = data;
       deferred.resolve(extensions);
     })
     .catch(function error(err) {
@@ -28,14 +26,16 @@ function ExtensionManagerFactory($q, PluginService, SystemService, ExtensionServ
     return deferred.promise;
   };
 
-  function initStoridgeExtension(endpointId) {
+  function initStoridgeExtension() {
     var deferred = $q.defer();
 
     PluginService.volumePlugins()
     .then(function success(data) {
       var volumePlugins = data;
       if (_.includes(volumePlugins, 'cio:latest')) {
-        return registerStoridgeUsingSwarmManagerIP(endpointId);
+        return registerStoridgeUsingSwarmManagerIP();
+      } else {
+        return deregisterStoridgeExtension();
       }
     })
     .then(function success(data) {
@@ -48,14 +48,15 @@ function ExtensionManagerFactory($q, PluginService, SystemService, ExtensionServ
     return deferred.promise;
   }
 
-  function registerStoridgeUsingSwarmManagerIP(endpointId) {
+  function registerStoridgeUsingSwarmManagerIP() {
     var deferred = $q.defer();
 
     SystemService.info()
     .then(function success(data) {
       var managerIP = data.Swarm.NodeAddr;
-      var storidgeAPIURL = 'tcp://' + managerIP + ':8282';
-      return ExtensionService.registerStoridgeExtension(endpointId, storidgeAPIURL);
+      // var storidgeAPIURL = 'tcp://' + managerIP + ':8282';
+      var storidgeAPIURL = 'tcp://home.cresswell.net.nz:8282';
+      return ExtensionService.registerStoridgeExtension(storidgeAPIURL);
     })
     .then(function success(data) {
       deferred.resolve(data);
@@ -65,6 +66,10 @@ function ExtensionManagerFactory($q, PluginService, SystemService, ExtensionServ
     });
 
     return deferred.promise;
+  }
+
+  function deregisterStoridgeExtension() {
+    return ExtensionService.deregisterStoridgeExtension();
   }
 
   return service;

--- a/app/portainer/views/auth/authController.js
+++ b/app/portainer/views/auth/authController.js
@@ -1,6 +1,6 @@
 angular.module('portainer.app')
-.controller('AuthenticationController', ['$scope', '$state', '$transition$', '$window', '$timeout', '$sanitize', 'Authentication', 'Users', 'UserService', 'EndpointService', 'StateManager', 'EndpointProvider', 'Notifications', 'SettingsService',
-function ($scope, $state, $transition$, $window, $timeout, $sanitize, Authentication, Users, UserService, EndpointService, StateManager, EndpointProvider, Notifications, SettingsService) {
+.controller('AuthenticationController', ['$scope', '$state', '$transition$', '$window', '$timeout', '$sanitize', 'Authentication', 'Users', 'UserService', 'EndpointService', 'StateManager', 'EndpointProvider', 'Notifications', 'SettingsService', 'ExtensionManager',
+function ($scope, $state, $transition$, $window, $timeout, $sanitize, Authentication, Users, UserService, EndpointService, StateManager, EndpointProvider, Notifications, SettingsService, ExtensionManager) {
 
   $scope.logo = StateManager.getState().application.logo;
 
@@ -18,7 +18,12 @@ function ($scope, $state, $transition$, $window, $timeout, $sanitize, Authentica
     if (!endpointID) {
       EndpointProvider.setEndpointID(endpoint.Id);
     }
-    StateManager.updateEndpointState(true, endpoint.Extensions)
+
+    ExtensionManager.initEndpointExtensions(endpoint.Id)
+    .then(function success(data) {
+      var extensions = data;
+      return StateManager.updateEndpointState(true, extensions);
+    })
     .then(function success(data) {
       $state.go('docker.dashboard');
     })

--- a/app/portainer/views/endpoints/endpointsController.js
+++ b/app/portainer/views/endpoints/endpointsController.js
@@ -1,6 +1,6 @@
 angular.module('portainer.app')
-.controller('EndpointsController', ['$scope', '$state', '$filter',  'EndpointService', 'Notifications', 'ExtensionManager', 'EndpointProvider',
-function ($scope, $state, $filter, EndpointService, Notifications, ExtensionManager, EndpointProvider) {
+.controller('EndpointsController', ['$scope', '$state', '$filter',  'EndpointService', 'Notifications', 'SystemService', 'EndpointProvider',
+function ($scope, $state, $filter, EndpointService, Notifications, SystemService, EndpointProvider) {
   $scope.state = {
     uploadInProgress: false,
     actionInProgress: false
@@ -37,8 +37,8 @@ function ($scope, $state, $filter, EndpointService, Notifications, ExtensionMana
       endpointId = data.Id;
       var currentEndpointId = EndpointProvider.endpointID();
       EndpointProvider.setEndpointID(endpointId);
-      ExtensionManager.initEndpointExtensions(endpointId)
-      .then(function success(data) {
+      SystemService.info()
+      .then(function success() {
         Notifications.success('Endpoint created', name);
         $state.reload();
       })

--- a/app/portainer/views/sidebar/sidebarController.js
+++ b/app/portainer/views/sidebar/sidebarController.js
@@ -1,6 +1,6 @@
 angular.module('portainer.app')
-.controller('SidebarController', ['$q', '$scope', '$state', 'Settings', 'EndpointService', 'StateManager', 'EndpointProvider', 'Notifications', 'Authentication', 'UserService',
-function ($q, $scope, $state, Settings, EndpointService, StateManager, EndpointProvider, Notifications, Authentication, UserService) {
+.controller('SidebarController', ['$q', '$scope', '$state', 'Settings', 'EndpointService', 'StateManager', 'EndpointProvider', 'Notifications', 'Authentication', 'UserService', 'ExtensionManager',
+function ($q, $scope, $state, Settings, EndpointService, StateManager, EndpointProvider, Notifications, Authentication, UserService, ExtensionManager) {
 
   $scope.switchEndpoint = function(endpoint) {
     var activeEndpointID = EndpointProvider.endpointID();
@@ -8,7 +8,11 @@ function ($q, $scope, $state, Settings, EndpointService, StateManager, EndpointP
     EndpointProvider.setEndpointID(endpoint.Id);
     EndpointProvider.setEndpointPublicURL(endpoint.PublicURL);
 
-    StateManager.updateEndpointState(true, endpoint.Extensions)
+    ExtensionManager.initEndpointExtensions(endpoint.Id)
+    .then(function success(data) {
+      var extensions = data;
+      return StateManager.updateEndpointState(true, extensions);
+    })
     .then(function success() {
       $state.go('docker.dashboard');
     })


### PR DESCRIPTION
This PR changes the behavior of extension management:

* Upon the init of the endpoint, endpoint extensions are checked
* Upon switching endpoint using the dropdown, endpoint extensions are checked
* After login, endpoint extensions are checked

Also, the endpoint extension check now implies the following:

Check if the extension can be enabled, if yes, register the extension in the endpoint. If no, send a request to remove the extension (will be removed if it exists, otherwise ignored)