### PR TITLE
fix : exclude cache from the Memory Usage chart to avoid misinterpret…

### DIFF
--- a/app/docker/models/container.js
+++ b/app/docker/models/container.js
@@ -64,7 +64,8 @@ function ContainerViewModel(data) {
 
 function ContainerStatsViewModel(data) {
   this.Date = data.read;
-  this.MemoryUsage = data.memory_stats.usage;
+  // Page cache is intentionally excluded to avoid misinterpretation of memory usage.
+  this.MemoryUsage = data.memory_stats.usage - data.memory_stats.stats.cache;
   this.PreviousCPUTotalUsage = data.precpu_stats.cpu_usage.total_usage;
   this.PreviousCPUSystemUsage = data.precpu_stats.system_cpu_usage;
   this.CurrentCPUTotalUsage = data.cpu_stats.cpu_usage.total_usage;

--- a/app/docker/models/container.js
+++ b/app/docker/models/container.js
@@ -64,7 +64,6 @@ function ContainerViewModel(data) {
 
 function ContainerStatsViewModel(data) {
   this.Date = data.read;
-  // Page cache is intentionally excluded to avoid misinterpretation of memory usage.
   this.MemoryUsage = data.memory_stats.usage - data.memory_stats.stats.cache;
   this.PreviousCPUTotalUsage = data.precpu_stats.cpu_usage.total_usage;
   this.PreviousCPUSystemUsage = data.precpu_stats.system_cpu_usage;


### PR DESCRIPTION
Exclude cache from the Memory Usage chart to avoid misinterpretation of the chart and to be coherent with the docker CLI. fixes #2074.