### PR TITLE
fix(container): recreate container with multiple networks

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -387,7 +387,14 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     }
     $scope.config.NetworkingConfig.EndpointsConfig[$scope.config.HostConfig.NetworkMode] = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode];
     // Mac Address
-    $scope.formValues.MacAddress = d.NetworkSettings.Networks[$scope.config.HostConfig.NetworkMode].MacAddress;
+    if(Object.keys(d.NetworkSettings.Networks).length) {
+      var firstNetwork = d.NetworkSettings.Networks[Object.keys(d.NetworkSettings.Networks)[0]];
+      $scope.formValues.MacAddress = firstNetwork.MacAddress;
+      $scope.config.NetworkingConfig.EndpointsConfig[$scope.config.HostConfig.NetworkMode] = firstNetwork;
+    } else {
+      $scope.formValues.MacAddress = '';
+    }
+    
     // ExtraHosts
     if ($scope.config.HostConfig.ExtraHosts) {
       var extraHosts = $scope.config.HostConfig.ExtraHosts;

--- a/app/docker/views/containers/create/createcontainer.html
+++ b/app/docker/views/containers/create/createcontainer.html
@@ -126,11 +126,6 @@
                 <span ng-hide="state.actionInProgress">Deploy the container</span>
                 <span ng-show="state.actionInProgress">Deployment in progress...</span>
               </button>
-              <span class="text-danger" ng-if="state.formValidationError" style="margin-left: 5px;">{{ state.formValidationError }}</span>
-              <span ng-if="fromContainerMultipleNetworks" style="margin-left: 10px">
-                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                <span class="small text-muted" style="margin-left: 5px;">This container is connected to multiple networks, only one network will be kept at creation time.</span>
-              </span>
             </div>
           </div>
           <!-- !actions -->


### PR DESCRIPTION
Now Portainer will create a container with the first network from the list(if there is any) and then add other networks after a container creation. I was thinking to add this step before container started inside of `containerService` but I didn't want to mix services together. 

Please let me know what do you think!

Fixes #1849