### PR TITLE
fix(containers-console): strange console behaviour on error at start

### DIFF
--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -52,6 +52,7 @@ function ($scope, $transition$, ContainerService, ImageService, EndpointProvider
     })
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to exec into container');
+      $scope.disconnect();
     });
   };
 


### PR DESCRIPTION
Close the console when selected shell does not exist inside the container.