### PR TITLE
fix(api): avoid using TLS for endpoint ping if tls disabled but Skip …

### DIFF
--- a/api/http/client/client.go
+++ b/api/http/client/client.go
@@ -22,7 +22,7 @@ func ExecutePingOperationFromEndpoint(endpoint *portainer.Endpoint) (bool, error
 
 	scheme := "http"
 
-	if endpoint.TLSConfig.TLS || endpoint.TLSConfig.TLSSkipVerify {
+	if endpoint.TLSConfig.TLS {
 		tlsConfig, err := crypto.CreateTLSConfiguration(&endpoint.TLSConfig)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Avoid using TLS for pinging if TLS disabled and skipVerify enabled.

Fixes #1889 