### PR TITLE
[WIP] fix(images): custom registry support for pull/push

### DIFF
--- a/app/docker/services/imageService.js
+++ b/app/docker/services/imageService.js
@@ -123,8 +123,8 @@ angular.module('portainer.docker')
   }
 
   service.pullImage = function(image, registry, ignoreErrors) {
-    var imageDetails = ImageHelper.extractImageAndRegistryFromRepository(image);
-    var imageConfiguration = ImageHelper.createImageConfigForContainer(imageDetails.image, registry.URL);
+    // var imageDetails = ImageHelper.extractImageAndRegistryFromRepository(image);
+    var imageConfiguration = ImageHelper.createImageConfigForContainer(image, registry.URL);
     var authenticationDetails = registry.Authentication ? RegistryService.encodedCredentials(registry) : '';
     HttpRequestHelper.setRegistryAuthenticationHeader(authenticationDetails);
 


### PR DESCRIPTION
Closes #2105 .

Step 1: [first commit](https://github.com/portainer/portainer/commit/688499fb0cce170ca73f6988254ec546e7008b1e) is a temporary fix to pull images with the format `namespace/ [namespace2/...] /image:tag` with custom registries.
Duplicating a container based on a `custom.registry.com/namespace/image:tag` image will not work !

[ImageHelper.extractImageAndRegistryFromRepository function](https://github.com/portainer/portainer/blob/develop/app/docker/helpers/imageHelper.js#L7) needs to be reworked as it's trying to retrieve registry + image but in all calls, registry returned is never used.

Step 2 : will break the ability to pull an image directly from `custom.registry.com/namespace/myimage:tag` with the `DockerHub` registry selected in the dropdown (container creation view & images list view).
It will me mandatory to add first a registry with URL `custom.registry.com`, then pull `namespace/myimage:tag` with custom registry selected in the dropdown, even for a 1 time pull.

Setting a registry with URL `custom.registry.com/namespace` and pulling `myimage:tag` will also work.
For this part, `ImageHelper.extractImageAndRegistryFromRepository` function needs to have access to the repositories registered in Portainer to be able to detect and extract the image name+tag & the registry properly.


Step 3 (if necessary) : will restore the ability to do 1-time pulls, setting the entire url as image name and selecting the `DockerHub` registry in the dropdowns. It may introduce more complexity in the `ImageHelper.extractImageAndRegistryFromRepository` function.