### PR TITLE
feat(motd): relocate motd file URL and always return 200

### DIFF
--- a/api/http/handler/motd/motd.go
+++ b/api/http/handler/motd/motd.go
@@ -18,7 +18,7 @@ func (handler *Handler) motd(w http.ResponseWriter, r *http.Request) {
 
 	motd, err := client.Get(portainer.MessageOfTheDayURL, 0)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		response.JSON(w, &motdResponse{Message: ""})
 		return
 	}
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -714,7 +714,7 @@ const (
 	// DBVersion is the version number of the Portainer database
 	DBVersion = 14
 	// MessageOfTheDayURL represents the URL where Portainer MOTD message can be retrieved
-	MessageOfTheDayURL = "https://raw.githubusercontent.com/portainer/motd/master/message.html"
+	MessageOfTheDayURL = "https://portainer-io-assets.sfo2.digitaloceanspaces.com/motd.html"
 	// PortainerAgentHeader represents the name of the header available in any agent response
 	PortainerAgentHeader = "Portainer-Agent"
 	// PortainerAgentTargetHeader represent the name of the header containing the target node name

--- a/app/portainer/views/home/home.html
+++ b/app/portainer/views/home/home.html
@@ -8,7 +8,7 @@
 </rd-header>
 
 <information-panel
-  ng-if="motd && applicationState.UI.dismissedInfoHash !== motd.Hash"
+  ng-if="motd && motd.Message !== '' && applicationState.UI.dismissedInfoHash !== motd.Hash"
   title-text="Important message"
   dismiss-action="dismissImportantInformation(motd.Hash)">
   <span class="text-muted">


### PR DESCRIPTION
Returns an empty message instead of 500 when no motd available.

Also upload the URL for the MOTD file location.