### PR TITLE
feat(services): add the ability to pull latest image when updating a …

### DIFF
--- a/app/docker/helpers/imageHelper.js
+++ b/app/docker/helpers/imageHelper.js
@@ -55,5 +55,9 @@ angular.module('portainer.docker')
     };
   };
 
+  helper.removeDigestFromRepository = function(repository) {
+    return repository.split('@sha')[0];
+  };
+
   return helper;
 }]);

--- a/app/docker/models/service.js
+++ b/app/docker/models/service.js
@@ -49,7 +49,7 @@ function ServiceViewModel(data, runningTasks, allTasks, nodes) {
     this.LogDriverName = '';
     this.LogDriverOpts = [];
   }
-    
+
   this.Constraints = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Constraints || [] : [];
   this.Preferences = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Preferences || [] : [];
   this.Platforms = data.Spec.TaskTemplate.Placement ? data.Spec.TaskTemplate.Placement.Platforms || [] : [];

--- a/app/docker/rest/service.js
+++ b/app/docker/rest/service.js
@@ -15,7 +15,7 @@ function ServiceFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, Htt
       // We should do digest pinning in Portainer as well.
       headers: {
         'X-Registry-Auth': HttpRequestHelper.registryAuthenticationHeader,
-        'version': '1.29'
+        'version': '1.30'
       },
       ignoreLoadingBar: true
     },
@@ -24,7 +24,7 @@ function ServiceFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, Htt
       // TODO: This is a temporary work-around that allows us to leverage digest pinning on
       // the Docker daemon side. It has been moved client-side since Docker API version > 1.30.
       // We should do digest pinning in Portainer as well.
-      headers: { 'version': '1.29' }
+      headers: { 'version': '1.30' }
     },
     remove: { method: 'DELETE', params: {id: '@id'} },
     logs: {

--- a/app/docker/rest/service.js
+++ b/app/docker/rest/service.js
@@ -10,21 +10,23 @@ function ServiceFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, Htt
     query: { method: 'GET', isArray: true, params: {filters: '@filters'} },
     create: {
       method: 'POST', params: {action: 'create'},
-      // TODO: This is a temporary work-around that allows us to leverage digest pinning on
-      // the Docker daemon side. It has been moved client-side since Docker API version > 1.30.
-      // We should do digest pinning in Portainer as well.
       headers: {
         'X-Registry-Auth': HttpRequestHelper.registryAuthenticationHeader,
-        'version': '1.30'
+        // TODO: This is a temporary work-around that allows us to leverage digest pinning on
+        // the Docker daemon side. It has been moved client-side since Docker API version > 1.29.
+        // We should introduce digest pinning in Portainer as well.
+        'version': '1.29'
       },
       ignoreLoadingBar: true
     },
     update: {
       method: 'POST', params: { id: '@id', action: 'update', version: '@version' },
-      // TODO: This is a temporary work-around that allows us to leverage digest pinning on
-      // the Docker daemon side. It has been moved client-side since Docker API version > 1.30.
-      // We should do digest pinning in Portainer as well.
-      headers: { 'version': '1.30' }
+      headers: {
+        // TODO: This is a temporary work-around that allows us to leverage digest pinning on
+        // the Docker daemon side. It has been moved client-side since Docker API version > 1.29.
+        // We should introduce digest pinning in Portainer as well.
+        'version': '1.29'
+      }
     },
     remove: { method: 'DELETE', params: {id: '@id'} },
     logs: {

--- a/app/docker/rest/service.js
+++ b/app/docker/rest/service.js
@@ -10,10 +10,22 @@ function ServiceFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider, Htt
     query: { method: 'GET', isArray: true, params: {filters: '@filters'} },
     create: {
       method: 'POST', params: {action: 'create'},
-      headers: { 'X-Registry-Auth': HttpRequestHelper.registryAuthenticationHeader },
+      // TODO: This is a temporary work-around that allows us to leverage digest pinning on
+      // the Docker daemon side. It has been moved client-side since Docker API version > 1.30.
+      // We should do digest pinning in Portainer as well.
+      headers: {
+        'X-Registry-Auth': HttpRequestHelper.registryAuthenticationHeader,
+        'version': '1.29'
+      },
       ignoreLoadingBar: true
     },
-    update: { method: 'POST', params: {id: '@id', action: 'update', version: '@version'} },
+    update: {
+      method: 'POST', params: { id: '@id', action: 'update', version: '@version' },
+      // TODO: This is a temporary work-around that allows us to leverage digest pinning on
+      // the Docker daemon side. It has been moved client-side since Docker API version > 1.30.
+      // We should do digest pinning in Portainer as well.
+      headers: { 'version': '1.29' }
+    },
     remove: { method: 'DELETE', params: {id: '@id'} },
     logs: {
       method: 'GET', params: { id: '@id', action: 'logs' },

--- a/app/portainer/services/modalService.js
+++ b/app/portainer/services/modalService.js
@@ -156,10 +156,18 @@ angular.module('portainer.app')
     });
   };
 
+  // TODO: message parameter for different message in serviceController and ServicesDatatableActionsController
   service.confirmServiceForceUpdate = function(message, callback) {
-    service.confirm({
+    service.customPrompt({
       title: 'Are you sure ?',
       message: message,
+      inputType: 'checkbox',
+      inputOptions: [
+        {
+          text: 'Pull latest image version<i></i>',
+          value: '1'
+        }
+      ],
       buttons: {
         confirm: {
           label: 'Update',

--- a/app/portainer/services/modalService.js
+++ b/app/portainer/services/modalService.js
@@ -156,7 +156,6 @@ angular.module('portainer.app')
     });
   };
 
-  // TODO: message parameter for different message in serviceController and ServicesDatatableActionsController
   service.confirmServiceForceUpdate = function(message, callback) {
     service.customPrompt({
       title: 'Are you sure ?',


### PR DESCRIPTION
…service

This PR introduces a temporary work-around to give the ability to pull the latest image associated to a service when doing a service update.

In order to pull the latest version of an image, the image associated to a service must be an image with an associated digest **AND** the digest of the image must be remove in the update request.

Image digest pinning was introduced in the Docker daemon in version 1.13 (https://github.com/moby/moby/pull/28173) but was relocated inside the Docker client in version 17.06 (API version 1.30) although the decision was taken to disable digest pinning in the daemon for older client versions: https://github.com/moby/moby/pull/32388#issuecomment-300913733

The work-around introduced by this PR is to set the value of the `version` header of the ServiceCreate and ServiceUpdate operations to `1.29`, forcing digest pinning via the daemon when creating/updating a service.

From what I've checked, there should be no impact of setting this header value, but my opinion is that we should follow closely how the Docker client interacts with the Docker daemon and introduce digest pinning inside Portainer later on (and remove that header as well).

Tagging as a work-around, I'll open another issue to track the digest pinning on Portainer side.

Closes #1577  