### PR TITLE
feat(containers): propagate non-primary container IDs in URLs when navigating

### DIFF
--- a/app/docker/views/containers/console/containerconsole.html
+++ b/app/docker/views/containers/console/containerconsole.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Container console"></rd-header-title>
   <rd-header-content ng-if="state.loaded">
-    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container({id: container.Id})">{{ container.Name|trimcontainername }}</a> &gt; Console
+    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container()">{{ container.Name|trimcontainername }}</a> &gt; Console
   </rd-header-content>
 </rd-header>
 

--- a/app/docker/views/containers/edit/container.html
+++ b/app/docker/views/containers/edit/container.html
@@ -2,7 +2,7 @@
   <rd-header-title title="Container details">
   </rd-header-title>
   <rd-header-content>
-    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container({id: container.Id})">{{ container.Name|trimcontainername }}</a>
+    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container()">{{ container.Name|trimcontainername }}</a>
   </rd-header-content>
 </rd-header>
 
@@ -84,10 +84,10 @@
               <tr>
                 <td colspan="2">
                   <div class="btn-group" role="group" aria-label="...">
-                    <a class="btn" type="button" ui-sref="docker.containers.container.stats({id: container.Id})"><i class="fa fa-chart-area space-right" aria-hidden="true"></i>Stats</a>
-                    <a class="btn" type="button" ui-sref="docker.containers.container.logs({id: container.Id})"><i class="fa fa-file-alt space-right" aria-hidden="true"></i>Logs</a>
-                    <a class="btn" type="button" ui-sref="docker.containers.container.console({id: container.Id})"><i class="fa fa-terminal space-right" aria-hidden="true"></i>Console</a>
-                    <a class="btn" type="button" ui-sref="docker.containers.container.inspect({id: container.Id})"><i class="fa fa-info-circle space-right" aria-hidden="true"></i>Inspect</a>
+                    <a class="btn" type="button" ui-sref="docker.containers.container.stats()"><i class="fa fa-chart-area space-right" aria-hidden="true"></i>Stats</a>
+                    <a class="btn" type="button" ui-sref="docker.containers.container.logs()"><i class="fa fa-file-alt space-right" aria-hidden="true"></i>Logs</a>
+                    <a class="btn" type="button" ui-sref="docker.containers.container.console()"><i class="fa fa-terminal space-right" aria-hidden="true"></i>Console</a>
+                    <a class="btn" type="button" ui-sref="docker.containers.container.inspect()"><i class="fa fa-info-circle space-right" aria-hidden="true"></i>Inspect</a>
                   </div>
                 </td>
               </tr>

--- a/app/docker/views/containers/inspect/containerinspect.html
+++ b/app/docker/views/containers/inspect/containerinspect.html
@@ -2,7 +2,7 @@
   <rd-header-title title="Container inspect">
   </rd-header-title>
   <rd-header-content>
-    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container({id: containerInfo.Id})">{{ containerInfo.Name|trimcontainername }}</a> &gt; Inspect
+    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container()">{{ containerInfo.Name|trimcontainername }}</a> &gt; Inspect
   </rd-header-content>
 </rd-header>
 

--- a/app/docker/views/containers/logs/containerlogs.html
+++ b/app/docker/views/containers/logs/containerlogs.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Container logs"></rd-header-title>
   <rd-header-content>
-    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container({id: container.Id})">{{ container.Name|trimcontainername }}</a> &gt; Logs
+    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container()">{{ container.Name|trimcontainername }}</a> &gt; Logs
   </rd-header-content>
 </rd-header>
 

--- a/app/docker/views/containers/stats/containerstats.html
+++ b/app/docker/views/containers/stats/containerstats.html
@@ -1,7 +1,7 @@
 <rd-header>
   <rd-header-title title="Container statistics"></rd-header-title>
   <rd-header-content>
-    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container({id: container.Id})">{{ container.Name|trimcontainername }}</a> &gt; Stats
+    <a ui-sref="docker.containers">Containers</a> &gt; <a ui-sref="docker.containers.container()">{{ container.Name|trimcontainername }}</a> &gt; Stats
   </rd-header-content>
 </rd-header>
 


### PR DESCRIPTION
I've noticed that when you're viewing the details of a container, the URL hash starts with `/containers/<container ID>`, but that it also works if you replace it with `/containers/<container name>`.

I find that this can be useful, because otherwise if I were recreating a container under the same name, I could refresh the page and see the new container, unlike if I were using the container ID which always changes if a container is re-created.

*The problem* is that the container name in the URL gets lost when navigating around within the container details, having the container name replaced back with the ID again.

Although currently there's no way to have the name be in the URL other than manually typing it in, I think it would be great if the web app respected the current type of identifier used, and propagated the name if the name was used, but continue to use ID if that was used.

The change of mine should affect the Stats, Logs, Console, Inspect links in the container details page, and also the breadcrumbs within the container details page and its subpages.

![screenshot from 2018-03-29 17-13-42](https://user-images.githubusercontent.com/116494/38097020-90109466-3374-11e8-885c-58687033e7a1.png)


