### PR TITLE
feat(templates): support resource settings in template definition (#2008)

### DIFF
--- a/app/docker/models/template.js
+++ b/app/docker/models/template.js
@@ -18,6 +18,15 @@ function TemplateViewModel(data) {
   this.RestartPolicy = data.restart_policy ? data.restart_policy : 'always';
   this.Labels = data.labels ? data.labels : [];
   this.Volumes = [];
+  if (data.resources) {
+    this.MemoryReservation = data.resources.memory_reservation > 0 ? data.resources.memory_reservation : 0;
+    this.MemoryLimit = data.resources.memory_limit > 0 ? data.resources.memory_limit : 0;
+    this.CpuLimit = data.resources.cpu_limit > 0 ? data.resources.cpu_limit : 0;
+  } else {
+    this.MemoryReservation = 0;
+    this.MemoryLimit = 0;
+    this.CpuLimit = 0;
+  }
 
   if (data.volumes) {
     this.Volumes = data.volumes.map(function (v) {

--- a/app/portainer/services/templateService.js
+++ b/app/portainer/services/templateService.js
@@ -55,6 +55,22 @@ angular.module('portainer.app')
     configuration.OpenStdin = consoleConfiguration.openStdin;
     configuration.Tty = consoleConfiguration.tty;
     configuration.Labels = TemplateHelper.updateContainerConfigurationWithLabels(template.Labels);
+    if (template.MemoryLimit > 0) {
+      // Memory Limit - Round to 0.125
+      var memoryLimit = (Math.round(template.MemoryLimit * 8) / 8).toFixed(3);
+      memoryLimit *= 1024 * 1024;
+      configuration.HostConfig.Memory = memoryLimit;
+    }
+    if (template.MemoryReservation > 0) {
+      // Memory Reservation - Round to 0.125
+      var memoryReservation = (Math.round(template.MemoryReservation * 8) / 8).toFixed(3);
+      memoryReservation *= 1024 * 1024;
+      configuration.HostConfig.MemoryReservation = memoryReservation;
+    }
+    if (template.CpuLimit > 0) {
+      // CPU Limit
+      configuration.HostConfig.NanoCpus = template.CpuLimit * 1000000000;
+    }
     return configuration;
   };
 


### PR DESCRIPTION
See #2008 

Basically this is an extension to #1224 to work with template definitions in addition to adding containers manually.

I'm not sure where the "rounding memory values to multiples of 0.128" comes from, but I assume that's there for a good reason.

If/when this is accepted I will also send a portainer-docs PR.