### PR TITLE
feat(swarm-visualizer): save settings to local storage

### DIFF
--- a/app/docker/views/swarm/visualizer/swarmVisualizerController.js
+++ b/app/docker/views/swarm/visualizer/swarmVisualizerController.js
@@ -3,21 +3,21 @@ angular.module('portainer.docker')
 function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskService, Notifications, LocalStorage) {
 
   $scope.state = {
-    ShowInformationPanel: LocalStorage.getSwarmVisualizerSettings("show_info_panel", true),
-    DisplayOnlyRunningTasks: LocalStorage.getSwarmVisualizerSettings("display_only_running_tasks", false),
-    refreshRate: LocalStorage.getSwarmVisualizerSettings("refresh_rate", '5')
+    ShowInformationPanel: LocalStorage.getSwarmVisualizerSettings('show_info_panel', true),
+    DisplayOnlyRunningTasks: LocalStorage.getSwarmVisualizerSettings('display_only_running_tasks', false),
+    refreshRate: LocalStorage.getSwarmVisualizerSettings('refresh_rate', '5')
   };
 
   $scope.$on('$destroy', function() {
     stopRepeater();
   });
 
-  $scope.$watch("state.DisplayOnlyRunningTasks", function(newVal, oldVal) {
-    LocalStorage.storeSwarmVisualizerSettings("display_only_running_tasks", newVal);
+  $scope.$watch('state.DisplayOnlyRunningTasks', function(newVal, oldVal) {
+    LocalStorage.storeSwarmVisualizerSettings('display_only_running_tasks', newVal);
   });
 
-  $scope.$watch("state.ShowInformationPanel", function(newVal, oldVal) {
-    LocalStorage.storeSwarmVisualizerSettings("show_info_panel", newVal);
+  $scope.$watch('state.ShowInformationPanel', function(newVal, oldVal) {
+    LocalStorage.storeSwarmVisualizerSettings('show_info_panel', newVal);
   });
   
   $scope.changeUpdateRepeater = function() {
@@ -58,7 +58,7 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
       });
     }, refreshRate * 1000);
     
-    LocalStorage.storeSwarmVisualizerSettings("refresh_rate", refreshRate);
+    LocalStorage.storeSwarmVisualizerSettings('refresh_rate', refreshRate);
   }
 
 

--- a/app/docker/views/swarm/visualizer/swarmVisualizerController.js
+++ b/app/docker/views/swarm/visualizer/swarmVisualizerController.js
@@ -5,26 +5,29 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
   $scope.state = {
     ShowInformationPanel: true,
     DisplayOnlyRunningTasks: false,
-    refreshRate: '5',
+    refreshRate: '5'
   };
 
   $scope.$on('$destroy', function() {
     stopRepeater();
   });
 
-  $scope.$watch('state.DisplayOnlyRunningTasks', function(newVal, oldVal) {
-    LocalStorage.storeSwarmVisualizerSettings('display_only_running_tasks', newVal);
-  });
+  $scope.changeShowInformationPanel = function(value) {
+      $scope.state.ShowInformationPanel = value;
+      LocalStorage.storeSwarmVisualizerSettings('show_info_panel', value);
+  };
 
-  $scope.$watch('state.ShowInformationPanel', function(newVal, oldVal) {
-    LocalStorage.storeSwarmVisualizerSettings('show_info_panel', newVal);
-  });
-  
+  $scope.changeDisplayOnlyRunningTasks = function() {
+      var value = $scope.state.DisplayOnlyRunningTasks;
+      LocalStorage.storeSwarmVisualizerSettings('display_only_running_tasks', value);
+  };
+
   $scope.changeUpdateRepeater = function() {
     stopRepeater();
     setUpdateRepeater();
     $('#refreshRateChange').show();
     $('#refreshRateChange').fadeOut(1500);
+    LocalStorage.storeSwarmVisualizerSettings('refresh_rate', $scope.state.refreshRate);
   };
 
   function stopRepeater() {
@@ -57,10 +60,7 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
         Notifications.error('Failure', err, 'Unable to retrieve cluster information');
       });
     }, refreshRate * 1000);
-    
-    LocalStorage.storeSwarmVisualizerSettings('refresh_rate', refreshRate);
   }
-
 
   function assignServiceInfo(services, tasks) {
     for (var i = 0; i < services.length; i++) {

--- a/app/docker/views/swarm/visualizer/swarmVisualizerController.js
+++ b/app/docker/views/swarm/visualizer/swarmVisualizerController.js
@@ -1,17 +1,25 @@
 angular.module('portainer.docker')
-.controller('SwarmVisualizerController', ['$q', '$scope', '$document', '$interval', 'NodeService', 'ServiceService', 'TaskService', 'Notifications',
-function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskService, Notifications) {
+.controller('SwarmVisualizerController', ['$q', '$scope', '$document', '$interval', 'NodeService', 'ServiceService', 'TaskService', 'Notifications', 'LocalStorage',
+function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskService, Notifications, LocalStorage) {
 
   $scope.state = {
-    ShowInformationPanel: true,
-    DisplayOnlyRunningTasks: false,
-    refreshRate: '5'
+    ShowInformationPanel: LocalStorage.getSwarmVisualizerSettings("show_info_panel", true),
+    DisplayOnlyRunningTasks: LocalStorage.getSwarmVisualizerSettings("display_only_running_tasks", false),
+    refreshRate: LocalStorage.getSwarmVisualizerSettings("refresh_rate", '5')
   };
 
   $scope.$on('$destroy', function() {
     stopRepeater();
   });
 
+  $scope.$watch("state.DisplayOnlyRunningTasks", function(newVal, oldVal) {
+    LocalStorage.storeSwarmVisualizerSettings("display_only_running_tasks", newVal);
+  });
+
+  $scope.$watch("state.ShowInformationPanel", function(newVal, oldVal) {
+    LocalStorage.storeSwarmVisualizerSettings("show_info_panel", newVal);
+  });
+  
   $scope.changeUpdateRepeater = function() {
     stopRepeater();
     setUpdateRepeater();
@@ -49,6 +57,8 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
         Notifications.error('Failure', err, 'Unable to retrieve cluster information');
       });
     }, refreshRate * 1000);
+    
+    LocalStorage.storeSwarmVisualizerSettings("refresh_rate", refreshRate);
   }
 
 

--- a/app/docker/views/swarm/visualizer/swarmVisualizerController.js
+++ b/app/docker/views/swarm/visualizer/swarmVisualizerController.js
@@ -3,9 +3,9 @@ angular.module('portainer.docker')
 function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskService, Notifications, LocalStorage) {
 
   $scope.state = {
-    ShowInformationPanel: LocalStorage.getSwarmVisualizerSettings('show_info_panel', true),
-    DisplayOnlyRunningTasks: LocalStorage.getSwarmVisualizerSettings('display_only_running_tasks', false),
-    refreshRate: LocalStorage.getSwarmVisualizerSettings('refresh_rate', '5')
+    ShowInformationPanel: true,
+    DisplayOnlyRunningTasks: false,
+    refreshRate: '5',
   };
 
   $scope.$on('$destroy', function() {
@@ -120,6 +120,18 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to initialize cluster visualizer');
     });
+    
+    var showInfoPanel = LocalStorage.getSwarmVisualizerSettings('show_info_panel');
+    if (showInfoPanel !== undefined && showInfoPanel !== null)
+        $scope.state.ShowInformationPanel = showInfoPanel;
+    
+    var displayOnlyRunningTasks = LocalStorage.getSwarmVisualizerSettings('display_only_running_tasks');
+    if (displayOnlyRunningTasks !== undefined && displayOnlyRunningTasks !== null)
+        $scope.state.DisplayOnlyRunningTasks = displayOnlyRunningTasks;
+    
+    var refreshRate = LocalStorage.getSwarmVisualizerSettings('refresh_rate');
+    if (refreshRate !== undefined && refreshRate !== null)
+        $scope.state.refreshRate = refreshRate;
   }
 
   initView();

--- a/app/docker/views/swarm/visualizer/swarmVisualizerController.js
+++ b/app/docker/views/swarm/visualizer/swarmVisualizerController.js
@@ -101,6 +101,20 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
     $scope.visualizerData = visualizerData;
   }
 
+  function loadState() {
+    var showInfoPanel = LocalStorage.getSwarmVisualizerSettings('show_info_panel');
+    if (showInfoPanel !== undefined && showInfoPanel !== null)
+        $scope.state.ShowInformationPanel = showInfoPanel;
+
+    var displayOnlyRunningTasks = LocalStorage.getSwarmVisualizerSettings('display_only_running_tasks');
+    if (displayOnlyRunningTasks !== undefined && displayOnlyRunningTasks !== null)
+        $scope.state.DisplayOnlyRunningTasks = displayOnlyRunningTasks;
+
+    var refreshRate = LocalStorage.getSwarmVisualizerSettings('refresh_rate');
+    if (refreshRate !== undefined && refreshRate !== null)
+        $scope.state.refreshRate = refreshRate;
+  }
+
   function initView() {
     $q.all({
       nodes: NodeService.nodes(),
@@ -120,18 +134,8 @@ function ($q, $scope, $document, $interval, NodeService, ServiceService, TaskSer
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to initialize cluster visualizer');
     });
-    
-    var showInfoPanel = LocalStorage.getSwarmVisualizerSettings('show_info_panel');
-    if (showInfoPanel !== undefined && showInfoPanel !== null)
-        $scope.state.ShowInformationPanel = showInfoPanel;
-    
-    var displayOnlyRunningTasks = LocalStorage.getSwarmVisualizerSettings('display_only_running_tasks');
-    if (displayOnlyRunningTasks !== undefined && displayOnlyRunningTasks !== null)
-        $scope.state.DisplayOnlyRunningTasks = displayOnlyRunningTasks;
-    
-    var refreshRate = LocalStorage.getSwarmVisualizerSettings('refresh_rate');
-    if (refreshRate !== undefined && refreshRate !== null)
-        $scope.state.refreshRate = refreshRate;
+
+    loadState();
   }
 
   initView();

--- a/app/docker/views/swarm/visualizer/swarmvisualizer.html
+++ b/app/docker/views/swarm/visualizer/swarmvisualizer.html
@@ -14,8 +14,8 @@
     <rd-widget>
       <rd-widget-header icon="fa-object-group" title="Cluster information">
         <div class="pull-right">
-          <button type="button" class="btn btn-sm btn-primary" ng-click="state.ShowInformationPanel = true;" ng-if="!state.ShowInformationPanel">Show</button>
-          <button type="button" class="btn btn-sm btn-primary" ng-click="state.ShowInformationPanel = false;" ng-if="state.ShowInformationPanel">Hide</button>
+          <button type="button" class="btn btn-sm btn-primary" ng-click="changeShowInformationPanel(true)" ng-if="!state.ShowInformationPanel">Show</button>
+          <button type="button" class="btn btn-sm btn-primary" ng-click="changeShowInformationPanel(false)" ng-if="state.ShowInformationPanel">Hide</button>
         </div>
       </rd-widget-header>
       <rd-widget-body ng-if="state.ShowInformationPanel">
@@ -45,7 +45,7 @@
                 Only display running tasks
               </label>
               <label class="switch" style="margin-left: 20px;">
-                <input type="checkbox" ng-model="state.DisplayOnlyRunningTasks"><i></i>
+                <input type="checkbox" ng-model="state.DisplayOnlyRunningTasks" ng-change="changeDisplayOnlyRunningTasks()"><i></i>
               </label>
             </div>
           </div>

--- a/app/portainer/services/localStorage.js
+++ b/app/portainer/services/localStorage.js
@@ -62,12 +62,8 @@ angular.module('portainer.app')
     storeSwarmVisualizerSettings: function(key, data) {
       localStorageService.set('swarmvisualizer_' + key, data);
     },
-    getSwarmVisualizerSettings: function(key, defaultVal) {
-      var val = localStorageService.get('swarmvisualizer_' + key);
-      if (val === undefined || val === null)
-          return defaultVal;
-      
-      return val;
+    getSwarmVisualizerSettings: function(key) {
+      return localStorageService.get('swarmvisualizer_' + key);
     },
     clean: function() {
       localStorageService.clearAll();

--- a/app/portainer/services/localStorage.js
+++ b/app/portainer/services/localStorage.js
@@ -59,6 +59,16 @@ angular.module('portainer.app')
     storeDataTableSettings: function(key, data) {
       localStorageService.set('datatable_settings_' + key, data);
     },
+    storeSwarmVisualizerSettings: function(key, data) {
+      localStorageService.set('swarmvisualizer_' + key, data);
+    },
+    getSwarmVisualizerSettings: function(key, defaultVal) {
+      var val = localStorageService.get('swarmvisualizer_' + key);
+      if (val === undefined || val === null)
+          return defaultVal;
+      
+      return val;
+    },
     clean: function() {
       localStorageService.clearAll();
     }


### PR DESCRIPTION
With this pull request changes to settings on the swarm visualizer view are stored to local storage. 

- Hide / Show Status of Information Panel
- Filter: Only display running tasks
- Refresh rate