### PR TITLE
feat(image-details): display image layer depth and sort by it by default (#1706)

### DIFF
--- a/app/docker/models/imageLayer.js
+++ b/app/docker/models/imageLayer.js
@@ -1,4 +1,5 @@
-function ImageLayerViewModel(data) {
+function ImageLayerViewModel(depth, data) {
+  this.Depth = depth;
   this.Id = data.Id;
   this.Created = data.Created;
   this.CreatedBy = data.CreatedBy;

--- a/app/docker/models/imageLayer.js
+++ b/app/docker/models/imageLayer.js
@@ -1,5 +1,5 @@
-function ImageLayerViewModel(depth, data) {
-  this.Depth = depth;
+function ImageLayerViewModel(order, data) {
+  this.Order = order;
   this.Id = data.Id;
   this.Created = data.Created;
   this.CreatedBy = data.CreatedBy;

--- a/app/docker/services/imageService.js
+++ b/app/docker/services/imageService.js
@@ -57,8 +57,10 @@ angular.module('portainer.docker')
         deferred.reject({ msg: data.message });
       } else {
         var layers = [];
+        var depth = data.length;
         angular.forEach(data, function(imageLayer) {
-          layers.push(new ImageLayerViewModel(imageLayer));
+          layers.push(new ImageLayerViewModel(depth, imageLayer));
+          depth--;
         });
         deferred.resolve(layers);
       }

--- a/app/docker/services/imageService.js
+++ b/app/docker/services/imageService.js
@@ -57,10 +57,10 @@ angular.module('portainer.docker')
         deferred.reject({ msg: data.message });
       } else {
         var layers = [];
-        var depth = data.length;
+        var order = data.length;
         angular.forEach(data, function(imageLayer) {
-          layers.push(new ImageLayerViewModel(depth, imageLayer));
-          depth--;
+          layers.push(new ImageLayerViewModel(order, imageLayer));
+          order--;
         });
         deferred.resolve(layers);
       }

--- a/app/docker/views/images/edit/image.html
+++ b/app/docker/views/images/edit/image.html
@@ -183,10 +183,10 @@
         <table id="image-layers" class="table">
           <thead>
             <th style="white-space:nowrap;">
-              <a ng-click="order('Depth')">
-                Depth
-                <span ng-show="sortType == 'Depth' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
-                <span ng-show="sortType == 'Depth' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
+              <a ng-click="order('Order')">
+                Order
+                <span ng-show="sortType == 'Order' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
+                <span ng-show="sortType == 'Order' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
               </a>
             </th>
             <th>
@@ -207,7 +207,7 @@
           <tbody>
             <tr ng-repeat="layer in history | orderBy:sortType:sortReverse">
               <td style="white-space:nowrap;">
-                {{ layer.Depth }}
+                {{ layer.Order }}
               </td>
               <td style="white-space:nowrap;">
                 {{ layer.Size | humansize }}

--- a/app/docker/views/images/edit/image.html
+++ b/app/docker/views/images/edit/image.html
@@ -182,6 +182,13 @@
       <rd-widget-body classes="no-padding">
         <table id="image-layers" class="table">
           <thead>
+            <th style="white-space:nowrap;">
+              <a ng-click="order('Depth')">
+                Depth
+                <span ng-show="sortType == 'Depth' && !sortReverse" class="glyphicon glyphicon-chevron-down"></span>
+                <span ng-show="sortType == 'Depth' && sortReverse" class="glyphicon glyphicon-chevron-up"></span>
+              </a>
+            </th>
             <th>
               <a ng-click="order('Size')">
                 Size
@@ -199,6 +206,9 @@
           </thead>
           <tbody>
             <tr ng-repeat="layer in history | orderBy:sortType:sortReverse">
+              <td style="white-space:nowrap;">
+                {{ layer.Depth }}
+              </td>
               <td style="white-space:nowrap;">
                 {{ layer.Size | humansize }}
               </td>

--- a/app/docker/views/images/edit/imageController.js
+++ b/app/docker/views/images/edit/imageController.js
@@ -6,7 +6,7 @@ function ($q, $scope, $transition$, $state, $timeout, ImageService, RegistryServ
 		Registry: ''
 	};
 
-	$scope.sortType = 'Depth';
+	$scope.sortType = 'Order';
 	$scope.sortReverse = true;
 
 	$scope.order = function(sortType) {

--- a/app/docker/views/images/edit/imageController.js
+++ b/app/docker/views/images/edit/imageController.js
@@ -6,8 +6,8 @@ function ($q, $scope, $transition$, $state, $timeout, ImageService, RegistryServ
 		Registry: ''
 	};
 
-	$scope.sortType = 'Size';
-  $scope.sortReverse = true;
+	$scope.sortType = 'Depth';
+	$scope.sortReverse = true;
 
 	$scope.order = function(sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;

--- a/app/docker/views/images/edit/imageController.js
+++ b/app/docker/views/images/edit/imageController.js
@@ -7,7 +7,7 @@ function ($q, $scope, $transition$, $state, $timeout, ImageService, RegistryServ
 	};
 
 	$scope.sortType = 'Order';
-	$scope.sortReverse = true;
+	$scope.sortReverse = false;
 
 	$scope.order = function(sortType) {
     $scope.sortReverse = ($scope.sortType === sortType) ? !$scope.sortReverse : false;


### PR DESCRIPTION
This pull request adds new column named "Depth" to the table with image layers and changes default sorting to use that column.

Fixes #1706

Screenshot:
![portainer-image-layers-depth](https://user-images.githubusercontent.com/3846677/37257162-9f372aa8-2565-11e8-8795-5ecf85577390.png)
