### PR TITLE
#2174 fix(images): Fix to allow both tar and gzip images

### DIFF
--- a/app/docker/views/images/import/importimage.html
+++ b/app/docker/views/images/import/importimage.html
@@ -21,7 +21,7 @@
           </div>
           <div class="form-group">
             <div class="col-sm-12">
-              <button class="btn btn-sm btn-primary" ngf-select ngf-min-size="10" ngf-accept="'application/x-tar'" ng-model="formValues.UploadFile">Select file</button>
+              <button class="btn btn-sm btn-primary" ngf-select ngf-min-size="10" ngf-accept="'application/x-tar,application/x-gzip'" ng-model="formValues.UploadFile">Select file</button>
               <span style="margin-left: 5px;">
                 {{ formValues.UploadFile.name }}
                 <i class="fa fa-times red-icon" ng-if="!formValues.UploadFile" aria-hidden="true"></i>


### PR DESCRIPTION
This is a PR to fix #2174 

Current Behaviour in master - Allows only .tar files 
Expected Behaviour after merge - Allows both .tar and .tar.gz files

![current_behaviour](https://user-images.githubusercontent.com/4348461/44630003-3e5d8300-a925-11e8-8c0c-34736dc6ecc2.png)

![after_fix](https://user-images.githubusercontent.com/4348461/44630002-3e5d8300-a925-11e8-8121-8b706f40e649.png)


