### PR TITLE
style(services): format stop grace period (fix #1772)

### DIFF
--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -402,6 +402,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     service.RestartDelay = ServiceHelper.translateNanosToHumanDuration(service.RestartDelay) || '5s';
     service.RestartWindow = ServiceHelper.translateNanosToHumanDuration(service.RestartWindow) || '0s';
     service.UpdateDelay = ServiceHelper.translateNanosToHumanDuration(service.UpdateDelay) || '0s';
+    service.StopGracePeriod = (service.StopGracePeriod ? ServiceHelper.translateNanosToHumanDuration(service.StopGracePeriod) : '');
   }
 
   function initView() {

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -402,7 +402,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     service.RestartDelay = ServiceHelper.translateNanosToHumanDuration(service.RestartDelay) || '5s';
     service.RestartWindow = ServiceHelper.translateNanosToHumanDuration(service.RestartWindow) || '0s';
     service.UpdateDelay = ServiceHelper.translateNanosToHumanDuration(service.UpdateDelay) || '0s';
-    service.StopGracePeriod = (service.StopGracePeriod ? ServiceHelper.translateNanosToHumanDuration(service.StopGracePeriod) : '');
+    service.StopGracePeriod = service.StopGracePeriod ? ServiceHelper.translateNanosToHumanDuration(service.StopGracePeriod) : '';
   }
 
   function initView() {


### PR DESCRIPTION
The stop-grace-period is now shown in a human-friendly format e.g. 10s, 15m.

To avoid misinterpretations the field is left blank if the value of the attribute is 0, which means it has not been set.

Close #1772 