### PR TITLE
feat2359 remove deprecated TLS1.0 protocol

### DIFF
--- a/api/crypto/tls.go
+++ b/api/crypto/tls.go
@@ -26,6 +26,7 @@ func CreateTLSConfigurationFromBytes(caCert, cert, key []byte, skipClientVerific
 		config.RootCAs = caCertPool
 	}
 
+	config.MinVersion = tls.VersionTLS11  // feat2359 removed deprecated TLS1.0 protocol
 	return config, nil
 }
 
@@ -54,6 +55,7 @@ func CreateTLSConfigurationFromDisk(caCertPath, certPath, keyPath string, skipSe
 		caCertPool.AppendCertsFromPEM(caCert)
 		config.RootCAs = caCertPool
 	}
-
+	
+	config.MinVersion = tls.VersionTLS11  // feat2359 removed deprecated TLS1.0 protocol
 	return config, nil
 }

--- a/api/crypto/tls.go
+++ b/api/crypto/tls.go
@@ -26,7 +26,7 @@ func CreateTLSConfigurationFromBytes(caCert, cert, key []byte, skipClientVerific
 		config.RootCAs = caCertPool
 	}
 
-	config.MinVersion = tls.VersionTLS11  // feat2359 removed deprecated TLS1.0 protocol
+	config.MinVersion = tls.VersionTLS11
 	return config, nil
 }
 

--- a/api/crypto/tls.go
+++ b/api/crypto/tls.go
@@ -56,6 +56,6 @@ func CreateTLSConfigurationFromDisk(caCertPath, certPath, keyPath string, skipSe
 		config.RootCAs = caCertPool
 	}
 	
-	config.MinVersion = tls.VersionTLS11  // feat2359 removed deprecated TLS1.0 protocol
+	config.MinVersion = tls.VersionTLS11
 	return config, nil
 }

--- a/api/crypto/tls.go
+++ b/api/crypto/tls.go
@@ -55,7 +55,7 @@ func CreateTLSConfigurationFromDisk(caCertPath, certPath, keyPath string, skipSe
 		caCertPool.AppendCertsFromPEM(caCert)
 		config.RootCAs = caCertPool
 	}
-	
+
 	config.MinVersion = tls.VersionTLS11
 	return config, nil
 }


### PR DESCRIPTION
The default for tls config minversion is tls1.0 (tls.VersionTLS10).  This changes it to TLS 1.1 (tls.VersionTLS11).

Closes #2359 