### PR TITLE
 feat2442: container image create visual feedback

### DIFF
--- a/app/docker/views/containers/edit/containerController.js
+++ b/app/docker/views/containers/edit/containerController.js
@@ -154,6 +154,7 @@ function ($q, $scope, $state, $transition$, $filter, Commit, ContainerHelper, Co
     Commit.commitContainer({id: $transition$.params().id, tag: imageConfig.tag, repo: imageConfig.repo}, function () {
       update();
       Notifications.success('Container commited', $transition$.params().id);
+      $scope.config.Image = '';
     }, function (e) {
       update();
       Notifications.error('Failure', e, 'Unable to commit container');


### PR DESCRIPTION
Closes #2442 .

Note: no real visual feedback added, as Notification is already present.
Simply purging the entered image name on creation success disables the button and prevents a user to create many images.