### PR TITLE
feat(api): remove any version api before proxying request

### DIFF
--- a/api/http/proxy/transport.go
+++ b/api/http/proxy/transport.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/portainer/portainer"
 	"github.com/portainer/portainer/http/security"
 )
+
+var apiVersionRe = regexp.MustCompile(`(/v[0-9]\.[0-9]*)?`)
 
 type (
 	proxyTransport struct {
@@ -55,7 +58,8 @@ func (p *proxyTransport) executeDockerRequest(request *http.Request) (*http.Resp
 }
 
 func (p *proxyTransport) proxyDockerRequest(request *http.Request) (*http.Response, error) {
-	path := request.URL.Path
+	path := apiVersionRe.ReplaceAllString(request.URL.Path, "")
+	request.URL.Path = path
 
 	switch {
 	case strings.HasPrefix(path, "/configs"):


### PR DESCRIPTION
This PR removes any version path prefix that might be present when using the Docker CLI (`/v1.37/containers/json` -> `/containers/json` for example).