### PR TITLE
feat(api): filter LDAP password from settings response

### DIFF
--- a/api/http/handler/settings/handler.go
+++ b/api/http/handler/settings/handler.go
@@ -9,6 +9,10 @@ import (
 	"github.com/portainer/portainer/http/security"
 )
 
+func hideFields(settings *portainer.Settings) {
+	settings.LDAPSettings.Password = ""
+}
+
 // Handler is the HTTP handler used to handle settings operations.
 type Handler struct {
 	*mux.Router

--- a/api/http/handler/settings/settings_inspect.go
+++ b/api/http/handler/settings/settings_inspect.go
@@ -14,5 +14,6 @@ func (handler *Handler) settingsInspect(w http.ResponseWriter, r *http.Request) 
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve the settings from the database", err}
 	}
 
+	hideFields(settings)
 	return response.JSON(w, settings)
 }

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -47,7 +47,7 @@ type (
 	// LDAPSettings represents the settings used to connect to a LDAP server
 	LDAPSettings struct {
 		ReaderDN            string                    `json:"ReaderDN"`
-		Password            string                    `json:"Password"`
+		Password            string                    `json:"Password,omitempty"`
 		URL                 string                    `json:"URL"`
 		TLSConfig           TLSConfiguration          `json:"TLSConfig"`
 		StartTLS            bool                      `json:"StartTLS"`


### PR DESCRIPTION
Fixes a potential LDAP credential leak by removing the password from the `/api/settings` response.