### PR TITLE
feat(console): Adds custom commands based on container labels

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -15,4 +15,5 @@ angular.module('portainer')
 .constant('API_ENDPOINT_TEMPLATES', 'api/templates')
 .constant('DEFAULT_TEMPLATES_URL', 'https://raw.githubusercontent.com/portainer/templates/master/templates.json')
 .constant('PAGINATION_MAX_ITEMS', 10)
-.constant('APPLICATION_CACHE_VALIDITY', 3600);
+.constant('APPLICATION_CACHE_VALIDITY', 3600)
+.constant('CONSOLE_COMMANDS_LABEL_PREFIX', 'portainer.commands.');

--- a/app/constants.js
+++ b/app/constants.js
@@ -16,4 +16,4 @@ angular.module('portainer')
 .constant('DEFAULT_TEMPLATES_URL', 'https://raw.githubusercontent.com/portainer/templates/master/templates.json')
 .constant('PAGINATION_MAX_ITEMS', 10)
 .constant('APPLICATION_CACHE_VALIDITY', 3600)
-.constant('CONSOLE_COMMANDS_LABEL_PREFIX', 'portainer.commands.');
+.constant('CONSOLE_COMMANDS_LABEL_PREFIX', 'io.portainer.commands.');

--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -1,6 +1,6 @@
 angular.module('portainer.docker')
-.controller('ContainerConsoleController', ['$scope', '$transition$', 'ContainerService', 'ImageService', 'EndpointProvider', 'Notifications', 'ContainerHelper', 'ExecService', 'HttpRequestHelper', 'LocalStorage',
-function ($scope, $transition$, ContainerService, ImageService, EndpointProvider, Notifications, ContainerHelper, ExecService, HttpRequestHelper, LocalStorage) {
+.controller('ContainerConsoleController', ['$scope', '$transition$', 'ContainerService', 'ImageService', 'EndpointProvider', 'Notifications', 'ContainerHelper', 'ExecService', 'HttpRequestHelper', 'LocalStorage', 'CONSOLE_COMMANDS_LABEL_PREFIX',
+function ($scope, $transition$, ContainerService, ImageService, EndpointProvider, Notifications, ContainerHelper, ExecService, HttpRequestHelper, LocalStorage, CONSOLE_COMMANDS_LABEL_PREFIX) {
   var socket, term;
 
   $scope.state = {
@@ -9,6 +9,7 @@ function ($scope, $transition$, ContainerService, ImageService, EndpointProvider
   };
 
   $scope.formValues = {};
+  $scope.containerCommands = [];
 
   // Ensure the socket is closed before leaving the view
   $scope.$on('$stateChangeStart', function (event, next, current) {
@@ -106,8 +107,16 @@ function ($scope, $transition$, ContainerService, ImageService, EndpointProvider
     })
     .then(function success(data) {
       var image = data;
+      var containerLabels = $scope.container.Config.Labels;
       $scope.imageOS = image.Os;
       $scope.formValues.command = image.Os === 'windows' ? 'powershell' : 'bash';
+      $scope.containerCommands = Object.keys(containerLabels)
+        .filter(function(l) {
+          return l.indexOf(CONSOLE_COMMANDS_LABEL_PREFIX) === 0;
+        })
+        .map(function(l) {
+          return {title: l.replace(CONSOLE_COMMANDS_LABEL_PREFIX, ''), command: containerLabels[l]};
+        });
       $scope.state.loaded = true;
     })
     .catch(function error(err) {

--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -111,11 +111,11 @@ function ($scope, $transition$, ContainerService, ImageService, EndpointProvider
       $scope.imageOS = image.Os;
       $scope.formValues.command = image.Os === 'windows' ? 'powershell' : 'bash';
       $scope.containerCommands = Object.keys(containerLabels)
-        .filter(function(l) {
-          return l.indexOf(CONSOLE_COMMANDS_LABEL_PREFIX) === 0;
+        .filter(function(label) {
+          return label.indexOf(CONSOLE_COMMANDS_LABEL_PREFIX) === 0;
         })
-        .map(function(l) {
-          return {title: l.replace(CONSOLE_COMMANDS_LABEL_PREFIX, ''), command: containerLabels[l]};
+        .map(function(label) {
+          return {title: label.replace(CONSOLE_COMMANDS_LABEL_PREFIX, ''), command: containerLabels[label]};
         });
       $scope.state.loaded = true;
     })

--- a/app/docker/views/containers/console/containerconsole.html
+++ b/app/docker/views/containers/console/containerconsole.html
@@ -27,6 +27,7 @@
                       <option value="sh" ng-if="imageOS == 'linux'">/bin/sh</option>
                       <option value="powershell" ng-if="imageOS == 'windows'">powershell</option>
                       <option value="cmd.exe" ng-if="imageOS == 'windows'">cmd.exe</option>
+                      <option ng-repeat="command in containerCommands" value="{{command.command}}">{{command.title}}: {{command.command}}</option>
                     </select>
                   </div>
                   <input class="form-control" ng-if="formValues.isCustomCommand" type="text" name="custom-command" ng-model="formValues.customCommand" placeholder="e.g. ps aux">


### PR DESCRIPTION
**Update**
Finally implemented as 
```LABEL io.portainer.commands.my-command-name="mycommand"```

--
Given we have an image/container running with lables as `porainer.commands.*`
e.g.
```shell
docker run --rm -it \
-l portainer.commands.ls_tmp="ls -lah tmp" \
-l portainer.commands.ls_workdir="ls -lah" \
bash bash
```
portainer commands section would add those to commands dropdown

![screen shot 2018-08-14 at 19 57 07](https://user-images.githubusercontent.com/907125/44112394-e64a4e72-9ffc-11e8-85fb-297974130e8b.png)


idea is to have handy commands based on your image available in dropdown which I believe would be best to specify in `Dockerfile` as labels (rather than managing them in portainer instance)

closes similar #1684 #1874