### PR TITLE
fix(services): replicas numbers display (#1990)

### DIFF
--- a/app/docker/components/datatables/services-datatable/servicesDatatable.html
+++ b/app/docker/components/datatables/services-datatable/servicesDatatable.html
@@ -96,7 +96,7 @@
               <td>{{ item.Image | hideshasum }}</td>
               <td ng-controller="ServicesDatatableActionsController as actionCtrl">
                 {{ item.Mode }}
-                <code>{{ item.Tasks | runningtaskscount }}</code> / <code>{{ item.Mode === 'replicated' ? item.Replicas : ($ctrl.nodes | availablenodecount) }}</code>
+                <code>{{ item.Tasks | runningtaskscount }}</code> / <code>{{ item.Mode === 'replicated' ? item.Replicas : ($ctrl.nodes | availablenodecount:item) }}</code>
                 <span ng-if="item.Mode === 'replicated' && !item.Scale">
                   <a class="interactive" ng-click="item.Scale = true; item.ReplicaCount = item.Replicas; $event.stopPropagation();">
                     <i class="fa fa-arrows-alt-v" aria-hidden="true"></i> Scale

--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -192,26 +192,26 @@ angular.module('portainer.docker')
     return '';
   };
 })
-.filter('availablenodecount', function () {
+.filter('availablenodecount', ['ConstraintsHelper', function (ConstraintsHelper) {
   'use strict';
-  return function (nodes) {
+  return function (nodes, service) {
     var availableNodes = 0;
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i];
-      if (node.Availability === 'active' && node.Status === 'ready') {
+      if (node.Availability === 'active' && node.Status === 'ready' && ConstraintsHelper.matchesServiceConstraints(service, node)) {
         availableNodes++;
       }
     }
     return availableNodes;
   };
-})
+}])
 .filter('runningtaskscount', function () {
   'use strict';
   return function (tasks) {
     var runningTasks = 0;
     for (var i = 0; i < tasks.length; i++) {
       var task = tasks[i];
-      if (task.Status.State === 'running') {
+      if (task.Status.State === 'running' && task.DesiredState === 'running') {
         runningTasks++;
       }
     }

--- a/app/docker/helpers/constraintsHelper.js
+++ b/app/docker/helpers/constraintsHelper.js
@@ -19,20 +19,19 @@ var patterns = {
 };
 
 function matchesConstraint(value, constraint) {
-  if (constraint && ((constraint.op === patterns.op.eq &&
-        value !== constraint.value) ||
-      (constraint.op === patterns.op.neq &&
-        value === constraint.value))) {
-    return false;
+  if (!constraint ||
+    (constraint.op === patterns.op.eq && value === constraint.value) ||
+    (constraint.op === patterns.op.neq && value !== constraint.value)) {
+    return true;
   }
-  return true;
+  return false;
 }
 
 function matchesLabel(labels, constraint) {
   if (!constraint) {
     return true;
   }
-  var found = labels.find(function (label) {
+  var found = _.find(labels, function (label) {
     return label.key === constraint.key && label.value === constraint.value;
   });
   return found !== undefined;

--- a/app/docker/helpers/constraintsHelper.js
+++ b/app/docker/helpers/constraintsHelper.js
@@ -1,0 +1,83 @@
+var ConstraintOperator = {
+  EQ: 'eq',
+  NEQ: 'neq'
+};
+
+function ConstraintModel(op, value) {
+  this.op = op;
+  this.value = value;
+}
+// MISSING
+// node.labels    node.labels.security==high
+// engine.labels  engine.labels.operatingsystem==ubuntu 14.04
+var patterns = {
+  id: {
+    nodeId: /(node\.id)/,
+    nodeHostname: /(node\.hostname)/,
+    nodeRole: /(node\.role)/
+  },
+  op: {
+    eq: /(\s?==\s?)/,
+    neq: /(\s?!=\s?)/
+  },
+  value: /(node\.(id|hostname|role)\s?(=|!)=\s?)/
+};
+
+
+
+angular.module('portainer.docker')
+  .factory('ConstraintsHelper', [function ConstraintsHelperFactory() {
+    'use strict';
+    return {
+      transformConstraints: function (constraints) {
+        var transform = {};
+        angular.forEach(constraints, function (cons) {
+          var value = cons.replace(patterns.value, '');
+          var op;
+
+          if (cons.match(patterns.op.eq))
+            op = ConstraintOperator.EQ;
+          else if (cons.match(patterns.op.NEQ))
+            op = ConstraintOperator.NEQ;
+          if (cons.match(patterns.id.nodeId))
+            transform.nodeId = new ConstraintModel(op, value);
+          else if (cons.match(patterns.id.nodeHostname))
+            transform.nodeHostname = new ConstraintModel(op, value);
+          else if (cons.match(patterns.id.nodeRole))
+            transform.nodeRole = new ConstraintModel(op, value);
+        });
+        return transform;
+      },
+
+      matchesServiceConstraints: function (service, node) {
+        if (service.Constraints === undefined || service.Constraints.length === 0) return true;
+        var constraints = this.transformConstraints(angular.copy(service.Constraints));
+
+        // e.g. node.id==2ivku8v2gvtg4
+        if (constraints.nodeId) {
+          if ((constraints.nodeId.op === ConstraintOperator.EQ &&
+              node.Id !== constraints.nodeId.value) ||
+            (constraints.nodeId.op === ConstraintOperator.NEQ &&
+              node.Id === constraints.nodeId.value))
+            return false;
+        }
+        // e.g. node.hostname!=node-2
+        if (constraints.nodeHostname) {
+          if ((constraints.nodeHostname.op === ConstraintOperator.EQ &&
+              node.Hostname !== constraints.nodeHostname.value) ||
+            (constraints.nodeHostname.op === ConstraintOperator.NEQ &&
+              node.Hostname === constraints.nodeHostname.value))
+            return false;
+        }
+        // e.g. node.role==manager
+        if (constraints.nodeRole) {
+          if ((constraints.nodeRole.op === ConstraintOperator.EQ &&
+              node.Role !== constraints.nodeRole.value) ||
+            (constraints.nodeRole.op === ConstraintOperator.NEQ &&
+              node.Role === constraints.nodeRole.value))
+            return false;
+        }
+        return true;
+      }
+    };
+  }]);

--- a/app/docker/helpers/constraintsHelper.js
+++ b/app/docker/helpers/constraintsHelper.js
@@ -3,9 +3,10 @@ var ConstraintOperator = {
   NEQ: 'neq'
 };
 
-function ConstraintModel(op, value) {
+function ConstraintModel(op, key, value) {
   this.op = op;
   this.value = value;
+  this.key = key;
 }
 // node.id        node.id==2ivku8v2gvtg4
 // node.hostname  node.hostname!=node-2
@@ -17,24 +18,37 @@ var patterns = {
   id: {
     nodeId: /(node\.id)/,
     nodeHostname: /(node\.hostname)/,
-    nodeRole: /(node\.role)/
+    nodeRole: /(node\.role)/,
+    nodeLabels: /(node\.labels)/,
+    engineLabels: /(node\.labels)/
   },
   op: {
+    both: /(\s?(=|!)=\s?)/,
     eq: /(\s?==\s?)/,
     neq: /(\s?!=\s?)/
   },
-  value: /(node\.(id|hostname|role)\s?(=|!)=\s?)/
+  labelKey: /((node|engine)\.labels\.)/,
+  value: /((node\.(id|hostname|role|(labels\..*)))|(engine\.labels\..*))\s?(=|!)=\s?/
 };
 
 function matchesConstraint(value, constraint) {
-  if (constraint) {
-    if ((constraint.op === ConstraintOperator.EQ &&
+  if (constraint && ((constraint.op === ConstraintOperator.EQ &&
         value !== constraint.value) ||
       (constraint.op === ConstraintOperator.NEQ &&
-        value === constraint.value))
-      return false;
+        value === constraint.value))) {
+    return false;
   }
   return true;
+}
+
+function matchesLabel(labels, constraint) {
+  if (!constraint) {
+    return true;
+  }
+  var found = labels.find(function (label) {
+    return label.key === constraint.key && label.value === constraint.value;
+  });
+  return found !== undefined;
 }
 
 angular.module('portainer.docker')
@@ -44,32 +58,44 @@ angular.module('portainer.docker')
       transformConstraints: function (constraints) {
         var transform = {};
         angular.forEach(constraints, function (cons) {
-          var value = cons.replace(patterns.value, '');
+          var value = cons.replace(patterns.value, '').trim();
+          var key = cons.replace(patterns.labelKey, '').replace(patterns.op.both, '').replace(value, '');
           var op;
 
-          if (cons.match(patterns.op.eq))
+          if (cons.match(patterns.op.eq)) {
             op = ConstraintOperator.EQ;
-          else if (cons.match(patterns.op.NEQ))
+          } else if (cons.match(patterns.op.NEQ)) {
             op = ConstraintOperator.NEQ;
-          if (cons.match(patterns.id.nodeId))
-            transform.nodeId = new ConstraintModel(op, value);
-          else if (cons.match(patterns.id.nodeHostname))
-            transform.nodeHostname = new ConstraintModel(op, value);
-          else if (cons.match(patterns.id.nodeRole))
-            transform.nodeRole = new ConstraintModel(op, value);
+          }
+
+          if (cons.match(patterns.id.nodeId)) {
+            transform.nodeId = new ConstraintModel(op, key, value);
+          } else if (cons.match(patterns.id.nodeHostname)) {
+            transform.nodeHostname = new ConstraintModel(op, key, value);
+          } else if (cons.match(patterns.id.nodeRole)) {
+            transform.nodeRole = new ConstraintModel(op, key, value);
+          } else if (cons.match(patterns.id.nodeLabels)) {
+            transform.nodeLabels = new ConstraintModel(op, key, value);
+          } else if (cons.match(patterns.id.engineLabels)) {
+            transform.engineLabels = new ConstraintModel(op, key, value);
+          }
         });
         return transform;
       },
 
       matchesServiceConstraints: function (service, node) {
-        if (service.Constraints === undefined || service.Constraints.length === 0) return true;
+        if (service.Constraints === undefined || service.Constraints.length === 0) {
+          return true;
+        }
         var constraints = this.transformConstraints(angular.copy(service.Constraints));
-
         if (matchesConstraint(node.Id, constraints.nodeId) &&
           matchesConstraint(node.Hostname, constraints.nodeHostname) &&
-          matchesConstraint(node.Role, constraints.nodeRole)
-        )
+          matchesConstraint(node.Role, constraints.nodeRole) &&
+          matchesLabel(node.Labels, constraints.nodeLabels) &&
+          matchesLabel(node.EngineLabels, constraints.engineLabels)
+        ) {
           return true;
+        }
         return false;
       }
     };

--- a/app/docker/models/task.js
+++ b/app/docker/models/task.js
@@ -5,6 +5,7 @@ function TaskViewModel(data) {
   this.Slot = data.Slot;
   this.Spec = data.Spec;
   this.Status = data.Status;
+  this.DesiredState = data.DesiredState;
   this.ServiceId = data.ServiceID;
   this.NodeId = data.NodeID;
   if (data.Status && data.Status.ContainerStatus && data.Status.ContainerStatus.ContainerID) {


### PR DESCRIPTION
Fix a bug on replicas number display for services in `global` mode with constraints or `replicated` mode with tasks in unknown state (e.g. Desired State != Current State)

Missing `nodes.labels` and `engine.labels` constraints evaluation.

Closes #1990 .