### PR TITLE
feat(registry): private/custom registry management

### DIFF
--- a/api/http/handler/registries/handler.go
+++ b/api/http/handler/registries/handler.go
@@ -3,6 +3,7 @@ package registries
 import (
 	"github.com/portainer/portainer"
 	httperror "github.com/portainer/portainer/http/error"
+	"github.com/portainer/portainer/http/proxy"
 	"github.com/portainer/portainer/http/security"
 
 	"net/http"
@@ -18,6 +19,7 @@ func hideFields(registry *portainer.Registry) {
 type Handler struct {
 	*mux.Router
 	RegistryService portainer.RegistryService
+	ProxyManager    *proxy.Manager
 }
 
 // NewHandler creates a handler to manage registry operations.
@@ -38,6 +40,8 @@ func NewHandler(bouncer *security.RequestBouncer) *Handler {
 		bouncer.AdministratorAccess(httperror.LoggerHandler(h.registryUpdateAccess))).Methods(http.MethodPut)
 	h.Handle("/registries/{id}",
 		bouncer.AdministratorAccess(httperror.LoggerHandler(h.registryDelete))).Methods(http.MethodDelete)
+	h.PathPrefix("/registries/{id}/v2").Handler(
+		bouncer.PublicAccess(httperror.LoggerHandler(h.proxyRequestsToRegistryAPI)))
 
 	return h
 }

--- a/api/http/handler/registries/proxy.go
+++ b/api/http/handler/registries/proxy.go
@@ -1,0 +1,40 @@
+package registries
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/portainer/portainer"
+	httperror "github.com/portainer/portainer/http/error"
+	"github.com/portainer/portainer/http/request"
+)
+
+// request on /api/registries/:id/v2
+func (handler *Handler) proxyRequestsToRegistryAPI(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	registryID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid registry identifier route variable", err}
+	}
+
+	registry, err := handler.RegistryService.Registry(portainer.RegistryID(registryID))
+	if err == portainer.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
+	} else if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
+	}
+
+	id := strconv.Itoa(int(registryID))
+
+	var proxy http.Handler
+	proxy = handler.ProxyManager.GetRegistryProxy(id)
+	if proxy == nil {
+		proxy, err = handler.ProxyManager.CreateAndRegisterRegistryProxy(registry)
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to register registry proxy", err}
+		}
+	}
+
+	http.StripPrefix("/registries/"+id, proxy).ServeHTTP(w, r)
+
+	return nil
+}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -120,6 +120,7 @@ func (server *Server) Start() error {
 
 	var registryHandler = registries.NewHandler(requestBouncer)
 	registryHandler.RegistryService = server.RegistryService
+	registryHandler.ProxyManager = proxyManager
 
 	var resourceControlHandler = resourcecontrols.NewHandler(requestBouncer)
 	resourceControlHandler.ResourceControlService = server.ResourceControlService

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -242,6 +242,34 @@ angular.module('portainer.app', [])
     }
   };
 
+
+  var registryImages = {
+    name: 'portainer.registries.registry.images',
+    url: '/images',
+    views: {
+      'content@': {
+        templateUrl: 'app/portainer/views/registries/images/registryImages.html',
+        controller: 'RegistryImagesController'
+      }
+    }
+  };
+
+  var registryRepository = {
+    name: 'portainer.registries.registry.repository',
+    url: '/:repository'
+  };
+
+  var registryImageDetails = {
+    name: 'portainer.registries.registry.repository.image',
+    url: '/:imageId',
+    views: {
+      'content@': {
+        templateUrl: 'app/portainer/views/registries/images/edit/registryImage.html',
+        controller: 'RegistryImageController'
+      }
+    }
+  };
+
   var settings = {
     name: 'portainer.settings',
     url: '/settings',
@@ -420,6 +448,9 @@ angular.module('portainer.app', [])
   $stateRegistryProvider.register(registry);
   $stateRegistryProvider.register(registryAccess);
   $stateRegistryProvider.register(registryCreation);
+  $stateRegistryProvider.register(registryImages);
+  $stateRegistryProvider.register(registryRepository);
+  $stateRegistryProvider.register(registryImageDetails);
   $stateRegistryProvider.register(settings);
   $stateRegistryProvider.register(settingsAuthentication);
   $stateRegistryProvider.register(stacks);

--- a/app/portainer/components/datatables/registries-image-tags-datatable/registriesImageTagsDatatable.html
+++ b/app/portainer/components/datatables/registries-image-tags-datatable/registriesImageTagsDatatable.html
@@ -7,12 +7,8 @@
         </div>
       </div>
       <div class="actionBar">
-        <button type="button" class="btn btn-sm btn-danger"
-          ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
+        <button type="button" class="btn btn-sm btn-danger" ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
-        </button>
-        <button type="button" class="btn btn-sm btn-primary" ui-sref="portainer.registries.new">
-          <i class="fa fa-plus space-right" aria-hidden="true"></i>Add registry
         </button>
       </div>
       <div class="searchBar">
@@ -34,45 +30,37 @@
                   <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Name' && $ctrl.state.reverseOrder"></i>
                 </a>
               </th>
-              <th>
-                <a ng-click="$ctrl.changeOrderBy('URL')">
-                  URL
-                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'URL' && !$ctrl.state.reverseOrder"></i>
-                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'URL' && $ctrl.state.reverseOrder"></i>
-                </a>
-              </th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            <tr dir-paginate="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit))" ng-class="{active: item.Checked}">
+            <tr dir-paginate="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit))"
+              ng-class="{active: item.Checked}">
               <td>
                 <span class="md-checkbox">
-                  <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)"/>
+                  <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)" />
                   <label for="select_{{ $index }}"></label>
                 </span>
-                <a ui-sref="portainer.registries.registry({id: item.Id})">{{ item.Name }}</a>
-                <span ng-if="item.Authentication" style="margin-left: 5px;" class="label label-info image-tag">authentication-enabled</span>
+                {{ item.Value }}
               </td>
               <td>
-                {{ item.URL }}
-              </td>
-              <td>
-                <a ui-sref="portainer.registries.registry.access({id: item.Id})" ng-if="$ctrl.accessManagement">
-                  <i class="fa fa-users" aria-hidden="true"></i> Manage access
-                </a>
-              </td>
-              <td>
-                <a ui-sref="portainer.registries.registry.images({id: item.Id})">
-                  <i class="fa fa-search" aria-hidden="true"></i> Browse
-                </a>
+                <span ng-if="!item.Modified">
+                  <a class="interactive" ng-click="item.Modified = true; item.NewValue = item.Value; $event.stopPropagation();">
+                    <i class="fa fa-tag" aria-hidden="true"></i> Retag
+                  </a>
+                </span>
+                <span ng-if="item.Modified">
+                  <input class="input-sm" type="text" ng-model="item.NewValue" on-enter-key="$ctrl.retagAction(item)" auto-focus ng-click="$event.stopPropagation();"/>
+                  <a class="interactive" ng-click="item.Modified = false; $event.stopPropagation();"><i class="fa fa-times"></i></a>
+                  <a class="interactive" ng-click="$ctrl.retagAction(item); $event.stopPropagation();"><i class="fa fa-check-square"></i></a>
+                </span>
               </td>
             </tr>
             <tr ng-if="!$ctrl.dataset">
               <td colspan="3" class="text-center text-muted">Loading...</td>
             </tr>
             <tr ng-if="$ctrl.state.filteredDataSet.length === 0">
-              <td colspan="3" class="text-center text-muted">No registry available.</td>
+              <td colspan="3" class="text-center text-muted">No tags available.</td>
             </tr>
           </tbody>
         </table>

--- a/app/portainer/components/datatables/registries-image-tags-datatable/registriesImageTagsDatatable.js
+++ b/app/portainer/components/datatables/registries-image-tags-datatable/registriesImageTagsDatatable.js
@@ -1,0 +1,14 @@
+angular.module('portainer.app').component('registriesImageTagsDatatable', {
+  templateUrl: 'app/portainer/components/datatables/registries-image-tags-datatable/registriesImageTagsDatatable.html',
+  controller: 'GenericDatatableController',
+  bindings: {
+    titleText: '@',
+    titleIcon: '@',
+    dataset: '<',
+    tableKey: '@',
+    orderBy: '@',
+    reverseOrder: '<',
+    removeAction: '<',
+    retagAction: '<'
+  }
+});

--- a/app/portainer/components/datatables/registries-images-datatable/registryImagesDatatable.html
+++ b/app/portainer/components/datatables/registries-images-datatable/registryImagesDatatable.html
@@ -1,0 +1,114 @@
+<div class="datatable">
+  <rd-widget>
+    <rd-widget-body classes="no-padding">
+      <div class="toolBar">
+        <div class="toolBarTitle">
+          <i class="fa" ng-class="$ctrl.titleIcon" aria-hidden="true" style="margin-right: 2px;"></i> {{ $ctrl.titleText }}
+        </div>
+      </div>
+      <div class="actionBar">
+        <button type="button" class="btn btn-sm btn-danger" ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
+          <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
+        </button>
+      </div>
+      <div class="searchBar">
+        <i class="fa fa-search searchIcon" aria-hidden="true"></i>
+        <input type="text" class="searchInput" ng-model="$ctrl.state.textFilter" placeholder="Search..." auto-focus>
+      </div>
+      <div class="table-responsive">
+        <table class="table table-hover table-filters nowrap-cells">
+          <thead>
+            <tr>
+              <th>
+                <span class="md-checkbox">
+                  <input id="select_all" type="checkbox" ng-model="$ctrl.state.selectAll" ng-change="$ctrl.selectAll()" />
+                  <label for="select_all"></label>
+                </span>
+                <a ng-click="$ctrl.changeOrderBy('Id')">
+                  Id
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Id' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Id' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
+                <a ng-click="$ctrl.changeOrderBy('Name')">
+                  Repository
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Name' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Name' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
+                <a ng-click="$ctrl.changeOrderBy('Tags')">
+                  Tags
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Tags' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Tags' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
+                <a ng-click="$ctrl.changeOrderBy('Size')">
+                  Size
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Size' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Size' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
+                <a ng-click="$ctrl.changeOrderBy('Created')">
+                  Created
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Created' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Created' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr dir-paginate="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit))"
+              ng-class="{active: item.Checked}">
+              <td>
+                <span class="md-checkbox">
+                  <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)" />
+                  <label for="select_{{ $index }}"></label>
+                </span>
+                <a ui-sref="portainer.registries.registry.repository.image({repository: item.Name, imageId: item.Id})" class="monospaced"
+                  title="{{ item.Id }}">{{ item.Id | truncate:40 }}</a>
+              </td>
+              <td>{{ item.Name }}</td>
+              <td>
+                <span class="label label-primary image-tag" ng-repeat="tag in item.Tags">{{ tag.Value }}</span>
+              </td>
+              <td>{{ item.Size | humansize }}</td>
+              <td>{{ item.Created | getisodate }}</td>
+            </tr>
+            <tr ng-if="!$ctrl.dataset">
+              <td colspan="5" class="text-center text-muted">Loading...</td>
+            </tr>
+            <tr ng-if="$ctrl.state.filteredDataSet.length === 0">
+              <td colspan="5" class="text-center text-muted">No image available.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="footer" ng-if="$ctrl.dataset">
+        <div class="infoBar" ng-if="$ctrl.state.selectedItemCount !== 0">
+          {{ $ctrl.state.selectedItemCount }} item(s) selected
+        </div>
+        <div class="paginationControls">
+          <form class="form-inline">
+            <span class="limitSelector">
+              <span style="margin-right: 5px;">
+                Items per page
+              </span>
+              <select class="form-control" ng-model="$ctrl.state.paginatedItemLimit" ng-change="$ctrl.changePaginationLimit()">
+                <option value="0">All</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+              </select>
+            </span>
+            <dir-pagination-controls max-size="5"></dir-pagination-controls>
+          </form>
+        </div>
+      </div>
+    </rd-widget-body>
+  </rd-widget>
+</div>

--- a/app/portainer/components/datatables/registries-images-datatable/registryImagesDatatable.js
+++ b/app/portainer/components/datatables/registries-images-datatable/registryImagesDatatable.js
@@ -1,0 +1,13 @@
+angular.module('portainer.docker').component('registryImagesDatatable', {
+  templateUrl: 'app/portainer/components/datatables/registries-images-datatable/registryImagesDatatable.html',
+  controller: 'GenericDatatableController',
+  bindings: {
+    titleText: '@',
+    titleIcon: '@',
+    dataset: '<',
+    tableKey: '@',
+    orderBy: '@',
+    reverseOrder: '<',
+    removeAction: '<'
+  }
+});

--- a/app/portainer/helpers/localRegistryHelper.js
+++ b/app/portainer/helpers/localRegistryHelper.js
@@ -1,0 +1,108 @@
+angular.module('portainer.app')
+  .factory('LocalRegistryHelper', [function LocalRegistryHelperFactory() {
+    'use strict';
+
+    var helper = {};
+
+    /*
+     ** Manifests/images history transform
+     */
+
+    function historyRawToParsed(rawHistory) {
+      var history = [];
+      for (var i = 0; i < rawHistory.length; i++) {
+        var item = rawHistory[i];
+        history.push(angular.fromJson(item.v1Compatibility));
+      }
+      return history;
+    }
+
+    function historyParsedToRaw(parsedHistory) {
+      var history = [];
+      for (var i = 0; i < parsedHistory.length; i++) {
+        var item = parsedHistory[i];
+        history.push({
+          v1Compatibility: angular.toJson(item)
+        });
+      }
+      return history;
+    }
+
+    /*
+     ** Manifests / images transformation
+     */
+
+    function groupBy(array, prop) {
+      return array.reduce(function (groups, item) {
+        var val = item[prop];
+        groups[val] = groups[val] || [];
+        groups[val].push(item);
+        return groups;
+      }, {});
+    }
+
+    helper.groupImagesTags = function (manifests) {
+      var grouped = groupBy(manifests, 'Name');
+      for (var prop in grouped) {
+        if (grouped.hasOwnProperty(prop)) {
+          grouped[prop] = groupBy(grouped[prop], 'Id');
+        }
+      }
+      var images = [];
+      for (var name in grouped) {
+        if (grouped.hasOwnProperty(name)) {
+          for (var id in grouped[name]) {
+            if (grouped[name].hasOwnProperty(id)) {
+              grouped[name][id].map(function (image) {
+                image.Tags = [{
+                  Value: image.Tags[0],
+                  Digest: image.Digest
+                }];
+                return image;
+              });
+              var squashedImage = grouped[name][id].reduce(function (a, b) {
+                a.Tags = a.Tags.concat(b.Tags);
+                return a;
+              });
+              images.push(squashedImage);
+            }
+          }
+        }
+      }
+      return images;
+    };
+
+    helper.manifestsToImage = function (manifests) {
+      var basicInfo = manifests.basicInfo;
+      var details = manifests.details;
+
+      var history = historyRawToParsed(basicInfo.history);
+      var id = history[0].id;
+      var name = basicInfo.name;
+      var tags = [basicInfo.tag];
+      var created = history[0].created;
+      var size = details.layers.reduce(function (a, b) {
+        return {
+          size: a.size + b.size
+        };
+      }).size;
+      var digest = details.digest;
+      var fsLayers = basicInfo.fsLayers;
+      var signatures = basicInfo.signatures;
+
+      return new RepositoryImageViewModel(id, name, tags, created, size, digest, fsLayers, history, signatures, details);
+    };
+
+    helper.imageToManifest = function (image) {
+      var manifest = {};
+      manifest.name = image.Name;
+      manifest.tag = tag[0];
+      manifest.fsLayers = image.FsLayers;
+      manifest.history = historyParsedToRaw(image.History);
+      manifest.schemaVersion = 1;
+      manifest.architecture = image.History[0].architecture;
+      return manifest;
+    };
+
+    return helper;
+  }]);

--- a/app/portainer/models/repositoryImages.js
+++ b/app/portainer/models/repositoryImages.js
@@ -1,0 +1,12 @@
+function RepositoryImageViewModel(id, name, tags, created, size, digest, fsLayers, history, signatures, manifestV2) {
+  this.Id = id;
+  this.Name = name;
+  this.Tags = tags;
+  this.Created = created;
+  this.Size = size;
+  this.Digest = digest;
+  this.FsLayers = fsLayers;
+  this.History = history;
+  this.Signatures = signatures;
+  this.ManifestV2 = manifestV2;
+}

--- a/app/portainer/rest/registries/catalog.js
+++ b/app/portainer/rest/registries/catalog.js
@@ -1,0 +1,12 @@
+angular.module('portainer.app')
+  .factory('RegistryCatalog', ['$resource', 'API_ENDPOINT_REGISTRIES', function RegistryCatalogFactory($resource, API_ENDPOINT_REGISTRIES) {
+    'use strict';
+    return $resource(API_ENDPOINT_REGISTRIES + '/:id/v2/_catalog', {}, {
+      get: {
+        method: 'GET',
+        params: {
+          id: '@id'
+        }
+      }
+    });
+  }]);

--- a/app/portainer/rest/registries/manifest.js
+++ b/app/portainer/rest/registries/manifest.js
@@ -1,0 +1,61 @@
+angular.module('portainer.app')
+  .factory('RegistryManifests', ['$resource', 'API_ENDPOINT_REGISTRIES', function RegistryManifestsFactory($resource, API_ENDPOINT_REGISTRIES) {
+    'use strict';
+    return $resource(API_ENDPOINT_REGISTRIES + '/:id/v2/:repository/manifests/:tag', {}, {
+      get: {
+        method: 'GET',
+        params: {
+          id: '@id',
+          repository: '@repository',
+          tag: '@tag'
+        },
+        headers: {
+          'Cache-Control': 'no-cache'
+        },
+        transformResponse: function (data, headers) {
+          var response = angular.fromJson(data);
+          response.digest = headers('docker-content-digest');
+          return response;
+        }
+      },
+      getV2: {
+        method: 'GET',
+        params: {
+          id: '@id',
+          repository: '@repository',
+          tag: '@tag'
+        },
+        headers: {
+          'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
+          'Cache-Control': 'no-cache'
+        },
+        transformResponse: function (data, headers) {
+          var response = angular.fromJson(data);
+          response.digest = headers('docker-content-digest');
+          return response;
+        }
+      },
+      put: {
+        method: 'PUT',
+        params: {
+          id: '@id',
+          repository: '@repository',
+          tag: '@tag'
+        },
+        headers: {
+          'Content-Type': 'application/vnd.docker.distribution.manifest.v2+json'
+        },
+        transformRequest: function (data) {
+          return angular.toJson(data, 3);
+        }
+      },
+      delete: {
+        method: 'DELETE',
+        params: {
+          id: '@id',
+          repository: '@repository',
+          tag: '@tag'
+        }
+      }
+    });
+  }]);

--- a/app/portainer/rest/registries/tags.js
+++ b/app/portainer/rest/registries/tags.js
@@ -1,0 +1,13 @@
+angular.module('portainer.app')
+  .factory('RegistryTags', ['$resource', 'API_ENDPOINT_REGISTRIES', function RegistryTagsFactory($resource, API_ENDPOINT_REGISTRIES) {
+    'use strict';
+    return $resource(API_ENDPOINT_REGISTRIES + '/:id/v2/:repository/tags/list', {}, {
+      get: {
+        method: 'GET',
+        params: {
+          id: '@id',
+          repository: '@repository'
+        }
+      }
+    });
+  }]);

--- a/app/portainer/services/api/localRegistryService.js
+++ b/app/portainer/services/api/localRegistryService.js
@@ -1,0 +1,140 @@
+angular.module('portainer.app')
+  .factory('LocalRegistryService', ['$q', 'RegistryCatalog', 'RegistryTags', 'RegistryManifests', 'LocalRegistryHelper',
+    function LocalRegistryServiceFactory($q, RegistryCatalog, RegistryTags, RegistryManifests, LocalRegistryHelper) {
+      'use strict';
+      var service = {};
+
+      function manifestPromise(id, repository, tag) {
+        var deferred = $q.defer();
+
+        var promises = [RegistryManifests.get({
+            id: id,
+            repository: repository.name,
+            tag: tag
+          }).$promise,
+          RegistryManifests.getV2({
+            id: id,
+            repository: repository.name,
+            tag: tag
+          }).$promise
+        ];
+
+        $q.all(promises)
+          .then(function success(data) {
+            var basicInfo = _.find(data, function (item) {
+              return item.schemaVersion === 1;
+            });
+            var details = _.find(data, function (item) {
+              return item.schemaVersion === 2;
+            });
+            deferred.resolve({
+              basicInfo: basicInfo,
+              details: details
+            });
+          }).catch(function error() {
+            deferred.reject();
+          });
+
+        return deferred.promise;
+      }
+
+      service.images = function (id) {
+        var deferred = $q.defer();
+
+        RegistryCatalog.get({
+            id: id
+          }).$promise
+          .then(function success(data) {
+            var repositories = data.repositories;
+            var tagsPromises = [];
+            for (var i = 0; i < repositories.length; i++) {
+              var repository = repositories[i];
+              var promise = RegistryTags.get({
+                id: id,
+                repository: repository
+              }).$promise;
+              tagsPromises.push(promise);
+            }
+            return $q.all(tagsPromises);
+          }).then(function success(data) {
+            var manifestsPromises = [];
+            for (var i = 0; i < data.length; i++) {
+              var repository = data[i];
+              if (repository.tags) {
+                for (var j = 0; j < repository.tags.length; j++) {
+                  var tag = repository.tags[j];
+                  var promise = manifestPromise(id, repository, tag);
+                  manifestsPromises.push(promise);
+                }
+              }
+            }
+            return $q.all(manifestsPromises);
+          })
+          .then(function success(data) {
+            var manifests = data.map(function (item) {
+              return LocalRegistryHelper.manifestsToImage(item);
+            });
+            var images = LocalRegistryHelper.groupImagesTags(manifests);
+            deferred.resolve(images);
+          }).catch(function error(err) {
+            deferred.reject({
+              msg: 'Unable to retrieve repositories',
+              err: err
+            });
+          });
+        return deferred.promise;
+      };
+
+      service.repositoryImage = function (id, repository, imageId) {
+        var deferred = $q.defer();
+        RegistryTags.get({
+            id: id,
+            repository: repository
+          }).$promise
+          .then(function success(data) {
+            var manifestsPromises = [];
+            for (var j = 0; j < data.tags.length; j++) {
+              var tag = data.tags[j];
+              var promise = manifestPromise(id, data, tag);
+              manifestsPromises.push(promise);
+            }
+            return $q.all(manifestsPromises);
+          })
+          .then(function success(data) {
+            var manifests = data.map(function (item) {
+              return LocalRegistryHelper.manifestsToImage(item);
+            });
+            var images = LocalRegistryHelper.groupImagesTags(manifests);
+            var image = _.find(images, function (item) {
+              return item.Id === imageId;
+            });
+            deferred.resolve(image);
+          }).catch(function error(err) {
+            deferred.reject({
+              msg: 'Unable to retrieve image information',
+              err: err
+            });
+          });
+        return deferred.promise;
+      };
+
+      service.deleteManifest = function (id, repository, digest) {
+        return RegistryManifests.delete({
+          id: id,
+          repository: repository,
+          tag: digest
+        }).$promise;
+      };
+
+      service.addTag = function (id, repository, tag, manifest) {
+        delete manifest.digest;
+        return RegistryManifests.put({
+          id: id,
+          repository: repository,
+          tag: tag
+        }, manifest).$promise;
+      };
+
+      return service;
+    }
+  ]);

--- a/app/portainer/views/registries/images/edit/registryImage.html
+++ b/app/portainer/views/registries/images/edit/registryImage.html
@@ -1,0 +1,82 @@
+<rd-header>
+  <rd-header-title title-text="Repository image">
+    <a data-toggle="tooltip" title="Refresh" ui-sref="portainer.registries.registry.repository.image" ui-sref-opts="{reload: true}">
+      <i class="fa fa-sync" aria-hidden="true"></i>
+    </a>
+  </rd-header-title>
+  <rd-header-content>
+    <a ui-sref="portainer.registries">Registries</a> &gt;
+    <a ui-sref="portainer.registries.registry({id: registry.Id})">{{ registry.Name }}</a> &gt;
+    <a ui-sref="portainer.registries.registry.images({id: registry.Id})">{{ image.Name }} </a> &gt;
+    <a ui-sref="portainer.registries.registry.repository.image()">{{ image.Id }} </a>
+  </rd-header-content>
+</rd-header>
+
+<div class="row">
+  <div class="col-sm-8">
+    <rd-widget>
+      <rd-widget-header icon="fa-info" title-text="Image information">
+      </rd-widget-header>
+      <rd-widget-body classes="no-padding">
+        <table class="table">
+          <tbody>
+            <tr>
+              <td>Repository</td>
+              <td>{{ image.Name }}</td>
+            </tr>
+            <tr>
+              <td>ID</td>
+              <td>
+                {{ image.Id }}
+                <button class="btn btn-xs btn-danger" ng-click="removeImage()">
+                  <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Delete this image
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td>Size</td>
+              <td>{{ image.Size|humansize }}</td>
+            </tr>
+            <tr>
+              <td>Created</td>
+              <td>{{ image.Created|getisodate }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+
+  <div class="col-sm-4">
+    <rd-widget>
+      <rd-widget-header icon="fa-plus" title-text="Add tag">
+      </rd-widget-header>
+      <rd-widget-body>
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label for="tag" class="col-sm-3 col-lg-2 control-label text-left">Tag</label>
+            <div class="col-sm-9 col-lg-10">
+              <input type="text" class="form-control" id="tag" ng-model="formValues.Tag">
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-12">
+              <button type="button" class="btn btn-primary btn-sm" ng-disabled="state.actionInProgress || !formValues.Tag" ng-click="addTag()"
+                button-spinner="state.actionInProgress">
+                <span ng-hide="state.actionInProgress">Add tag</span>
+                <span ng-show="state.actionInProgress">Adding tag...</span>
+              </button>
+            </div>
+          </div>
+        </form>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <registries-image-tags-datatable title-text="Tags" title-icon="fa-tags" dataset="image.Tags" table-key="images.Tags" order-by="Name"
+      remove-action="removeTags" retag-action="retagAction"></registries-image-tags-datatable>
+  </div>
+</div>

--- a/app/portainer/views/registries/images/edit/registryImageController.js
+++ b/app/portainer/views/registries/images/edit/registryImageController.js
@@ -1,0 +1,120 @@
+angular.module('portainer.app')
+  .controller('RegistryImageController', ['$q', '$scope', '$transition$', '$state', 'LocalRegistryService', 'RegistryService', 'LocalRegistryHelper', 'ModalService', 'Notifications',
+    function ($q, $scope, $transition$, $state, LocalRegistryService, RegistryService, LocalRegistryHelper, ModalService, Notifications) {
+
+      $scope.state = {
+        actionInProgress: false
+      };
+
+      $scope.formValues = {
+        Tag: ''
+      };
+
+      $scope.addTag = function () {
+        LocalRegistryService.addTag($scope.registryId, $scope.image.Name, $scope.formValues.Tag, $scope.image.ManifestV2)
+          .then(function success(data) {
+            Notifications.success('Success', 'Tag successfully added');
+            $state.reload();
+          })
+          .catch(function error(err) {
+            Notifications.error('Failure', err, 'Unable to add tag');
+          });
+      };
+
+      $scope.retagAction = function (tag) {
+        var manifest = LocalRegistryHelper.imageToManifest($scope.image);
+        manifest.tag = tag.Value;
+        LocalRegistryService.deleteManifest($scope.registryId, $scope.image.Name, tag.Digest)
+          .then(function success() {
+            var promises = [];
+            $scope.image.Tags.map(function (item) {
+              var tagValue = item.Modified && item.Value !== item.NewValue ? item.NewValue : item.Value;
+              promises.push(LocalRegistryService.addTag($scope.registryId, $scope.image.Name, tagValue, $scope.image.ManifestV2));
+            });
+            return $q.all(promises);
+          })
+          .then(function success() {
+            Notifications.success('Tag successfully modified', 'New tag name: ' + tag.NewValue);
+            $state.reload();
+          })
+          .catch(function error(err) {
+            Notifications.error('Failure', err, 'Unable to modify tag');
+            tag.Modified = false;
+            tag.NewValue = tag.Value;
+          });
+      };
+
+      $scope.removeTags = function (selectedItems) {
+        ModalService.confirmDeletion(
+          'Are you sure you want to remove the selected tags ?',
+          function onConfirm(confirmed) {
+            if (!confirmed) {
+              return;
+            }
+            var promises = [];
+            var uniqItems = _.uniqBy(selectedItems, 'Digest');
+            uniqItems.map(function (item) {
+              promises.push(LocalRegistryService.deleteManifest($scope.registryId, $scope.image.Name, item.Digest));
+            });
+            $q.all(promises)
+              .then(function success() {
+                var promises = [];
+                var tagsToReupload = _.differenceBy($scope.image.Tags, selectedItems, 'Value');
+                tagsToReupload.map(function (item) {
+                  promises.push(LocalRegistryService.addTag($scope.registryId, $scope.image.Name, item.Value, $scope.image.ManifestV2));
+                });
+                return $q.all(promises);
+              })
+              .then(function success(data) {
+                Notifications.success('Success', 'Tags successfully deleted');
+                $state.reload();
+              })
+              .catch(function error(err) {
+                Notifications.error('Failure', err, 'Unable to delete tags');
+              });
+          });
+      };
+
+      $scope.removeImage = function () {
+        ModalService.confirmDeletion(
+          'This action will only remove the manifests linked to this image. You need to manually trigger a garbage collector pass on your registry to remove orphan layers and really remove the image content.',
+          function onConfirm(confirmed) {
+            if (!confirmed) {
+              return;
+            }
+            LocalRegistryService.deleteManifest($scope.registryId, $scope.image.Name, $scope.image.Digest)
+              .then(function success(data) {
+                Notifications.success('Success', 'Image sucessfully removed');
+                $state.go('portainer.registries.registry.images', {
+                  id: $scope.registryId
+                }, {
+                  reload: true
+                });
+              }).catch(function error(err) {
+                Notifications.error('Failure', err, 'Unable to delete image');
+              });
+          }
+        );
+      };
+
+      function initView() {
+        var registryId = $scope.registryId = $transition$.params().id;
+        var repositoryName = $transition$.params().repository;
+        var imageId = $transition$.params().imageId;
+
+        $q.all({
+            registry: RegistryService.registry(registryId),
+            image: LocalRegistryService.repositoryImage(registryId, repositoryName, imageId)
+          })
+          .then(function success(data) {
+            $scope.registry = data.registry;
+            $scope.image = data.image;
+          })
+          .catch(function error(err) {
+            Notifications.error('Failure', err, 'Unable to retrieve image information');
+          });
+      }
+
+      initView();
+    }
+  ]);

--- a/app/portainer/views/registries/images/registryImages.html
+++ b/app/portainer/views/registries/images/registryImages.html
@@ -1,0 +1,21 @@
+<rd-header>
+  <rd-header-title title-text="Registry images">
+    <a data-toggle="tooltip" title="Refresh" ui-sref="portainer.registries.registry.images" ui-sref-opts="{reload: true}">
+      <i class="fa fa-sync" aria-hidden="true"></i>
+    </a>
+  </rd-header-title>
+  <rd-header-content>
+      <a ui-sref="portainer.registries">Registries</a> &gt; <a ui-sref="portainer.registries.registry({id: registry.Id})">{{ registry.Name }}</a> &gt; Images
+    </rd-header-content>
+</rd-header>
+
+<div class="row">
+  <div class="col-sm-12">
+    <registry-images-datatable
+    title-text="Images" title-icon="fa-clone"
+    dataset="images" table-key="registryImages"
+    order-by="Name" 
+    remove-action="removeImages"
+    ></registry-images-datatable>
+  </div>
+</div>

--- a/app/portainer/views/registries/images/registryImagesController.js
+++ b/app/portainer/views/registries/images/registryImagesController.js
@@ -1,0 +1,46 @@
+angular.module('portainer.app')
+  .controller('RegistryImagesController', ['$q', '$transition$', '$scope', '$state', 'RegistryService', 'LocalRegistryService', 'ModalService', 'Notifications',
+    function ($q, $transition$, $scope, $state, RegistryService, LocalRegistryService, ModalService, Notifications) {
+
+      $scope.state = {
+        actionInProgress: false
+      };
+      $scope.images = [];
+      $scope.registry = {};
+
+      $scope.removeImages = function(selectedItems) {
+        ModalService.confirmDeletion(
+          'This action will only remove the manifests linked to the selected images. You need to manually trigger a garbage collector pass on your registry to remove orphan layers if you want to remove the images content.',
+          function onConfirm(confirmed) {
+            if (!confirmed) {
+              return;
+            }
+            var promises = [];
+            selectedItems.map(function (item) {
+              promises.push(LocalRegistryService.deleteManifest($scope.registry.Id, item.Name, item.Digest));
+            });
+            $q.all(promises).then(function success(data) {
+                Notifications.success('Success', 'Images successfully deleted');
+                $state.reload();
+              })
+              .catch(function error(err) {
+                Notifications.error('Failure', err, 'Unable to delete images');
+              });
+          });
+      };
+
+      function initView() {
+        var registryId = $transition$.params().id;
+        $q.all({
+          registry: RegistryService.registry(registryId),
+          images: LocalRegistryService.images(registryId)
+        }).then(function success(data) {
+          $scope.registry = data.registry;
+          $scope.images = data.images;
+        }).catch(function error(err) {
+          Notifications.error('Failure', err, 'Unable to retrieve registry details');
+        });
+      }
+      initView();
+    }
+  ]);


### PR DESCRIPTION
Add the following management features for private registries:

_For a registry_
- List images
- Remove images
![2018-08-24-155816_1893x428_scrot](https://user-images.githubusercontent.com/7642331/44588862-31228600-a7b7-11e8-8974-488eeafb4abc.png)

_For an image in a repository_
- Basic image information (more can be added)
- List tags
- Add tag
- Delete tags
- Update tags (retag)
- Remove image
![2018-08-24-155854_1900x636_scrot](https://user-images.githubusercontent.com/7642331/44588882-40a1cf00-a7b7-11e8-8b5a-b4b8b2b43845.png)


Note: removing an image only removes its reference (manifest) in the repository.
To completely remove images from the registry, the garbage collector need to be triggered manually on the registry to remove orphan blobs (images layers that are not referenced by any manifest in the registry).

This has only been tested on v2 self-hosted registries for now.

Closes #56 