### PR TITLE
containersDatable: add containers name if error on executeActionOnCon…

### DIFF
--- a/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
+++ b/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
@@ -72,7 +72,7 @@ function ($state, ContainerService, ModalService, Notifications, HttpRequestHelp
         Notifications.success(successMessage, container.Names[0]);
       })
       .catch(function error(err) {
-        Notifications.error('Failure', err, errorMessage);
+        Notifications.error('Failure', err, `${errorMessage}:${container.Names[0]}`);
       })
       .finally(function final() {
         --actionCount;

--- a/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
+++ b/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
@@ -72,7 +72,8 @@ function ($state, ContainerService, ModalService, Notifications, HttpRequestHelp
         Notifications.success(successMessage, container.Names[0]);
       })
       .catch(function error(err) {
-        Notifications.error('Failure', err, `${errorMessage}:${container.Names[0]}`);
+        errorMessage = errorMessage + ":" + container.Names[0];
+        Notifications.error('Failure', err, errorMessage);
       })
       .finally(function final() {
         --actionCount;

--- a/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
+++ b/app/docker/components/datatables/containers-datatable/actions/containersDatatableActionsController.js
@@ -72,7 +72,7 @@ function ($state, ContainerService, ModalService, Notifications, HttpRequestHelp
         Notifications.success(successMessage, container.Names[0]);
       })
       .catch(function error(err) {
-        errorMessage = errorMessage + ":" + container.Names[0];
+        errorMessage = errorMessage + ':' + container.Names[0];
         Notifications.error('Failure', err, errorMessage);
       })
       .finally(function final() {


### PR DESCRIPTION
Fix: add the container name if there is an error when restarting a container.

Current state: no container name is shown when we restart a container and it fails, but we do show the container name when there is a success.

Reason: Useful when restarting different containers at once.