### PR TITLE
Add security HTTP Headers

### DIFF
--- a/api/http/handler/file.go
+++ b/api/http/handler/file.go
@@ -33,7 +33,7 @@ func isHTML(acceptContent []string) bool {
 }
 
 func (handler *FileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	//Security headers (concerning owasp rules)
+	//Security headers (According to Owasp recommendations)
 	w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/api/http/handler/file.go
+++ b/api/http/handler/file.go
@@ -35,7 +35,7 @@ func isHTML(acceptContent []string) bool {
 func (handler *FileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !isHTML(r.Header["Accept"]) {
 		w.Header().Set("Cache-Control", "max-age=31536000")
-		w.Header().Set("X-XSS-Protection", ""1; mode=block"")
+		w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 	} else {

--- a/api/http/handler/file.go
+++ b/api/http/handler/file.go
@@ -33,11 +33,13 @@ func isHTML(acceptContent []string) bool {
 }
 
 func (handler *FileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	//Security headers (concerning owasp rules)
+	w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	
 	if !isHTML(r.Header["Accept"]) {
 		w.Header().Set("Cache-Control", "max-age=31536000")
-		w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
-		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
 	} else {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}

--- a/api/http/handler/file.go
+++ b/api/http/handler/file.go
@@ -35,6 +35,9 @@ func isHTML(acceptContent []string) bool {
 func (handler *FileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !isHTML(r.Header["Accept"]) {
 		w.Header().Set("Cache-Control", "max-age=31536000")
+		w.Header().Set("X-XSS-Protection", ""1; mode=block"")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 	} else {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -73,7 +73,7 @@ func (bouncer *RequestBouncer) AdministratorAccess(h http.Handler) http.Handler 
 // mwSecureHeaders provides secure headers middleware for handlers.
 func mwSecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
+		w.Header().Add("X-XSS-Protection", "\"1; mode=block\"")
  		w.Header().Add("X-Content-Type-Options", "nosniff")
 		w.Header().Add("X-Frame-Options", "DENY")
 		next.ServeHTTP(w, r)

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -73,7 +73,8 @@ func (bouncer *RequestBouncer) AdministratorAccess(h http.Handler) http.Handler 
 // mwSecureHeaders provides secure headers middleware for handlers.
 func mwSecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
+ 		w.Header().Add("X-Content-Type-Options", "nosniff")
 		w.Header().Add("X-Frame-Options", "DENY")
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Some http security headers in the portainer.
To avoid problems with xss and Clickjacking attacks.