### PR TITLE
feat(i18n): multi-language support via front-end method #1134

### DIFF
--- a/build/html-ast/index.js
+++ b/build/html-ast/index.js
@@ -1,0 +1,6 @@
+// https://github.com/HenrikJoreteg/html-parse-stringify
+// merged pr12,13
+module.exports = {
+  parse: require('./parse'),
+  stringify: require('./stringify'),
+};

--- a/build/html-ast/parse-tag.js
+++ b/build/html-ast/parse-tag.js
@@ -1,0 +1,52 @@
+var attrRE = /([\w-]+)|(['"])(.*?)\2/g;
+
+// create optimized lookup object for
+// void elements as listed here:
+// http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
+var lookup = (Object.create) ? Object.create(null) : {};
+lookup.area = true;
+lookup.base = true;
+lookup.br = true;
+lookup.col = true;
+lookup.embed = true;
+lookup.hr = true;
+lookup.img = true;
+lookup.input = true;
+lookup.keygen = true;
+lookup.link = true;
+lookup.menuitem = true;
+lookup.meta = true;
+lookup.param = true;
+lookup.source = true;
+lookup.track = true;
+lookup.wbr = true;
+
+module.exports = function(tag) {
+  var i = 0;
+  var key;
+  var res = {
+    type: 'tag',
+    name: '',
+    voidElement: false,
+    attrs: {},
+    children: [],
+  };
+
+  tag.replace(attrRE, function(match) {
+    if (i % 2) {
+      key = match;
+    } else {
+      if (i === 0) {
+        if (lookup[match] || tag.charAt(tag.length - 2) === '/') {
+          res.voidElement = true;
+        }
+        res.name = match;
+      } else {
+        res.attrs[key] = match.replace(/^['"]|['"]$/g, '');
+      }
+    }
+    i++;
+  });
+
+  return res;
+};

--- a/build/html-ast/parse.js
+++ b/build/html-ast/parse.js
@@ -60,6 +60,9 @@ module.exports = function parse(html, options) {
     }
 
     if (!isOpen || current.voidElement) {
+      // use id to define element
+      current.idx = index;
+
       level--;
       if (!inComponent && nextChar !== '<' && nextChar) {
         // trailing text node

--- a/build/html-ast/parse.js
+++ b/build/html-ast/parse.js
@@ -1,0 +1,86 @@
+/*jshint -W030 */
+var tagRE = /<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g;
+var parseTag = require('./parse-tag');
+// re-used obj for quick lookups of components
+var empty = Object.create ? Object.create(null) : {};
+
+module.exports = function parse(html, options) {
+  options || (options = {});
+  options.components || (options.components = empty);
+  var result = [];
+  var current;
+  var level = -1;
+  var arr = [];
+  var byTag = {};
+  var inComponent = false;
+
+  html.replace(tagRE, function(tag, index) {
+    if (inComponent) {
+      if (tag !== ('</' + current.name + '>')) {
+        return;
+      } else {
+        inComponent = false;
+      }
+    }
+    var isOpen = tag.charAt(1) !== '/';
+    var start = index + tag.length;
+    var nextChar = html.charAt(start);
+    var parent;
+
+    if (isOpen) {
+      level++;
+
+      current = parseTag(tag);
+      if (current.type === 'tag' && options.components[current.name]) {
+        current.type = 'component';
+        inComponent = true;
+      }
+
+      if (!current.voidElement && !inComponent && nextChar && nextChar !== '<') {
+        current.children.push({
+          type: 'text',
+          content: html.slice(start, html.indexOf('<', start)),
+        });
+      }
+
+      byTag[current.tagName] = current;
+
+      // if we're at root, push new base node
+      if (level === 0) {
+        result.push(current);
+      }
+
+      parent = arr[level - 1];
+
+      if (parent) {
+        parent.children.push(current);
+      }
+
+      arr[level] = current;
+    }
+
+    if (!isOpen || current.voidElement) {
+      level--;
+      if (!inComponent && nextChar !== '<' && nextChar) {
+        // trailing text node
+        // if we're at the root, push a base text node. otherwise add as
+        // a child to the current node.
+        parent = level === -1 ? result : arr[level].children;
+
+        // calculate correct end of the content slice in case there's
+        // no tag after the text node.
+        var end = html.indexOf('<', start);
+        var content = html.slice(start, end === -1 ? undefined : end);
+        // if a node is nothing but whitespace, no need to add it.
+        if (!/^\s*$/.test(content)) {
+          parent.push({
+            type: 'text',
+            content: content,
+          });
+        }
+      }
+    }
+  });
+
+  return result;
+};

--- a/build/html-ast/stringify.js
+++ b/build/html-ast/stringify.js
@@ -1,0 +1,29 @@
+function attrString(attrs) {
+  var buff = [];
+  for (var key in attrs) {
+    buff.push(key + '="' + attrs[key] + '"');
+  }
+  if (!buff.length) {
+    return '';
+  }
+  return ' ' + buff.join(' ');
+}
+
+function stringify(buff, doc) {
+  switch (doc.type) {
+    case 'text':
+      return buff + doc.content;
+    case 'tag':
+      buff += '<' + doc.name + (doc.attrs ? attrString(doc.attrs) : '') + (doc.voidElement ? '/>' : '>');
+      if (doc.voidElement) {
+        return buff;
+      }
+      return buff + doc.children.reduce(stringify, '') + '</' + doc.name + '>';
+  }
+}
+
+module.exports = function (doc) {
+  return doc.reduce(function (token, rootEl) {
+    return token + stringify('', rootEl);
+  }, '');
+};

--- a/build/i18n.js
+++ b/build/i18n.js
@@ -1,0 +1,118 @@
+// WIP
+
+const {relative, resolve, join} = require('path');
+const {existsSync, readdirSync, readFileSync, writeFileSync, statSync} = require('fs');
+
+const charset = 'utf-8';
+
+const HTML = require('./html-ast');
+const esprima = require('esprima');
+
+const rootDir = resolve(__dirname, '..');
+const appDir = join(rootDir, 'app');
+
+if (!existsSync(appDir)) {
+  console.log('script path error.');
+  process.exit(404);
+}
+
+/**
+ * Scan file in dir, use ext to filter
+ * @param dirPath
+ * @param ext
+ * @returns {Array}
+ */
+function scandir(dirPath, ext) {
+  const result = readdirSync(dirPath);
+  if (!result.length) return [];
+  return result.map((dirName) => {
+    const filePath = join(dirPath, dirName);
+    if (statSync(filePath).isDirectory()) {
+      return scandir(join(dirPath, dirName), ext);
+    } else {
+      if (!ext) return filePath;
+      if (filePath.lastIndexOf(ext) === filePath.indexOf(ext) && filePath.indexOf(ext) > -1) return filePath;
+      return null;
+    }
+  }).filter(fileIsExist => fileIsExist);
+}
+
+/**
+ * flatten an array
+ * @param arr
+ */
+function flatten(arr) {
+  return arr.reduce(function(flat, toFlatten) {
+    return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);
+  }, []);
+}
+
+/**
+ * Stage 1: Process HTML Templates
+ */
+
+const allTemplateFiles = flatten(scandir(appDir, '.html'));
+
+console.log(`find ${allTemplateFiles.length} HTML templates.`);
+
+function getNodeWithText(nodeList) {
+
+  function isTextNode(node) {
+    return node.type === 'text' && !node.children;
+  }
+
+  function isEmpty(textNode) {
+    return textNode.content.match(/^\n\s+?$/);
+  }
+
+  function isInputNodeWithText(node) {
+    return node.type === 'tag' && node.name === 'input'
+        && node.children && node.children.filter((child) => child.attrs.type === 'text').length;
+  }
+
+  function isLabelNodeWithText(node) {
+    return node.type === 'tag' && node.name === 'label' &&
+        node.children && node.children.filter((child) => child.type === 'text' && child.content).length;
+  }
+
+  return nodeList.map((node) => {
+    if ((isTextNode(node) && !isEmpty(node)) || isInputNodeWithText(node) || isLabelNodeWithText(node)) return node;
+
+    if (node.children) {
+      node.children = getNodeWithText(node.children);
+      return node;
+    } else {
+      // todo: remove it when debug is not necessarily
+      if (!(isTextNode(node) && isEmpty(node))) console.log('not support node', node);
+      return null;
+    }
+  }).filter(nodeIsValid => nodeIsValid);
+}
+
+allTemplateFiles.forEach(file => {
+  const content = readFileSync(file, charset);
+  const ast = HTML.parse(content);
+
+  // node tree with `text`
+  // console.log(
+  //     JSON.stringify(getNodeWithText(ast), null, 4),
+  // );
+});
+// restore via HTML.stringify(...), keep newline etc...
+
+
+// todo:: 1. save ast nodes which contains text someplace
+// todo:: 2. check is there any type node lost
+// todo:: 3. modify ng render func
+
+const allScriptFiles = flatten(scandir(appDir, '.js')).slice(0, 1);
+
+allScriptFiles.forEach(file => {
+
+  const content = readFileSync(file, charset);
+  const ast = esprima.tokenize(content, {range: true}).filter(token => token.type === 'String');
+
+  // echo string write in js logic files.
+  console.log(ast);
+});
+// restore via esprima.parse(...)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "autoprefixer": "^7.1.1",
     "cssnano": "^3.10.0",
     "eslint": "^3.19.0",
+    "esprima": "^4.0.0",
     "grunt": "~0.4.0",
     "grunt-cli": "^1.2.0",
     "grunt-config": "^1.0.0",


### PR DESCRIPTION
This is a demo, full feat is still under WIP status.

- [x] Add front-end string analytics tools
  - [x] Analytics and extract strings content from html,js files.
  - [ ] move nodejs script to the right place.
- [ ] Design string's storage data structure for i18N tools R/W.
  - [x] JavaScript.
  - [ ] HTML
- [ ] Two-way update for project text content and i18N tools database.
    -  [ ] Conflict resolution: base file token position, if token is moved, i18N database remove the record, if the token is exist in file and content hash equl to i18N database hash value, use i18N database file value to update project, or use project text content always.
    - [ ] show database outdated items.
- [ ] Use dynamic injection to hook ng render func, finish render multi-langs.


more details: [feat(i18n): multi-language support #1134](https://github.com/portainer/portainer/pull/1134)