### PR TITLE
feat(docker-compose): add docker-compose.yml for deploying as a stack (#1851)`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  portainer:
+    image: portainer/portainer:latest
+    command: -H unix:///var/run/docker.sock
+    ports:
+      - "9000:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    deploy:
+      mode: global
+      placement:
+        constraints: [node.role == manager]
+
+volumes:
+  portainer_data:


### PR DESCRIPTION
Fixes [#1851](https://github.com/portainer/portainer/issues/1851) by including an official `docker-compose.yml`. Users can use this as a base and then build upon it.