### PR TITLE
feat(ux): always display search bar in datatables

### DIFF
--- a/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.html
+++ b/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add container
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.js
+++ b/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.azure').component('containergroupsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     removeAction: '<'
   }
 });

--- a/app/azure/views/containerinstances/containerinstances.html
+++ b/app/azure/views/containerinstances/containerinstances.html
@@ -12,7 +12,7 @@
     <containergroups-datatable
     title-text="Containers" title-icon="fa-server"
     dataset="containerGroups" table-key="containergroups"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     remove-action="deleteAction"
     ></containergroups-datatable>
   </div>

--- a/app/docker/components/datatables/configs-datatable/configsDatatable.html
+++ b/app/docker/components/datatables/configs-datatable/configsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add config
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/configs-datatable/configsDatatable.js
+++ b/app/docker/components/datatables/configs-datatable/configsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('configsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     removeAction: '<'
   }

--- a/app/docker/components/datatables/container-processes-datatable/containerProcessesDatatable.html
+++ b/app/docker/components/datatables/container-processes-datatable/containerProcessesDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/container-processes-datatable/containerProcessesDatatable.js
+++ b/app/docker/components/datatables/container-processes-datatable/containerProcessesDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('containerProcessesDatatable', {
     headerset: '<',
     tableKey: '@',
     orderBy: '@',
-    reverseOrder: '<',
-    showTextFilter: '<'
+    reverseOrder: '<'
   }
 });

--- a/app/docker/components/datatables/containers-datatable/containersDatatable.html
+++ b/app/docker/components/datatables/containers-datatable/containersDatatable.html
@@ -6,9 +6,6 @@
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
         <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
           <span class="setting" ng-class="{ 'setting-active': $ctrl.columnVisibility.state.open }" uib-dropdown dropdown-append-to-body auto-close="disabled" is-open="$ctrl.columnVisibility.state.open">
               <span uib-dropdown-toggle ><i class="fa fa-columns space-right" aria-hidden="true"></i>Columns</span>
               <div class="dropdown-menu dropdown-menu-right" uib-dropdown-menu>
@@ -110,7 +107,7 @@
         no-paused-items-selected="$ctrl.state.noPausedItemsSelected"
         show-add-action="$ctrl.showAddAction"
       ></containers-datatable-actions>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/containers-datatable/containersDatatable.js
+++ b/app/docker/components/datatables/containers-datatable/containersDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('containersDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     showHostColumn: '<',
     showAddAction: '<'

--- a/app/docker/components/datatables/containers-datatable/containersDatatableController.js
+++ b/app/docker/components/datatables/containers-datatable/containersDatatableController.js
@@ -141,13 +141,6 @@ function (PaginationService, DatatableService, EndpointProvider) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-
   this.applyFilters = function(value, index, array) {
     var container = value;
     var filters = ctrl.filters;

--- a/app/docker/components/datatables/events-datatable/eventsDatatable.html
+++ b/app/docker/components/datatables/events-datatable/eventsDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/events-datatable/eventsDatatable.js
+++ b/app/docker/components/datatables/events-datatable/eventsDatatable.js
@@ -7,7 +7,6 @@ angular.module('portainer.docker').component('eventsDatatable', {
     dataset: '<',
     tableKey: '@',
     orderBy: '@',
-    reverseOrder: '<',
-    showTextFilter: '<'
+    reverseOrder: '<'
   }
 });

--- a/app/docker/components/datatables/images-datatable/imagesDatatable.html
+++ b/app/docker/components/datatables/images-datatable/imagesDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <div class="btn-group">
@@ -29,7 +24,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Build a new image
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/images-datatable/imagesDatatable.js
+++ b/app/docker/components/datatables/images-datatable/imagesDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('imagesDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showHostColumn: '<',
     removeAction: '<',
     forceRemoveAction: '<'

--- a/app/docker/components/datatables/images-datatable/imagesDatatableController.js
+++ b/app/docker/components/datatables/images-datatable/imagesDatatableController.js
@@ -12,7 +12,7 @@ function (PaginationService, DatatableService) {
     selectedItemCount: 0,
     selectedItems: []
   };
-  
+
   this.filters = {
     usage: {
       open: false,
@@ -52,23 +52,16 @@ function (PaginationService, DatatableService) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-  
   this.applyFilters = function(value, index, array) {
     var image = value;
     var filters = ctrl.filters;
-    if ((image.ContainerCount === 0 && filters.usage.showUnusedImages) 
+    if ((image.ContainerCount === 0 && filters.usage.showUnusedImages)
       || (image.ContainerCount !== 0 && filters.usage.showUsedImages)) {
       return true;
     }
     return false;
   };
-  
+
   this.onUsageFilterChange = function() {
     var filters = this.filters.usage;
     var filtered = false;
@@ -87,7 +80,7 @@ function (PaginationService, DatatableService) {
       this.state.reverseOrder = storedOrder.reverse;
       this.state.orderBy = storedOrder.orderBy;
     }
-    
+
     var storedFilters = DatatableService.getDataTableFilters(this.tableKey);
     if (storedFilters !== null) {
       this.filters = storedFilters;

--- a/app/docker/components/datatables/networks-datatable/networksDatatable.html
+++ b/app/docker/components/datatables/networks-datatable/networksDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add network
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/networks-datatable/networksDatatable.js
+++ b/app/docker/components/datatables/networks-datatable/networksDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('networksDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     showHostColumn: '<',
     removeAction: '<'

--- a/app/docker/components/datatables/node-tasks-datatable/nodeTasksDatatable.html
+++ b/app/docker/components/datatables/node-tasks-datatable/nodeTasksDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/node-tasks-datatable/nodeTasksDatatable.js
+++ b/app/docker/components/datatables/node-tasks-datatable/nodeTasksDatatable.js
@@ -7,7 +7,6 @@ angular.module('portainer.docker').component('nodeTasksDatatable', {
     dataset: '<',
     tableKey: '@',
     orderBy: '@',
-    reverseOrder: '<',
-    showTextFilter: '<'
+    reverseOrder: '<'
   }
 });

--- a/app/docker/components/datatables/nodes-datatable/nodesDatatable.html
+++ b/app/docker/components/datatables/nodes-datatable/nodesDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/nodes-datatable/nodesDatatable.js
+++ b/app/docker/components/datatables/nodes-datatable/nodesDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('nodesDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showIpAddressColumn: '<',
     accessToNodeDetails: '<'
   }

--- a/app/docker/components/datatables/secrets-datatable/secretsDatatable.html
+++ b/app/docker/components/datatables/secrets-datatable/secretsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add secret
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/secrets-datatable/secretsDatatable.js
+++ b/app/docker/components/datatables/secrets-datatable/secretsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('secretsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     removeAction: '<'
   }

--- a/app/docker/components/datatables/services-datatable/servicesDatatable.html
+++ b/app/docker/components/datatables/services-datatable/servicesDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <services-datatable-actions
         selected-items="$ctrl.state.selectedItems"
@@ -17,7 +12,7 @@
         show-add-action="$ctrl.showAddAction"
         show-update-action="$ctrl.showUpdateAction"
       ></services-datatable-actions>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/services-datatable/servicesDatatable.js
+++ b/app/docker/components/datatables/services-datatable/servicesDatatable.js
@@ -10,7 +10,6 @@ angular.module('portainer.docker').component('servicesDatatable', {
     reverseOrder: '<',
     nodes: '<',
     agentProxy: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     showUpdateAction: '<',
     showAddAction: '<',

--- a/app/docker/components/datatables/services-datatable/servicesDatatableController.js
+++ b/app/docker/components/datatables/services-datatable/servicesDatatableController.js
@@ -54,13 +54,6 @@ function (PaginationService, DatatableService, EndpointProvider) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-
   this.expandItem = function(item, expanded) {
     item.Expanded = expanded;
     if (item.Expanded) {

--- a/app/docker/components/datatables/tasks-datatable/tasksDatatable.html
+++ b/app/docker/components/datatables/tasks-datatable/tasksDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/tasks-datatable/tasksDatatable.js
+++ b/app/docker/components/datatables/tasks-datatable/tasksDatatable.js
@@ -9,7 +9,6 @@ angular.module('portainer.docker').component('tasksDatatable', {
     orderBy: '@',
     reverseOrder: '<',
     nodes: '<',
-    showTextFilter: '<',
     showSlotColumn: '<',
     showLogsButton: '<',
     agentProxy: '<'

--- a/app/docker/components/datatables/volumes-datatable/volumesDatatable.html
+++ b/app/docker/components/datatables/volumes-datatable/volumesDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add volume
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/docker/components/datatables/volumes-datatable/volumesDatatable.js
+++ b/app/docker/components/datatables/volumes-datatable/volumesDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.docker').component('volumesDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     showHostColumn: '<',
     removeAction: '<'

--- a/app/docker/components/datatables/volumes-datatable/volumesDatatableController.js
+++ b/app/docker/components/datatables/volumes-datatable/volumesDatatableController.js
@@ -12,7 +12,7 @@ function (PaginationService, DatatableService) {
     selectedItemCount: 0,
     selectedItems: []
   };
-  
+
   this.filters = {
     usage: {
       open: false,
@@ -52,23 +52,16 @@ function (PaginationService, DatatableService) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-  
   this.applyFilters = function(value, index, array) {
     var volume = value;
     var filters = ctrl.filters;
-    if ((volume.dangling && filters.usage.showUnusedVolumes) 
+    if ((volume.dangling && filters.usage.showUnusedVolumes)
       || (!volume.dangling && filters.usage.showUsedVolumes)) {
       return true;
     }
     return false;
   };
-  
+
   this.onUsageFilterChange = function() {
     var filters = this.filters.usage;
     var filtered = false;
@@ -87,7 +80,7 @@ function (PaginationService, DatatableService) {
       this.state.reverseOrder = storedOrder.reverse;
       this.state.orderBy = storedOrder.orderBy;
     }
-    
+
     var storedFilters = DatatableService.getDataTableFilters(this.tableKey);
     if (storedFilters !== null) {
       this.filters = storedFilters;

--- a/app/docker/views/configs/configs.html
+++ b/app/docker/views/configs/configs.html
@@ -12,7 +12,7 @@
     <configs-datatable
     title-text="Configs" title-icon="fa-file-code"
     dataset="configs" table-key="configs"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     show-ownership-column="applicationState.application.authentication"
     remove-action="removeAction"
     ></configs-datatable>

--- a/app/docker/views/containers/containers.html
+++ b/app/docker/views/containers/containers.html
@@ -12,7 +12,7 @@
     <containers-datatable
       title-text="Containers" title-icon="fa-server"
       dataset="containers" table-key="containers"
-      order-by="Status" show-text-filter="true"
+      order-by="Status" 
       show-ownership-column="applicationState.application.authentication"
       show-host-column="applicationState.endpoint.mode.agentProxy"
       show-add-action="true"

--- a/app/docker/views/containers/stats/containerstats.html
+++ b/app/docker/views/containers/stats/containerstats.html
@@ -86,7 +86,7 @@
     title-text="Processes" title-icon="fa-tasks"
     dataset="processInfo.Processes" headerset="processInfo.Titles"
     table-key="container-processes"
-    show-text-filter="true"
+    
     ></container-processes>
   </div>
 </div>

--- a/app/docker/views/events/events.html
+++ b/app/docker/views/events/events.html
@@ -13,7 +13,7 @@
     title-text="Events" title-icon="fa-history"
     dataset="events" table-key="events"
     order-by="Time" reverse-order="true"
-    show-text-filter="true"
+    
     ></events-datatable>
   </div>
 </div>

--- a/app/docker/views/images/images.html
+++ b/app/docker/views/images/images.html
@@ -57,7 +57,7 @@
     <images-datatable
     title-text="Images" title-icon="fa-clone"
     dataset="images" table-key="images"
-    order-by="RepoTags" show-text-filter="true"
+    order-by="RepoTags" 
     show-host-column="applicationState.endpoint.mode.agentProxy"
     remove-action="removeAction"
     force-remove-action="confirmRemovalAction"

--- a/app/docker/views/networks/networks.html
+++ b/app/docker/views/networks/networks.html
@@ -12,7 +12,7 @@
     <networks-datatable
     title-text="Networks" title-icon="fa-sitemap"
     dataset="networks" table-key="networks"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     remove-action="removeAction"
     show-ownership-column="applicationState.application.authentication"
     show-host-column="applicationState.endpoint.mode.agentProxy"

--- a/app/docker/views/nodes/edit/node.html
+++ b/app/docker/views/nodes/edit/node.html
@@ -237,7 +237,7 @@
     title-text="Tasks" title-icon="fa-tasks"
     dataset="tasks" table-key="node-tasks"
     order-by="Updated" reverse-order="true"
-    show-text-filter="true"
+    
     ></node-tasks-datatable>
   </div>
 </div>

--- a/app/docker/views/secrets/secrets.html
+++ b/app/docker/views/secrets/secrets.html
@@ -12,7 +12,7 @@
     <secrets-datatable
     title-text="Secrets" title-icon="fa-user-secret"
     dataset="secrets" table-key="secrets"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     show-ownership-column="applicationState.application.authentication"
     remove-action="removeAction"
     ></secrets-datatable>

--- a/app/docker/views/services/edit/includes/tasks.html
+++ b/app/docker/views/services/edit/includes/tasks.html
@@ -4,7 +4,7 @@
     dataset="tasks" table-key="service-tasks"
     order-by="Updated" reverse-order="true"
     nodes="nodes"
-    show-text-filter="true"
+    
     show-slot-column="service.Mode !== 'global'"
     show-logs-button="applicationState.endpoint.apiVersion >= 1.30"
     agent-proxy="applicationState.endpoint.mode.agentProxy"

--- a/app/docker/views/services/services.html
+++ b/app/docker/views/services/services.html
@@ -12,7 +12,7 @@
     <services-datatable
     title-text="Services" title-icon="fa-list-alt"
     dataset="services" table-key="services"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     nodes="nodes"
     agent-proxy="applicationState.endpoint.mode.agentProxy"
     show-ownership-column="applicationState.application.authentication"

--- a/app/docker/views/swarm/swarm.html
+++ b/app/docker/views/swarm/swarm.html
@@ -49,7 +49,7 @@
     <nodes-datatable
     title-text="Nodes" title-icon="fa-hdd"
     dataset="nodes" table-key="nodes"
-    order-by="Hostname" show-text-filter="true"
+    order-by="Hostname" 
     show-ip-address-column="applicationState.endpoint.apiVersion >= 1.25"
     access-to-node-details="!applicationState.application.authentication || isAdmin"
     ></nodes-datatable>

--- a/app/docker/views/volumes/volumes.html
+++ b/app/docker/views/volumes/volumes.html
@@ -12,7 +12,7 @@
     <volumes-datatable
     title-text="Volumes" title-icon="fa-cubes"
     dataset="volumes" table-key="volumes"
-    order-by="Id" show-text-filter="true"
+    order-by="Id" 
     remove-action="removeAction"
     show-ownership-column="applicationState.application.authentication"
     show-host-column="applicationState.endpoint.mode.agentProxy"

--- a/app/extensions/storidge/components/cluster-events-datatable/storidgeClusterEventsDatatable.html
+++ b/app/extensions/storidge/components/cluster-events-datatable/storidgeClusterEventsDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/extensions/storidge/components/cluster-events-datatable/storidgeClusterEventsDatatable.js
+++ b/app/extensions/storidge/components/cluster-events-datatable/storidgeClusterEventsDatatable.js
@@ -7,7 +7,6 @@ angular.module('extension.storidge').component('storidgeClusterEventsDatatable',
     dataset: '<',
     tableKey: '@',
     orderBy: '@',
-    reverseOrder: '<',
-    showTextFilter: '<'
+    reverseOrder: '<'
   }
 });

--- a/app/extensions/storidge/components/nodes-datatable/storidgeNodesDatatable.html
+++ b/app/extensions/storidge/components/nodes-datatable/storidgeNodesDatatable.html
@@ -5,13 +5,8 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/extensions/storidge/components/nodes-datatable/storidgeNodesDatatable.js
+++ b/app/extensions/storidge/components/nodes-datatable/storidgeNodesDatatable.js
@@ -7,7 +7,6 @@ angular.module('extension.storidge').component('storidgeNodesDatatable', {
     dataset: '<',
     tableKey: '@',
     orderBy: '@',
-    reverseOrder: '<',
-    showTextFilter: '<'
+    reverseOrder: '<'
   }
 });

--- a/app/extensions/storidge/components/profiles-datatable/storidgeProfilesDatatable.html
+++ b/app/extensions/storidge/components/profiles-datatable/storidgeProfilesDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -17,7 +12,7 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/extensions/storidge/components/profiles-datatable/storidgeProfilesDatatable.js
+++ b/app/extensions/storidge/components/profiles-datatable/storidgeProfilesDatatable.js
@@ -8,7 +8,6 @@ angular.module('extension.storidge').component('storidgeProfilesDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     removeAction: '<'
   }
 });

--- a/app/extensions/storidge/views/cluster/cluster.html
+++ b/app/extensions/storidge/views/cluster/cluster.html
@@ -57,7 +57,7 @@
     <storidge-nodes-datatable
     title-text="Storage nodes" title-icon="fa-object-group"
     dataset="clusterNodes" table-key="storidge_nodes"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     ></storidge-nodes-datatable>
   </div>
 </div>

--- a/app/extensions/storidge/views/monitor/monitor.html
+++ b/app/extensions/storidge/views/monitor/monitor.html
@@ -116,7 +116,7 @@
     <storidge-cluster-events-datatable
     title-text="Cluster events" title-icon="fa-history"
     dataset="events" table-key="storidge_cluster_events"
-    order-by="Time" show-text-filter="true" reverse-order="true"
+    order-by="Time"  reverse-order="true"
     ></storidge-cluster-events-datatable>
   </div>
 </div>

--- a/app/extensions/storidge/views/profiles/profiles.html
+++ b/app/extensions/storidge/views/profiles/profiles.html
@@ -51,7 +51,7 @@
     <storidge-profiles-datatable
     title-text="Profiles" title-icon="fa-sticky-note"
     dataset="profiles" table-key="storidge_profiles"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     remove-action="removeAction"
     ></storidge-profiles-datatable>
   </div>

--- a/app/portainer/components/datatables/endpoints-datatable/endpointsDatatable.html
+++ b/app/portainer/components/datatables/endpoints-datatable/endpointsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar" ng-if="$ctrl.endpointManagement">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add endpoint
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/portainer/components/datatables/endpoints-datatable/endpointsDatatable.js
+++ b/app/portainer/components/datatables/endpoints-datatable/endpointsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('endpointsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     endpointManagement: '<',
     accessManagement: '<',
     removeAction: '<'

--- a/app/portainer/components/datatables/genericDatatableController.js
+++ b/app/portainer/components/datatables/genericDatatableController.js
@@ -41,13 +41,6 @@ function (PaginationService, DatatableService) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-
   this.$onInit = function() {
     setDefaults(this);
 

--- a/app/portainer/components/datatables/groups-datatable/groupsDatatable.html
+++ b/app/portainer/components/datatables/groups-datatable/groupsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add group
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/portainer/components/datatables/groups-datatable/groupsDatatable.js
+++ b/app/portainer/components/datatables/groups-datatable/groupsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('groupsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     accessManagement: '<',
     removeAction: '<'
   }

--- a/app/portainer/components/datatables/registries-datatable/registriesDatatable.html
+++ b/app/portainer/components/datatables/registries-datatable/registriesDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add registry
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/portainer/components/datatables/registries-datatable/registriesDatatable.js
+++ b/app/portainer/components/datatables/registries-datatable/registriesDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('registriesDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     accessManagement: '<',
     removeAction: '<'
   }

--- a/app/portainer/components/datatables/stacks-datatable/stacksDatatable.html
+++ b/app/portainer/components/datatables/stacks-datatable/stacksDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -20,7 +15,7 @@
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add stack
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
         <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
       </div>

--- a/app/portainer/components/datatables/stacks-datatable/stacksDatatable.js
+++ b/app/portainer/components/datatables/stacks-datatable/stacksDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('stacksDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     showOwnershipColumn: '<',
     removeAction: '<'
   }

--- a/app/portainer/components/datatables/stacks-datatable/stacksDatatableController.js
+++ b/app/portainer/components/datatables/stacks-datatable/stacksDatatableController.js
@@ -41,13 +41,6 @@ function (PaginationService, DatatableService) {
     PaginationService.setPaginationLimit(this.tableKey, this.state.paginatedItemLimit);
   };
 
-  this.updateDisplayTextFilter = function() {
-    this.state.displayTextFilter = !this.state.displayTextFilter;
-    if (!this.state.displayTextFilter) {
-      delete this.state.textFilter;
-    }
-  };
-
   this.$onInit = function() {
     setDefaults(this);
 

--- a/app/portainer/components/datatables/tags-datatable/tagsDatatable.html
+++ b/app/portainer/components/datatables/tags-datatable/tagsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -17,9 +12,9 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
-        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
+        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search...">
       </div>
       <div class="table-responsive">
         <table class="table table-hover">

--- a/app/portainer/components/datatables/tags-datatable/tagsDatatable.js
+++ b/app/portainer/components/datatables/tags-datatable/tagsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('tagsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     removeAction: '<'
   }
 });

--- a/app/portainer/components/datatables/teams-datatable/teamsDatatable.html
+++ b/app/portainer/components/datatables/teams-datatable/teamsDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -17,9 +12,9 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
-        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
+        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search...">
       </div>
       <div class="table-responsive">
         <table class="table table-hover">

--- a/app/portainer/components/datatables/teams-datatable/teamsDatatable.js
+++ b/app/portainer/components/datatables/teams-datatable/teamsDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('teamsDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     removeAction: '<'
   }
 });

--- a/app/portainer/components/datatables/users-datatable/usersDatatable.html
+++ b/app/portainer/components/datatables/users-datatable/usersDatatable.html
@@ -5,11 +5,6 @@
         <div class="toolBarTitle">
           <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
         </div>
-        <div class="settings">
-          <span class="setting" ng-class="{ 'setting-active': $ctrl.state.displayTextFilter }" ng-click="$ctrl.updateDisplayTextFilter()" ng-if="$ctrl.showTextFilter">
-            <i class="fa fa-search" aria-hidden="true"></i> Search
-          </span>
-        </div>
       </div>
       <div class="actionBar">
         <button type="button" class="btn btn-sm btn-danger"
@@ -17,9 +12,9 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
       </div>
-      <div class="searchBar" ng-if="$ctrl.state.displayTextFilter">
+      <div class="searchBar">
         <i class="fa fa-search searchIcon" aria-hidden="true"></i>
-        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
+        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search...">
       </div>
       <div class="table-responsive">
         <table class="table table-hover">

--- a/app/portainer/components/datatables/users-datatable/usersDatatable.js
+++ b/app/portainer/components/datatables/users-datatable/usersDatatable.js
@@ -8,7 +8,6 @@ angular.module('portainer.app').component('usersDatatable', {
     tableKey: '@',
     orderBy: '@',
     reverseOrder: '<',
-    showTextFilter: '<',
     removeAction: '<',
     authenticationMethod: '<'
   }

--- a/app/portainer/views/endpoints/endpoints.html
+++ b/app/portainer/views/endpoints/endpoints.html
@@ -27,7 +27,7 @@
     <endpoints-datatable
     title-text="Endpoints" title-icon="fa-plug"
     dataset="endpoints" table-key="endpoints"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     endpoint-management="applicationState.application.endpointManagement"
     access-management="applicationState.application.authentication"
     remove-action="removeAction"

--- a/app/portainer/views/groups/groups.html
+++ b/app/portainer/views/groups/groups.html
@@ -12,7 +12,7 @@
     <groups-datatable
     title-text="Endpoint groups" title-icon="fa-object-group"
     dataset="groups" table-key="groups"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     access-management="applicationState.application.authentication"
     remove-action="removeAction"
     ></groups-datatable>

--- a/app/portainer/views/registries/registries.html
+++ b/app/portainer/views/registries/registries.html
@@ -73,7 +73,7 @@
     <registries-datatable
     title-text="Registries" title-icon="fa-database"
     dataset="registries" table-key="registries"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     access-management="applicationState.application.authentication"
     remove-action="removeAction"
     ></registries-datatable>

--- a/app/portainer/views/stacks/edit/stack.html
+++ b/app/portainer/views/stacks/edit/stack.html
@@ -171,7 +171,7 @@
     <containers-datatable
       title-text="Containers" title-icon="fa-server"
       dataset="containers" table-key="stack-containers"
-      order-by="Status" show-text-filter="true"
+      order-by="Status" 
       show-ownership-column="applicationState.application.authentication"
       show-host-column="false"
       show-add-action="false"
@@ -184,7 +184,7 @@
     <services-datatable
     title-text="Services" title-icon="fa-list-alt"
     dataset="services" table-key="stack-services"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     nodes="nodes"
     agent-proxy="applicationState.endpoint.mode.agentProxy"
     show-ownership-column="false"

--- a/app/portainer/views/stacks/stacks.html
+++ b/app/portainer/views/stacks/stacks.html
@@ -12,7 +12,7 @@
     <stacks-datatable
     title-text="Stacks" title-icon="fa-th-list"
     dataset="stacks" table-key="stacks"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     remove-action="removeAction"
     show-ownership-column="applicationState.application.authentication"
     ></stacks-datatable>

--- a/app/portainer/views/tags/tags.html
+++ b/app/portainer/views/tags/tags.html
@@ -51,7 +51,7 @@
     <tags-datatable
     title-text="Tags" title-icon="fa-tags"
     dataset="tags" table-key="tags"
-    order-by="Name" show-text-filter="true"
+    order-by="Name" 
     remove-action="removeAction"
     ></tags-datatable>
   </div>

--- a/app/portainer/views/teams/teams.html
+++ b/app/portainer/views/teams/teams.html
@@ -19,7 +19,7 @@
             <label for="teamname" class="col-sm-1 control-label text-left">Name</label>
             <div class="col-sm-9">
               <div class="input-group">
-                <input type="text" class="form-control" id="teamname" ng-model="formValues.Name" ng-change="checkNameValidity()" placeholder="e.g. development">
+                <input type="text" class="form-control" id="teamname" ng-model="formValues.Name" ng-change="checkNameValidity()" placeholder="e.g. development" auto-focus>
                 <span class="input-group-addon"><i ng-class="{true: 'fa fa-check green-icon', false: 'fa fa-times red-icon'}[state.validName]" aria-hidden="true"></i></span>
               </div>
             </div>
@@ -69,7 +69,7 @@
     <teams-datatable
     title-text="Teams" title-icon="fa-users"
     dataset="teams" table-key="teams"
-    order-by="Name" show-text-filter="true"
+    order-by="Name"
     remove-action="removeAction"
     ></teams-datatable>
   </div>

--- a/app/portainer/views/users/users.html
+++ b/app/portainer/views/users/users.html
@@ -22,7 +22,7 @@
             </label>
             <div class="col-sm-8">
               <div class="input-group">
-                <input type="text" class="form-control" id="username" ng-model="formValues.Username" ng-change="checkUsernameValidity()" placeholder="e.g. jdoe">
+                <input type="text" class="form-control" id="username" ng-model="formValues.Username" ng-change="checkUsernameValidity()" placeholder="e.g. jdoe" auto-focus>
                 <span class="input-group-addon"><i ng-class="{true: 'fa fa-check green-icon', false: 'fa fa-times red-icon'}[state.validUsername]" aria-hidden="true"></i></span>
               </div>
             </div>
@@ -117,7 +117,7 @@
     <users-datatable
     title-text="Users" title-icon="fa-user"
     dataset="users" table-key="users"
-    order-by="Username" show-text-filter="true"
+    order-by="Username"
     authentication-method="AuthenticationMethod"
     remove-action="removeAction"
     ></users-datatable>


### PR DESCRIPTION
Remove the searchbar setting in datatables that allowed to hide/display the search bar in datatables.

Instead, the search bar is always displayed and automatically retrieve focus.