### PR TITLE
Update build_in_container.sh

### DIFF
--- a/build/build_in_container.sh
+++ b/build/build_in_container.sh
@@ -4,7 +4,7 @@ binary="portainer-$1-$2"
 
 mkdir -p dist
 
-docker run --rm -tv $(pwd)/api:/src -e BUILD_GOOS="$1" -e BUILD_GOARCH="$2" portainer/golang-builder:cross-platform /src/cmd/portainer
+docker run --rm -tv "$(pwd)/api:/src" -e BUILD_GOOS="$1" -e BUILD_GOARCH="$2" portainer/golang-builder:cross-platform /src/cmd/portainer
 
 mv "api/cmd/portainer/$binary" dist/
 #sha256sum "dist/$binary" > portainer-checksum.txt


### PR DESCRIPTION
wrapped `$(pwd)/api:/src` in `"` quotes to prevent word splitting on the `-tv` option