### PR TITLE
edit Portainer license info so that GitHub recognizes it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Portainer: Copyright (c) 2016 Portainer.io
+Copyright (c) 2018 Portainer.io
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages
@@ -15,45 +15,3 @@ freely, subject to the following restrictions:
 2. Altered source versions must be plainly marked as such, and must not be
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
-
-Portainer contains code which was originally under this license:
-
-UI For Docker: Copyright (c) 2013-2016 Michael Crosby (crosbymichael.com), Kevan Ahlquist (kevanahlquist.com), Anthony Lapenna (portainer.io)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-rdash-angular: Copyright (c) [2014] [Elliot Hesp]
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,13 @@ Unlike the public demo, the playground sessions are deleted after 4 hours. Apart
 Partial support for the following Docker versions (some features may not be available):
 
 * Docker 1.9
+
+## Licensing
+
+Portainer is licensed under the zlib license. See [LICENSE](./LICENSE) for reference.
+
+Portainer also contains the following code, which is licensed under the [MIT license](https://opensource.org/licenses/MIT):
+
+UI For Docker: Copyright (c) 2013-2016 Michael Crosby (crosbymichael.com), Kevan Ahlquist (kevanahlquist.com), Anthony Lapenna (portainer.io)
+
+rdash-angular: Copyright (c) [2014] [Elliot Hesp]


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in
https://landscape.cncf.io/selected=portainer)

GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit modifies a few of Portainer's docs so that Licensee is able
to recognize the repository's license type. It updates LICENSE so that
it contains only the text of the zlib license. It also moves the info
concerning 3rd-party software to a new "Licensing" section in the
README.

Collectively, these changes allow Licensee to successfully identify the
license type of Portainer as zlib.

For comparison purposes, here is the output that I get when I run Licensee locally on Portainer's remote repo:

```
$ licensee detect https://github.com/portainer/portainer
License:        Other
Matched files:  LICENSE
LICENSE:
  Content hash:  673eab1e0c6a41c7033245807db496235bc88703
  License:       Other
  Closest licenses:
    MIT similarity:   73.98%
    NCSA similarity:  67.66%
    Zlib similarity:  65.22%
```

And here is the output that I get when I run Licensee on the `update-license` branch of my local Portainer clone:

```
$ licensee detect ../portainer/
License:        zlib License
Matched files:  LICENSE
LICENSE:
  Content hash:  0e4bcdef920fc4997ebe96a2908a30b08fdc9b09
  Attribution:   Copyright (c) 2018 Portainer.io
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       zlib License
```