### PR TITLE
style(dashbard) avoid long container name to display on new line

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -132,6 +132,10 @@ a[ng-click]{
   font-weight: normal;
 }
 
+.widget .widget-body table tbody td {
+  white-space: nowrap; 
+}
+
 .template-widget {
   height: 100%;
 }


### PR DESCRIPTION
This avoids containers name to be displayed on newline if they're longer than expected.

Close #1767 