### PR TITLE
Display stack and host info when applicable

### DIFF
--- a/app/docker/views/containers/edit/container.html
+++ b/app/docker/views/containers/edit/container.html
@@ -81,6 +81,14 @@
                 <td>Finished</td>
                 <td>{{ container.State.FinishedAt|getisodate }}</td>
               </tr>
+              <tr ng-if="container.Model.Config.Labels['com.docker.compose.project']">
+                <td>Stack</td>
+                <td>{{ container.Model.Config.Labels["com.docker.compose.project"] }}</td>
+              </tr>
+              <tr ng-if="applicationState.endpoint.mode.agentProxy">
+                <td>Nodename</td>
+                <td>{{ container.NodeName }}</td>
+              </tr>
               <tr>
                 <td colspan="2">
                   <div class="btn-group" role="group" aria-label="...">


### PR DESCRIPTION
## What does this PR do?
- display the stack and host info on the container-details table 
- closes #2120 