### PR TITLE
Updates for swagger-codegen

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -265,7 +265,7 @@ paths:
       - name: "TLSSkipVerify"
         in: "formData"
         type: "string"
-        description: "Skip server verification when using TLS" (example: false)
+        description: "Skip server verification when using TLS (example: false)"
       - name: "TLSCACertFile"
         in: "formData"
         type: "file"
@@ -3848,9 +3848,9 @@ definitions:
   TemplateCreateRequest:
     type: "object"
     required:
-      - "type"
-      - "title"
-      - "description"
+    - "type"
+    - "title"
+    - "description"
     properties:
       type:
         type: "integer"
@@ -4202,7 +4202,7 @@ definitions:
   TemplateRepository:
     type: "object"
     required:
-      - "URL"
+    - "URL"
     properties:
       URL:
         type: "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -153,6 +153,8 @@ paths:
       operationId: "DockerHubInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -175,6 +177,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -211,6 +215,8 @@ paths:
       operationId: "EndpointList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -233,6 +239,8 @@ paths:
       - "multipart/form-data"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "Name"
         in: "formData"
@@ -324,6 +332,8 @@ paths:
       operationId: "EndpointInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -365,6 +375,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -413,6 +425,8 @@ paths:
         Remove an endpoint.
         **Access policy**: administrator
       operationId: "EndpointDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -460,6 +474,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -508,6 +524,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -573,6 +591,8 @@ paths:
       operationId: "EndpointGroupList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -595,6 +615,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -629,6 +651,8 @@ paths:
       operationId: "EndpointGroupInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -670,6 +694,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -720,6 +746,8 @@ paths:
         Remove an endpoint group.
         **Access policy**: administrator
       operationId: "EndpointGroupDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -767,6 +795,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -815,6 +845,8 @@ paths:
       operationId: "RegistryList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -837,6 +869,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -878,6 +912,8 @@ paths:
       operationId: "RegistryInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -919,6 +955,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -969,6 +1007,8 @@ paths:
         Remove a registry.
         **Access policy**: administrator
       operationId: "RegistryDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1009,6 +1049,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1057,6 +1099,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -1107,6 +1151,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1157,6 +1203,8 @@ paths:
         Remove a resource control.
         **Access policy**: restricted
       operationId: "ResourceControlDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1202,6 +1250,8 @@ paths:
       operationId: "SettingsInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -1224,6 +1274,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -1258,6 +1310,8 @@ paths:
       operationId: "PublicSettingsInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -1281,6 +1335,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -1313,6 +1369,8 @@ paths:
       operationId: "StatusInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -1336,6 +1394,8 @@ paths:
       operationId: "StackList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "filters"
         in: "query"
@@ -1368,6 +1428,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "type"
         in: "query"
@@ -1447,6 +1509,8 @@ paths:
       operationId: "StackInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1492,6 +1556,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1544,6 +1610,8 @@ paths:
         Remove a stack.
         **Access policy**: restricted
       operationId: "StackDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1594,6 +1662,8 @@ paths:
       operationId: "StackFileInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1639,6 +1709,8 @@ paths:
       operationId: "StackMigrate"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1693,6 +1765,8 @@ paths:
       operationId: "UserList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -1716,6 +1790,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -1764,6 +1840,8 @@ paths:
       operationId: "UserInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1805,6 +1883,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1855,6 +1935,8 @@ paths:
         Remove a user.
         **Access policy**: administrator
       operationId: "UserDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1893,6 +1975,8 @@ paths:
       operationId: "UserMembershipsInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1936,6 +2020,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -1983,6 +2069,8 @@ paths:
       operationId: "UserAdminCheck"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         204:
@@ -2012,6 +2100,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -2056,6 +2146,8 @@ paths:
       - multipart/form-data
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "path"
         name: "certificate"
@@ -2097,6 +2189,8 @@ paths:
       operationId: "TagList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -2119,6 +2213,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -2158,6 +2254,8 @@ paths:
         Remove a tag.
         **Access policy**: administrator
       operationId: "TagDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2190,6 +2288,8 @@ paths:
       operationId: "TeamList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -2212,6 +2312,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -2260,6 +2362,8 @@ paths:
       operationId: "TeamInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2308,6 +2412,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2349,6 +2455,8 @@ paths:
         Remove a team.
         **Access policy**: administrator
       operationId: "TeamDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2388,6 +2496,8 @@ paths:
       operationId: "TeamMembershipsInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2429,6 +2539,8 @@ paths:
       operationId: "TeamMembershipList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters: []
       responses:
         200:
@@ -2458,6 +2570,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -2508,6 +2622,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2558,6 +2674,8 @@ paths:
         Remove a team membership. Access is only available to administrators leaders of the associated team.
         **Access policy**: restricted
       operationId: "TeamMembershipDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2604,6 +2722,8 @@ paths:
       operationId: "TemplateList"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       responses:
         200:
@@ -2626,6 +2746,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - in: "body"
         name: "body"
@@ -2667,6 +2789,8 @@ paths:
       operationId: "TemplateInspect"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2715,6 +2839,8 @@ paths:
       - "application/json"
       produces:
       - "application/json"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"
@@ -2763,6 +2889,8 @@ paths:
         Remove a template.
         **Access policy**: administrator
       operationId: "TemplateDelete"
+      security:
+      - jwt: []
       parameters:
       - name: "id"
         in: "path"

--- a/api/swagger_config.json
+++ b/api/swagger_config.json
@@ -1,0 +1,4 @@
+{
+  "packageName": "portainer",
+  "projectName": "portainer"
+}

--- a/api/swagger_config.json
+++ b/api/swagger_config.json
@@ -1,4 +1,5 @@
 {
   "packageName": "portainer",
+  "packageVersion": "1.20-dev",
   "projectName": "portainer"
 }


### PR DESCRIPTION
* Fix yamllint errors that were interfering with `swagger-codegen-cli -l swagger`
* Add `security: [jwt: []]` to non-public endpoints
  * Allows use of `ApiClient.configuration.api_key['Authorization']` in generated clients
* Added `api/swagger_config.json` for use with `swagger-codegen`
  * Avoids `swagger_client` library name