### PR TITLE
Dropped support for standalone Docker Swarm documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Unlike the public demo, the playground sessions are deleted after 4 hours. Apart
 **_Portainer_** has full support for the following Docker versions:
 
 * Docker 1.10 to the latest version
-* Docker Swarm >= 1.2.3 (support for standalone Docker Swarm is dropped in Portainer 1.17.0, but the built-in Swarm Mode is fully supported)
+* Standalone Docker Swarm >= 1.2.3 _(**NOTE:** Use of Standalone Docker Swarm is being discouraged since the introduction of built-in Swarm Mode in Docker. While older versions of Portainer had support for Standalone Docker Swarm, Portainer 1.17.0 and newer **do not** support it. However, the built-in Swarm Mode of Docker is fully supported.)_
 
 Partial support for the following Docker versions (some features may not be available):
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Unlike the public demo, the playground sessions are deleted after 4 hours. Apart
 **_Portainer_** has full support for the following Docker versions:
 
 * Docker 1.10 to the latest version
-* Docker Swarm >= 1.2.3
+* Docker Swarm >= 1.2.3 (support for standalone Docker Swarm is dropped in Portainer 1.17.0, but the built-in Swarm Mode is fully supported)
 
 Partial support for the following Docker versions (some features may not be available):
 


### PR DESCRIPTION
README updated to document dropped support for standalone Docker Swarm.