### PR TITLE
#1808 fix(api): add json content-type to all json API responses

### DIFF
--- a/api/http/error/error.go
+++ b/api/http/error/error.go
@@ -17,6 +17,7 @@ func WriteErrorResponse(w http.ResponseWriter, err error, code int, logger *log.
 		logger.Printf("http error: %s (code=%d)", err, code)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(&errorResponse{Err: err.Error()})
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -90,6 +90,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // encodeJSON encodes v to w in JSON format. WriteErrorResponse() is called if encoding fails.
 func encodeJSON(w http.ResponseWriter, v interface{}, logger *log.Logger) {
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		httperror.WriteErrorResponse(w, err, http.StatusInternalServerError, logger)
 	}


### PR DESCRIPTION
This PR fixes #1808 and adds "Content-Type: application/json" header to all api responses.

@deviantony 