### PR TITLE
Display node name instead of hostname when applicable

### DIFF
--- a/app/docker/components/datatables/nodes-datatable/nodesDatatable.html
+++ b/app/docker/components/datatables/nodes-datatable/nodesDatatable.html
@@ -68,8 +68,8 @@
           <tbody>
             <tr dir-paginate="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit))" ng-class="{active: item.Checked}">
               <td>
-                <a ui-sref="docker.nodes.node({id: item.Id})" ng-if="$ctrl.accessToNodeDetails">{{ item.Hostname }}</a>
-                <span ng-if="!$ctrl.accessToNodeDetails">{{ item.Hostname }}</span>
+                <a ui-sref="docker.nodes.node({id: item.Id})" ng-if="$ctrl.accessToNodeDetails">{{ item.Name || item.Hostname }}</a>
+                <span ng-if="!$ctrl.accessToNodeDetails">{{ item.Name || item.Hostname }}</span>
               </td>
               <td>{{ item.Role }}</td>
               <td>{{ item.CPUs / 1000000000 }}</td>

--- a/app/docker/views/swarm/visualizer/swarmvisualizer.html
+++ b/app/docker/views/swarm/visualizer/swarmvisualizer.html
@@ -84,7 +84,7 @@
             <div class="node_info">
               <div>
                 <div>
-                  <b>{{ node.Hostname }}</b>
+                  <b>{{ node.Name || node.Hostname }}</b>
                   <span class="node_platform">
                     <i class="fab fa-linux" aria-hidden="true" ng-if="node.PlatformOS === 'linux'"></i>
                     <i class="fab fa-windows" aria-hidden="true" ng-if="node.PlatformOS === 'windows'"></i>


### PR DESCRIPTION
## What does this PR do?
- checks if the name of a node is available, otherwise it defaults to the Hostname
- closes #2213 