### PR TITLE
Replace filter for counting running and stopped containers

### DIFF
--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -234,19 +234,6 @@ angular.module('portainer.docker')
     }).length;
   };
 })
-.filter('containerswithstatus', function () {
-  'use strict';
-  return function (containers, status) {
-    var containersWithStatus = 0;
-    for (var i = 0; i < containers.length; i++) {
-      var container = containers[i];
-      if (container.Status === status) {
-        containersWithStatus++;
-      }
-    }
-    return containersWithStatus;
-  };
-})
 .filter('imagestotalsize', function () {
   'use strict';
   return function (images) {

--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -230,7 +230,7 @@ angular.module('portainer.docker')
   'use strict';
   return function stoppedContainersFilter(containers) {
     return containers.filter(function (container) {
-      return container.State !== 'running';
+      return container.State === 'exited';
     }).length;
   };
 })

--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -218,6 +218,22 @@ angular.module('portainer.docker')
     return runningTasks;
   };
 })
+.filter('runningcontainers', function () {
+  'use strict';
+  return function runningContainersFilter(containers) {
+    return containers.filter(function (container) {
+      return container.State === 'running';
+    }).length;
+  };
+})
+.filter('stoppedcontainers', function () {
+  'use strict';
+  return function stoppedContainersFilter(containers) {
+    return containers.filter(function (container) {
+      return container.State !== 'running';
+    }).length;
+  };
+})
 .filter('containerswithstatus', function () {
   'use strict';
   return function (containers, status) {

--- a/app/docker/views/dashboard/dashboard.html
+++ b/app/docker/views/dashboard/dashboard.html
@@ -115,8 +115,8 @@
             <i class="fa fa-server"></i>
           </div>
           <div class="pull-right">
-            <div><i class="fa fa-heartbeat space-right green-icon"></i>{{ containers | containerswithstatus:'running' }} running</div>
-            <div><i class="fa fa-heartbeat space-right red-icon"></i>{{ containers | containerswithstatus:'stopped' }} stopped</div>
+            <div><i class="fa fa-heartbeat space-right green-icon"></i>{{ containers | runningcontainers }} running</div>
+            <div><i class="fa fa-heartbeat space-right red-icon"></i>{{ containers | stoppedcontainers }} stopped</div>
           </div>
           <div class="title">{{ containers.length }}</div>
           <div class="comment">Containers</div>


### PR DESCRIPTION
I replaced the new `containerswithstatus` filter with two new filters `runningcontainers` and `stoppedcontainers` that count the number of running/stopped containers.

They do this by checking `State` property on each container if it's `running` or not.

I'm just worried that there are types of State that are considered running.

Fix #2106 