### PR TITLE
refactor(api): use a standard stack identifier

### DIFF
--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -31,6 +31,7 @@ type Store struct {
 
 	db                    *bolt.DB
 	checkForDataMigration bool
+	FileService           portainer.FileService
 }
 
 const (
@@ -50,7 +51,7 @@ const (
 )
 
 // NewStore initializes a new Store and the associated services
-func NewStore(storePath string) (*Store, error) {
+func NewStore(storePath string, fileService portainer.FileService) (*Store, error) {
 	store := &Store{
 		Path:                   storePath,
 		UserService:            &UserService{},
@@ -65,6 +66,7 @@ func NewStore(storePath string) (*Store, error) {
 		DockerHubService:       &DockerHubService{},
 		StackService:           &StackService{},
 		TagService:             &TagService{},
+		FileService:            fileService,
 	}
 	store.UserService.store = store
 	store.TeamService.store = store

--- a/api/bolt/migrate_dbversion11.go
+++ b/api/bolt/migrate_dbversion11.go
@@ -1,6 +1,13 @@
 package bolt
 
-import "github.com/portainer/portainer"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/boltdb/bolt"
+	"github.com/portainer/portainer"
+	"github.com/portainer/portainer/bolt/internal"
+)
 
 func (m *Migrator) updateEndpointsToVersion12() error {
 	legacyEndpoints, err := m.EndpointService.Endpoints()
@@ -38,20 +45,89 @@ func (m *Migrator) updateEndpointGroupsToVersion12() error {
 	return nil
 }
 
+type legacyStack struct {
+	ID          string               `json:"Id"`
+	Name        string               `json:"Name"`
+	EndpointID  portainer.EndpointID `json:"EndpointId"`
+	SwarmID     string               `json:"SwarmId"`
+	EntryPoint  string               `json:"EntryPoint"`
+	Env         []portainer.Pair     `json:"Env"`
+	ProjectPath string
+}
+
 func (m *Migrator) updateStacksToVersion12() error {
-	legacyStacks, err := m.StackService.Stacks()
+	legacyStacks, err := m.retrieveLegacyStacks()
 	if err != nil {
 		return err
 	}
 
-	for _, stack := range legacyStacks {
-		stack.Type = portainer.DockerSwarmStack
-
-		err = m.StackService.UpdateStack(stack.ID, &stack)
+	for _, legacyStack := range legacyStacks {
+		err := m.convertLegacyStack(&legacyStack)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (m *Migrator) convertLegacyStack(s *legacyStack) error {
+	stackID := m.StackService.GetNextIdentifier()
+	stack := &portainer.Stack{
+		ID:         portainer.StackID(stackID),
+		Name:       s.Name,
+		Type:       portainer.DockerSwarmStack,
+		SwarmID:    s.SwarmID,
+		EndpointID: 0,
+		EntryPoint: s.EntryPoint,
+		Env:        s.Env,
+	}
+
+	stack.ProjectPath = strings.Replace(s.ProjectPath, s.ID, strconv.Itoa(stackID), 1)
+	err := m.store.FileService.Rename(s.ProjectPath, stack.ProjectPath)
+	if err != nil {
+		return err
+	}
+
+	err = m.deleteLegacyStack(s.ID)
+	if err != nil {
+		return err
+	}
+
+	return m.StackService.CreateStack(stack)
+}
+
+func (m *Migrator) deleteLegacyStack(legacyID string) error {
+	return m.store.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(stackBucketName))
+		err := bucket.Delete([]byte(legacyID))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (m *Migrator) retrieveLegacyStacks() ([]legacyStack, error) {
+	var legacyStacks = make([]legacyStack, 0)
+	err := m.store.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(stackBucketName))
+		cursor := bucket.Cursor()
+
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			var stack legacyStack
+			err := internal.UnmarshalObject(v, &stack)
+			if err != nil {
+				return err
+			}
+			legacyStacks = append(legacyStacks, stack)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return legacyStacks, nil
 }

--- a/api/bolt/migrator.go
+++ b/api/bolt/migrator.go
@@ -14,6 +14,7 @@ type Migrator struct {
 	StackService           *StackService
 	UserService            *UserService
 	VersionService         *VersionService
+	FileService            portainer.FileService
 }
 
 // NewMigrator creates a new Migrator.

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -42,8 +42,8 @@ func initFileService(dataStorePath string) portainer.FileService {
 	return fileService
 }
 
-func initStore(dataStorePath string) *bolt.Store {
-	store, err := bolt.NewStore(dataStorePath)
+func initStore(dataStorePath string, fileService portainer.FileService) *bolt.Store {
+	store, err := bolt.NewStore(dataStorePath, fileService)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func main() {
 
 	fileService := initFileService(*flags.Data)
 
-	store := initStore(*flags.Data)
+	store := initStore(*flags.Data, fileService)
 	defer store.Close()
 
 	jwtService := initJWTService(!*flags.NoAuth)

--- a/api/filesystem/filesystem.go
+++ b/api/filesystem/filesystem.go
@@ -186,6 +186,11 @@ func (service *Service) GetFileContent(filePath string) (string, error) {
 	return string(content), nil
 }
 
+// Rename renames a file or directory
+func (service *Service) Rename(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}
+
 // WriteJSONToFile writes JSON to the specified file.
 func (service *Service) WriteJSONToFile(path string, content interface{}) error {
 	jsonContent, err := json.Marshal(content)

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -46,9 +46,9 @@ func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter,
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerComposeStack,
 		EndpointID: endpoint.ID,
@@ -126,9 +126,9 @@ func (handler *Handler) createComposeStackFromGitRepository(w http.ResponseWrite
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerComposeStack,
 		EndpointID: endpoint.ID,
@@ -211,9 +211,9 @@ func (handler *Handler) createComposeStackFromFileUpload(w http.ResponseWriter, 
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerComposeStack,
 		EndpointID: endpoint.ID,

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -51,9 +51,9 @@ func (handler *Handler) createSwarmStackFromFileContent(w http.ResponseWriter, r
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerSwarmStack,
 		SwarmID:    payload.SwarmID,
@@ -138,9 +138,9 @@ func (handler *Handler) createSwarmStackFromGitRepository(w http.ResponseWriter,
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerSwarmStack,
 		SwarmID:    payload.SwarmID,
@@ -239,9 +239,9 @@ func (handler *Handler) createSwarmStackFromFileUpload(w http.ResponseWriter, r 
 		}
 	}
 
-	stackIdentifier := buildStackIdentifier(payload.Name, endpoint.ID)
+	stackID := handler.StackService.GetNextIdentifier()
 	stack := &portainer.Stack{
-		ID:         portainer.StackID(stackIdentifier),
+		ID:         portainer.StackID(stackID),
 		Name:       payload.Name,
 		Type:       portainer.DockerSwarmStack,
 		SwarmID:    payload.SwarmID,

--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -1,8 +1,8 @@
 package stacks
 
 import (
+	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/portainer/portainer"
 	httperror "github.com/portainer/portainer/http/error"
@@ -15,12 +15,11 @@ func (handler *Handler) cleanUp(stack *portainer.Stack, doCleanUp *bool) error {
 		return nil
 	}
 
-	handler.FileService.RemoveDirectory(stack.ProjectPath)
+	err := handler.FileService.RemoveDirectory(stack.ProjectPath)
+	if err != nil {
+		log.Printf("http error: Unable to cleanup stack creation (err=%s)\n", err)
+	}
 	return nil
-}
-
-func buildStackIdentifier(stackName string, endpointID portainer.EndpointID) string {
-	return stackName + "_" + strconv.Itoa(int(endpointID))
 }
 
 // POST request on /api/stacks?type=<type>&method=<method>&endpointId=<endpointId>

--- a/api/http/handler/stacks/stack_file.go
+++ b/api/http/handler/stacks/stack_file.go
@@ -18,7 +18,7 @@ type stackFileResponse struct {
 
 // GET request on /api/stacks/:id/file
 func (handler *Handler) stackFile(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
-	stackID, err := request.RetrieveRouteVariableValue(r, "id")
+	stackID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid stack identifier route variable", err}
 	}

--- a/api/http/handler/stacks/stack_inspect.go
+++ b/api/http/handler/stacks/stack_inspect.go
@@ -13,7 +13,7 @@ import (
 
 // GET request on /api/stacks/:id
 func (handler *Handler) stackInspect(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
-	stackID, err := request.RetrieveRouteVariableValue(r, "id")
+	stackID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid stack identifier route variable", err}
 	}

--- a/api/http/handler/stacks/stack_update.go
+++ b/api/http/handler/stacks/stack_update.go
@@ -38,7 +38,7 @@ func (payload *updateSwarmStackPayload) Validate(r *http.Request) error {
 
 // PUT request on /api/stacks/:id?endpointId=<endpointId>
 func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
-	stackID, err := request.RetrieveRouteVariableValue(r, "id")
+	stackID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid stack identifier route variable", err}
 	}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -129,7 +129,7 @@ type (
 	}
 
 	// StackID represents a stack identifier (it must be composed of Name + "_" + SwarmID to create a unique identifier).
-	StackID string
+	StackID int
 
 	// StackType represents the type of the stack (compose v2, stack deploy v3).
 	StackType int
@@ -373,6 +373,7 @@ type (
 		CreateStack(stack *Stack) error
 		UpdateStack(ID StackID, stack *Stack) error
 		DeleteStack(ID StackID) error
+		GetNextIdentifier() int
 	}
 
 	// DockerHubService represents a service for managing the DockerHub object.
@@ -434,6 +435,7 @@ type (
 	// FileService represents a service for managing files.
 	FileService interface {
 		GetFileContent(filePath string) (string, error)
+		Rename(oldPath, newPath string) error
 		RemoveDirectory(directoryPath string) error
 		StoreTLSFileFromBytes(folder string, fileType TLSFileType, data []byte) (string, error)
 		GetPathForTLSFile(folder string, fileType TLSFileType) (string, error)


### PR DESCRIPTION
This PR introduces some refactoring regarding the type of a stack identifier. It was previously using a string (a concatenation of stack name + endpoint id) and it's now using an integer.