### PR TITLE
add start and start:server scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   ],
   "scripts": {
     "grunt": "grunt",
-    "dev": "yarn grunt run-dev",
-    "clean-all": "yarn grunt clean:all",
-    "build": "yarn grunt build",
-    "build-offline": "cd ./api/cmd/portainer && CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s' && mv -b portainer ../../../dist/portainer-linux-amd64"
+    "start": "grunt run-dev",
+    "start:server": "yarn build:server:offline && grunt shell:run:amd64",
+    "clean:all": "grunt clean:all",
+    "build": "grunt build",
+    "build:server:offline": "cd ./api/cmd/portainer && CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s' && mv -f portainer ../../../dist/portainer-linux-amd64"
   },
   "engines": {
     "node": ">= 0.8.4"


### PR DESCRIPTION
added the following scripts:
- `yarn start` - will start a dev environment - build the server and client and watch for changed client files (basically an alias for `grunt run-dev`
- `yarn start:server` - will build the server (using offline deps) and run the server