### PR TITLE
fix(authentication): escape LDAP filters

### DIFF
--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -22,11 +22,13 @@ type Service struct{}
 func searchUser(username string, conn *ldap.Conn, settings []portainer.LDAPSearchSettings) (string, error) {
 	var userDN string
 	found := false
+	usernameEscaped := ldap.EscapeFilter(username)
+
 	for _, searchSettings := range settings {
 		searchRequest := ldap.NewSearchRequest(
 			searchSettings.BaseDN,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-			fmt.Sprintf("(&%s(%s=%s))", searchSettings.Filter, searchSettings.UserNameAttribute, username),
+			fmt.Sprintf("(&%s(%s=%s))", searchSettings.Filter, searchSettings.UserNameAttribute, usernameEscaped),
 			[]string{"dn"},
 			nil,
 		)
@@ -134,12 +136,13 @@ func (*Service) GetUserGroups(username string, settings *portainer.LDAPSettings)
 // Get a list of group names for specified user from LDAP/AD
 func getGroups(userDN string, conn *ldap.Conn, settings []portainer.LDAPGroupSearchSettings) []string {
 	groups := make([]string, 0)
+	userDNEscaped := ldap.EscapeFilter(userDN)
 
 	for _, searchSettings := range settings {
 		searchRequest := ldap.NewSearchRequest(
 			searchSettings.GroupBaseDN,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-			fmt.Sprintf("(&%s(%s=%s))", searchSettings.GroupFilter, searchSettings.GroupAttribute, userDN),
+			fmt.Sprintf("(&%s(%s=%s))", searchSettings.GroupFilter, searchSettings.GroupAttribute, userDNEscaped),
 			[]string{"cn"},
 			nil,
 		)


### PR DESCRIPTION
Hi guys,

LDAP filters need to be escaped when run against an AD backend.

This PR does simple string replace of a few possible characters, in order to allow those in the user CN.

**NB:** I'm fairly new to the various Go tools, and I couldn't make GoLand understand the .godir file, so I haven't been able to actually compile this code. You should probably be very skeptic of this code.

Unfortunately, I'm short on time due to work and I really want to use Portainer at my work, so I wanted to do my best to fix this issue.
If nothing else it might serve as a base for someone else to pick this up.

_Thanks for an awesome project!_

Close #2177 
