### PR TITLE
chore(momentjs): upgrade momentjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.3.1",
     "js-yaml": "~3.10.0",
     "lodash": "4.12.0",
-    "moment": "~2.14.1",
+    "moment": "^2.21.0",
     "ng-file-upload": "~12.2.13",
     "rdash-ui": "1.0.*",
     "splitargs": "github:deviantony/splitargs#~0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,9 +2882,13 @@ mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.10.6, moment@~2.14.1:
+moment@^2.10.6:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.14.1.tgz#b35b27c47e57ed2ddc70053d6b07becdb291741c"
+
+moment@^2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 morgan@~1.6.1:
   version "1.6.1"


### PR DESCRIPTION
This PR upgrades momentjs library to version 2.21.0.