### PR TITLE
fix(containers): remove container stop/restart timeout overload

### DIFF
--- a/app/docker/rest/container.js
+++ b/app/docker/rest/container.js
@@ -15,10 +15,10 @@ function ContainerFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
       method: 'GET', params: { action: 'json' }
     },
     stop: {
-      method: 'POST', params: { id: '@id', t: 5, action: 'stop' }
+      method: 'POST', params: { id: '@id', action: 'stop' }
     },
     restart: {
-      method: 'POST', params: { id: '@id', t: 5, action: 'restart' }
+      method: 'POST', params: { id: '@id', action: 'restart' }
     },
     kill: {
       method: 'POST', params: { id: '@id', action: 'kill' }


### PR DESCRIPTION
REST call to stop/restart a container overrides the default stop timeout (before kill) with hardcoded 5 seconds.
Containers already have a default stop timeout handled by the engine API (https://github.com/moby/moby/blob/master/client/container_stop.go).
With this hardcoded 5 seconds, the containers get killed after 5 seconds even if they define a custom greater stop timeout.
Another solution would be to not hardcode the 5 seconds but rather use a global editable setting.