### PR TITLE
#776 feat(templates): support to pass host port mapped to container port

### DIFF
--- a/app/docker/models/template.js
+++ b/app/docker/models/template.js
@@ -40,6 +40,15 @@ function TemplateViewModel(data) {
   this.Ports = [];
   if (data.ports) {
     this.Ports = data.ports.map(function (p) {
+
+      if(_.isObject(p)){
+        return {
+          containerPort: p.container,
+          protocol: p.protocol || 'tcp',
+          hostPort: p.host
+        };
+      }
+
       var portAndProtocol = _.split(p, '/');
       return {
         containerPort: portAndProtocol[0],


### PR DESCRIPTION
@deviantony 

Hi,
  Added support to map host port to the container port using templates as discussed on #776 
 
```
{
      "ports": {
             ["80/tcp"],
             { 
                  "container": "443",
                  "host": "443",
                  "protocol": "tcp"
             }
      }
}
```