### PR TITLE
chore(terminal): updated xterm to 3.8.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "clean-all": "yarn grunt clean:all",
     "build": "yarn grunt build",
     "build-offline": "cd ./api/cmd/portainer && CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s' && mv -b portainer ../../../dist/portainer-linux-amd64"
-
   },
   "engines": {
     "node": ">= 0.8.4"
@@ -65,7 +64,7 @@
     "splitargs": "github:deviantony/splitargs#~0.2.0",
     "toastr": "github:CodeSeven/toastr#~2.1.3",
     "ui-select": "^0.19.8",
-    "xterm": "^3.1.0"
+    "xterm": "^3.8.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4506,9 +4506,10 @@ xtend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
 
-xterm@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.1.0.tgz#7f7e1c8cf4b80bd881a4e8891213b851423e90c9"
+xterm@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.8.0.tgz#55d1de518bdc9c9793823f5e4e97d6898972938d"
+  integrity sha512-rS3HLryuMWbLsv98+jVVSUXCxmoyXPwqwJNC0ad0VSMdXgl65LefPztQVwfurkaF7kM7ZSgM8eJjnJ9kkdoR1w==
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
I noticed that newer version of Xterm.js contains lot of bug fixes.

Here is simple example by copy pasting Portainer deployment command
```
docker run -d -p 9000:9000 --name portainer --restart always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer
```
to console.

**Xterm.js 3.1.0**
![portainer_xterm310](https://user-images.githubusercontent.com/6213926/48364393-f858c580-e6b0-11e8-8158-cc13e27eed77.png)

**Xterm.js 3.8.0**
![portainer_xterm_380](https://user-images.githubusercontent.com/6213926/48364398-fbec4c80-e6b0-11e8-882e-bc999baa20b6.png)


Probably can close #2348