### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 portainer-checksum.txt
 api/cmd/portainer/portainer*
 .tmp
+.vscode


### PR DESCRIPTION
When using vscode it sometime adds a .vscode folder that saves local settings to this project. We thought about adding it to a global `.gitignore` but some projects can decide to share the settings inside the repo.