### PR TITLE
fix(cli): fix default template file path on Windows

### DIFF
--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -15,5 +15,5 @@ const (
 	defaultSSLCertPath     = "C:\\certs\\portainer.crt"
 	defaultSSLKeyPath      = "C:\\certs\\portainer.key"
 	defaultSyncInterval    = "60s"
-	defaultTemplateFile    = "C:\\templates.json"
+	defaultTemplateFile    = "/templates.json"
 )


### PR DESCRIPTION
Fix an issue that was spotted in https://github.com/portainer/portainer/pull/2018#issuecomment-402562113