### PR TITLE
feat(networks): Add network details (#1717)

### DIFF
--- a/app/docker/components/datatables/networks-datatable/networksDatatable.html
+++ b/app/docker/components/datatables/networks-datatable/networksDatatable.html
@@ -56,6 +56,20 @@
                 </a>
               </th>
               <th>
+                <a ng-click="$ctrl.changeOrderBy('Attachable')">
+                  Attachable
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Attachable' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Attachable' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
+                <a ng-click="$ctrl.changeOrderBy('Internal')">
+                  Internal
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Internal' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Internal' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
                 <a ng-click="$ctrl.changeOrderBy('IPAM.Driver')">
                   IPAM Driver
                   <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'IPAM.Driver' && !$ctrl.state.reverseOrder"></i>
@@ -104,6 +118,8 @@
               <td>{{ item.StackName ? item.StackName : '-' }}</td>
               <td>{{ item.Scope }}</td>
               <td>{{ item.Driver }}</td>
+              <td>{{ item.Attachable }}</td>
+              <td>{{ item.Internal }}</td>
               <td>{{ item.IPAM.Driver }}</td>
               <td>{{ item.IPAM.Config[0].Subnet ? item.IPAM.Config[0].Subnet : '-' }}</td>
               <td>{{ item.IPAM.Config[0].Gateway ? item.IPAM.Config[0].Gateway : '-' }}</td>

--- a/app/docker/models/network.js
+++ b/app/docker/models/network.js
@@ -4,6 +4,7 @@ function NetworkViewModel(data) {
   this.Scope = data.Scope;
   this.Driver = data.Driver;
   this.Attachable = data.Attachable;
+  this.Internal = data.Internal;
   this.IPAM = data.IPAM;
   this.Containers = data.Containers;
   this.Options = data.Options;

--- a/app/docker/views/networks/edit/network.html
+++ b/app/docker/views/networks/edit/network.html
@@ -31,6 +31,14 @@
               <td>Scope</td>
               <td>{{ network.Scope }}</td>
             </tr>
+            <tr>
+              <td>Attachable</td>
+              <td>{{ network.Attachable }}</td>
+            </tr>
+            <tr>
+              <td>Internal</td>
+              <td>{{ network.Internal }}</td>
+            </tr>
             <tr ng-if="network.IPAM.Config[0].Subnet">
               <td>Subnet</td>
               <td>{{ network.IPAM.Config[0].Subnet }}</td>


### PR DESCRIPTION
Implements feature requested in #1717:

1. visibility of "--internal" and "--attachable" network options in the network list view
2. visibility of "--internal" and "--attachable" network options in the network details view

Closes #1717 