### PR TITLE
feat(containers-stats): add refresh rate of 1 and 3 seconds

### DIFF
--- a/app/docker/views/containers/stats/containerstats.html
+++ b/app/docker/views/containers/stats/containerstats.html
@@ -26,6 +26,8 @@
             </label>
             <div class="col-sm-3 col-md-2">
               <select id="refreshRate" ng-model="state.refreshRate" ng-change="changeUpdateRepeater()" class="form-control">
+                <option value="1">1s</option>
+                <option value="3">3s</option>
                 <option value="5">5s</option>
                 <option value="10">10s</option>
                 <option value="30">30s</option>


### PR DESCRIPTION
Sometimes user wants to monitor process and CPU usage even more frequently, such as 1s or 3s.