### PR TITLE
feat(log-viewer): Split auto scrolling & log refresh + wrap lines checkbox

### DIFF
--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -72,7 +72,7 @@
 
 <div class="row" style="height:54%;">
   <div class="col-sm-12" style="height:100%;">
-    <pre ng-class="$ctrl.getLogViewerCSSClass()" scroll-glue="$ctrl.state.autoScroll" force-glue>
+    <pre ng-class="{ 'wrap_lines': $ctrl.state.wrapLines }" class="log_viewer" scroll-glue="$ctrl.state.autoScroll" force-glue>
       <div ng-repeat="line in $ctrl.state.filteredLogs = ($ctrl.data | filter:$ctrl.state.search) track by $index" class="line" ng-if="line"><p class="inner_line" ng-click="$ctrl.selectLine(line)" ng-class="{ 'line_selected': $ctrl.state.selectedLines.indexOf(line) > -1 }">{{ line }}</p></div>
       <div ng-if="!$ctrl.state.filteredLogs.length" class="line"><p class="inner_line">No log line matching the '{{ $ctrl.state.search }}' filter</p></div>
       <div ng-if="$ctrl.state.filteredLogs.length === 1 && !$ctrl.state.filteredLogs[0]" class="line"><p class="inner_line">No logs available</p></div>

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -7,22 +7,11 @@
           <div class="form-group">
             <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
-                Auto-refresh
-                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process."></portainer-tooltip>
+                Auto-refresh logs
+                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
-                <input type="checkbox" ng-model="$ctrl.state.logCollection" ng-change="$ctrl.logCollectionChange($ctrl.state.logCollection)"><i></i>
-              </label>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-sm-12">
-              <label for="tls" class="control-label text-left">
-                Auto-scroll
-                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the auto-scrolling."></portainer-tooltip>
-              </label>
-              <label class="switch" style="margin-left: 20px;">
-                <input type="checkbox" ng-model="$ctrl.state.autoScroll"><i></i>
+                <input type="checkbox" ng-model="$ctrl.state.logCollection" ng-change="$ctrl.state.autoScroll = $ctrl.state.logCollection; $ctrl.logCollectionChange($ctrl.state.logCollection)"><i></i>
               </label>
             </div>
           </div>
@@ -83,7 +72,7 @@
 
 <div class="row" style="height:54%;">
   <div class="col-sm-12" style="height:100%;">
-    <pre ng-class="$ctrl.getLogViewerCSSClass()" scroll-glue="$ctrl.state.autoScroll" force-glue="$ctrl.state.autoScroll ? '' : null">
+    <pre ng-class="$ctrl.getLogViewerCSSClass()" scroll-glue="$ctrl.state.autoScroll" force-glue>
       <div ng-repeat="line in $ctrl.state.filteredLogs = ($ctrl.data | filter:$ctrl.state.search) track by $index" class="line" ng-if="line"><p class="inner_line" ng-click="$ctrl.selectLine(line)" ng-class="{ 'line_selected': $ctrl.state.selectedLines.indexOf(line) > -1 }">{{ line }}</p></div>
       <div ng-if="!$ctrl.state.filteredLogs.length" class="line"><p class="inner_line">No log line matching the '{{ $ctrl.state.search }}' filter</p></div>
       <div ng-if="$ctrl.state.filteredLogs.length === 1 && !$ctrl.state.filteredLogs[0]" class="line"><p class="inner_line">No logs available</p></div>

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -7,11 +7,32 @@
           <div class="form-group">
             <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
-                Auto-refresh logs
-                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
+                Auto-refresh
+                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process."></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
-                <input type="checkbox" ng-model="$ctrl.state.logCollection" ng-change="$ctrl.state.autoScroll = $ctrl.state.logCollection; $ctrl.logCollectionChange($ctrl.state.logCollection)"><i></i>
+                <input type="checkbox" ng-model="$ctrl.state.logCollection" ng-change="$ctrl.logCollectionChange($ctrl.state.logCollection)"><i></i>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-12">
+              <label for="tls" class="control-label text-left">
+                Auto-scroll
+                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the auto-scrolling."></portainer-tooltip>
+              </label>
+              <label class="switch" style="margin-left: 20px;">
+                <input type="checkbox" ng-model="$ctrl.state.autoScroll"><i></i>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-12">
+              <label for="tls" class="control-label text-left">
+                Wrap lines
+              </label>
+              <label class="switch" style="margin-left: 20px;">
+                <input type="checkbox" ng-model="$ctrl.state.wrapLines"><i></i>
               </label>
             </div>
           </div>
@@ -62,7 +83,7 @@
 
 <div class="row" style="height:54%;">
   <div class="col-sm-12" style="height:100%;">
-    <pre class="log_viewer" scroll-glue="$ctrl.state.autoScroll" force-glue>
+    <pre ng-class="$ctrl.getLogViewerCSSClass()" scroll-glue="$ctrl.state.autoScroll" force-glue="$ctrl.state.autoScroll ? '' : null">
       <div ng-repeat="line in $ctrl.state.filteredLogs = ($ctrl.data | filter:$ctrl.state.search) track by $index" class="line" ng-if="line"><p class="inner_line" ng-click="$ctrl.selectLine(line)" ng-class="{ 'line_selected': $ctrl.state.selectedLines.indexOf(line) > -1 }">{{ line }}</p></div>
       <div ng-if="!$ctrl.state.filteredLogs.length" class="line"><p class="inner_line">No log line matching the '{{ $ctrl.state.search }}' filter</p></div>
       <div ng-if="$ctrl.state.filteredLogs.length === 1 && !$ctrl.state.filteredLogs[0]" class="line"><p class="inner_line">No logs available</p></div>

--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -7,6 +7,7 @@ function (clipboard) {
     copySupported: clipboard.supported,
     logCollection: true,
     autoScroll: true,
+    wrapLines: true,
     search: '',
     filteredLogs: [],
     selectedLines: []
@@ -35,5 +36,9 @@ function (clipboard) {
     } else {
       this.state.selectedLines.splice(idx, 1);
     }
+  };
+
+  this.getLogViewerCSSClass = function() {
+    return 'log_viewer' + (this.state.wrapLines ? ' wrap_lines' : '');
   };
 }]);

--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -37,8 +37,4 @@ function (clipboard) {
       this.state.selectedLines.splice(idx, 1);
     }
   };
-
-  this.getLogViewerCSSClass = function() {
-    return 'log_viewer' + (this.state.wrapLines ? ' wrap_lines' : '');
-  };
 }]);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -708,10 +708,13 @@ ul.sidebar .sidebar-list .sidebar-sublist a.active {
 .log_viewer {
   height:100%;
   overflow-y: scroll;
-  white-space: pre-wrap;
   color: black;
   font-size: .85em;
   background-color: white;
+}
+
+.log_viewer.wrap_lines {
+  white-space: pre-wrap;
 }
 
 .log_viewer .inner_line {


### PR DESCRIPTION
Split auto scrolling & log refresh checkboxes + adds wrap settings for lines in log 
![auto-scrolling-and-lines-wrap](https://user-images.githubusercontent.com/907125/41409565-93abd5ae-6fce-11e8-8796-4a0272964a9e.gif)
