### PR TITLE
fix(api): use EntryPoint as a reference to overwrite stack Compose file

### DIFF
--- a/api/filesystem/filesystem.go
+++ b/api/filesystem/filesystem.go
@@ -76,14 +76,14 @@ func (service *Service) GetStackProjectPath(stackIdentifier string) string {
 
 // StoreStackFileFromString creates a subfolder in the ComposeStorePath and stores a new file using the content from a string.
 // It returns the path to the folder where the file is stored.
-func (service *Service) StoreStackFileFromString(stackIdentifier, stackFileContent string) (string, error) {
+func (service *Service) StoreStackFileFromString(stackIdentifier, fileName, stackFileContent string) (string, error) {
 	stackStorePath := path.Join(ComposeStorePath, stackIdentifier)
 	err := service.createDirectoryInStoreIfNotExist(stackStorePath)
 	if err != nil {
 		return "", err
 	}
 
-	composeFilePath := path.Join(stackStorePath, ComposeFileDefaultName)
+	composeFilePath := path.Join(stackStorePath, fileName)
 	data := []byte(stackFileContent)
 	r := bytes.NewReader(data)
 
@@ -97,14 +97,14 @@ func (service *Service) StoreStackFileFromString(stackIdentifier, stackFileConte
 
 // StoreStackFileFromReader creates a subfolder in the ComposeStorePath and stores a new file using the content from an io.Reader.
 // It returns the path to the folder where the file is stored.
-func (service *Service) StoreStackFileFromReader(stackIdentifier string, r io.Reader) (string, error) {
+func (service *Service) StoreStackFileFromReader(stackIdentifier, fileName string, r io.Reader) (string, error) {
 	stackStorePath := path.Join(ComposeStorePath, stackIdentifier)
 	err := service.createDirectoryInStoreIfNotExist(stackStorePath)
 	if err != nil {
 		return "", err
 	}
 
-	composeFilePath := path.Join(stackStorePath, ComposeFileDefaultName)
+	composeFilePath := path.Join(stackStorePath, fileName)
 
 	err = service.createFileInStore(composeFilePath, r)
 	if err != nil {

--- a/api/http/handler/stack.go
+++ b/api/http/handler/stack.go
@@ -179,7 +179,7 @@ func (handler *StackHandler) handlePostStacksStringMethod(w http.ResponseWriter,
 		Env:        req.Env,
 	}
 
-	projectPath, err := handler.FileService.StoreStackFileFromString(string(stack.ID), stackFileContent)
+	projectPath, err := handler.FileService.StoreStackFileFromString(string(stack.ID), stack.EntryPoint, stackFileContent)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -431,7 +431,7 @@ func (handler *StackHandler) handlePostStacksFileMethod(w http.ResponseWriter, r
 		Env:        env,
 	}
 
-	projectPath, err := handler.FileService.StoreStackFileFromReader(string(stack.ID), stackFile)
+	projectPath, err := handler.FileService.StoreStackFileFromReader(string(stack.ID), stack.EntryPoint, stackFile)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return
@@ -631,7 +631,7 @@ func (handler *StackHandler) handlePutStack(w http.ResponseWriter, r *http.Reque
 	}
 	stack.Env = req.Env
 
-	_, err = handler.FileService.StoreStackFileFromString(string(stack.ID), req.StackFileContent)
+	_, err = handler.FileService.StoreStackFileFromString(string(stack.ID), stack.EntryPoint, req.StackFileContent)
 	if err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, handler.Logger)
 		return

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -369,8 +369,8 @@ type (
 		DeleteTLSFile(folder string, fileType TLSFileType) error
 		DeleteTLSFiles(folder string) error
 		GetStackProjectPath(stackIdentifier string) string
-		StoreStackFileFromString(stackIdentifier string, stackFileContent string) (string, error)
-		StoreStackFileFromReader(stackIdentifier string, r io.Reader) (string, error)
+		StoreStackFileFromString(stackIdentifier, fileName, stackFileContent string) (string, error)
+		StoreStackFileFromReader(stackIdentifier, fileName string, r io.Reader) (string, error)
 	}
 
 	// GitService represents a service for managing Git.


### PR DESCRIPTION
Fix #1723 