### PR TITLE
feat(api): rewrite SwarmInspect operation

### DIFF
--- a/api/http/proxy/docker_transport.go
+++ b/api/http/proxy/docker_transport.go
@@ -248,7 +248,7 @@ func (p *proxyTransport) proxyNodeRequest(request *http.Request) (*http.Response
 func (p *proxyTransport) proxySwarmRequest(request *http.Request) (*http.Response, error) {
 	switch requestPath := request.URL.Path; requestPath {
 	case "/swarm":
-		return p.executeDockerRequest(request)
+		return p.rewriteOperation(request, swarmInspectOperation)
 	default:
 		// assume /swarm/{action}
 		return p.administratorOperation(request)

--- a/api/http/proxy/swarm.go
+++ b/api/http/proxy/swarm.go
@@ -4,12 +4,6 @@ import (
 	"net/http"
 )
 
-const (
-// ErrDockerConfigIdentifierNotFound defines an error raised when Portainer is unable to find a config identifier
-// ErrDockerConfigIdentifierNotFound = portainer.Error("Docker config identifier not found")
-// configIdentifier                  = "ID"
-)
-
 // swarmInspectOperation extracts the response as a JSON object and rewrites the response based
 // on the current user role. Sensitive fields are deleted from the response for non-administrator users.
 func swarmInspectOperation(response *http.Response, executor *operationExecutor) error {

--- a/api/http/proxy/swarm.go
+++ b/api/http/proxy/swarm.go
@@ -1,0 +1,29 @@
+package proxy
+
+import (
+	"net/http"
+)
+
+const (
+// ErrDockerConfigIdentifierNotFound defines an error raised when Portainer is unable to find a config identifier
+// ErrDockerConfigIdentifierNotFound = portainer.Error("Docker config identifier not found")
+// configIdentifier                  = "ID"
+)
+
+// swarmInspectOperation extracts the response as a JSON object and rewrites the response based
+// on the current user role. Sensitive fields are deleted from the response for non-administrator users.
+func swarmInspectOperation(response *http.Response, executor *operationExecutor) error {
+	// SwarmInspect response is a JSON object
+	// https://docs.docker.com/engine/api/v1.30/#operation/SwarmInspect
+	responseObject, err := getResponseAsJSONOBject(response)
+	if err != nil {
+		return err
+	}
+
+	if !executor.operationContext.isAdmin {
+		delete(responseObject, "JoinTokens")
+		delete(responseObject, "TLSInfo")
+	}
+
+	return rewriteResponse(response, responseObject, http.StatusOK)
+}


### PR DESCRIPTION
Close #2053 

Removes the `JoinTokens` and `TLSInfo` fields from the `SwarmInspect` operation for non-administrator users.