### PR TITLE
feat2481: generic resources for services

### DIFF
--- a/app/docker/helpers/serviceHelper.js
+++ b/app/docker/helpers/serviceHelper.js
@@ -52,13 +52,6 @@ angular.module('portainer.docker')
     return [];
   };
 
-
-
-
-
-
-
-
   helper.translateKeyValueToPlacementConstraints = function(keyValueConstraints) {
     if (keyValueConstraints) {
       var constraints = [];
@@ -72,30 +65,33 @@ angular.module('portainer.docker')
     return [];
   };
 
-    // Reto
   helper.translateKeyValueToGenericResources = function(keyValueGenericResources) {
     if (keyValueGenericResources) {
       var resources = [];
       keyValueGenericResources.forEach(function(resource) {
         if (resource.key && resource.key !== '' && resource.value && resource.value !== ''){
-          resources.push({
-              'DiscreteResourceSpec': {
+          if(!isNaN(resource.value) && parseInt(Number(resource.value)) == resource.value && !isNaN(parseInt(resource.value,10))){
+              resources.push({
+                  'DiscreteResourceSpec': {
+                      'Kind': resource.key,
+                      'Value': parseInt(resource.value)
+                  }
+              });
+          }
+          else {
+            resources.push({
+                'NamedResourceSpec': {
                   'Kind': resource.key,
-                  'Value': parseInt(resource.value)
-              }
-          });
+                  'Value': resource.value
+                }
+            });
+          }
         }
       });
       return resources;
     }
     return [];
   }
-
-
-
-
-
-
 
   helper.translateEnvironmentVariables = function(env) {
     if (env) {

--- a/app/docker/helpers/serviceHelper.js
+++ b/app/docker/helpers/serviceHelper.js
@@ -71,19 +71,19 @@ angular.module('portainer.docker')
       keyValueGenericResources.forEach(function(resource) {
         if (resource.key && resource.key !== '' && resource.value && resource.value !== ''){
           if(!isNaN(resource.value) && parseInt(Number(resource.value)) == resource.value && !isNaN(parseInt(resource.value,10))){
-              resources.push({
-                  'DiscreteResourceSpec': {
-                      'Kind': resource.key,
-                      'Value': parseInt(resource.value)
-                  }
-              });
+            resources.push({
+              'DiscreteResourceSpec': {
+                'Kind': resource.key,
+                'Value': parseInt(resource.value)
+              }
+            });
           }
           else {
             resources.push({
-                'NamedResourceSpec': {
-                  'Kind': resource.key,
-                  'Value': resource.value
-                }
+              'NamedResourceSpec': {
+                'Kind': resource.key,
+                'Value': resource.value
+              }
             });
           }
         }

--- a/app/docker/helpers/serviceHelper.js
+++ b/app/docker/helpers/serviceHelper.js
@@ -52,6 +52,13 @@ angular.module('portainer.docker')
     return [];
   };
 
+
+
+
+
+
+
+
   helper.translateKeyValueToPlacementConstraints = function(keyValueConstraints) {
     if (keyValueConstraints) {
       var constraints = [];
@@ -64,6 +71,31 @@ angular.module('portainer.docker')
     }
     return [];
   };
+
+    // Reto
+  helper.translateKeyValueToGenericResources = function(keyValueGenericResources) {
+    if (keyValueGenericResources) {
+      var resources = [];
+      keyValueGenericResources.forEach(function(resource) {
+        if (resource.key && resource.key !== '' && resource.value && resource.value !== ''){
+          resources.push({
+              'DiscreteResourceSpec': {
+                  'Kind': resource.key,
+                  'Value': parseInt(resource.value)
+              }
+          });
+        }
+      });
+      return resources;
+    }
+    return [];
+  }
+
+
+
+
+
+
 
   helper.translateEnvironmentVariables = function(env) {
     if (env) {

--- a/app/docker/models/service.js
+++ b/app/docker/models/service.js
@@ -21,12 +21,14 @@ function ServiceViewModel(data, runningTasks, allTasks) {
   }
   if (data.Spec.TaskTemplate.Resources) {
     if (data.Spec.TaskTemplate.Resources.Limits) {
-    this.LimitNanoCPUs = data.Spec.TaskTemplate.Resources.Limits.NanoCPUs;
-    this.LimitMemoryBytes = data.Spec.TaskTemplate.Resources.Limits.MemoryBytes;
+      this.LimitNanoCPUs = data.Spec.TaskTemplate.Resources.Limits.NanoCPUs;
+      this.LimitMemoryBytes = data.Spec.TaskTemplate.Resources.Limits.MemoryBytes;
+      this.GenericResources = data.Spec.TaskTemplate.Resources.Limits.GenericResources;
     }
     if (data.Spec.TaskTemplate.Resources.Reservations) {
-    this.ReservationNanoCPUs = data.Spec.TaskTemplate.Resources.Reservations.NanoCPUs;
-    this.ReservationMemoryBytes = data.Spec.TaskTemplate.Resources.Reservations.MemoryBytes;
+      this.ReservationNanoCPUs = data.Spec.TaskTemplate.Resources.Reservations.NanoCPUs;
+      this.ReservationMemoryBytes = data.Spec.TaskTemplate.Resources.Reservations.MemoryBytes;
+      this.GenericResources = data.Spec.TaskTemplate.Resources.Reservations.GenericResources;
     }
   }
 

--- a/app/docker/views/services/create/createServiceController.js
+++ b/app/docker/views/services/create/createServiceController.js
@@ -373,13 +373,10 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     }
   }
 
-
-    function prepareGenericResourcesConfig(config, input) {
-        config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
-        config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
-    }
-
-
+  function prepareGenericResourcesConfig(config, input) {
+      config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+      config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+  }
 
   function prepareLogDriverConfig(config, input) {
     var logOpts = {};

--- a/app/docker/views/services/create/createServiceController.js
+++ b/app/docker/views/services/create/createServiceController.js
@@ -374,7 +374,6 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
   }
 
   function prepareGenericResourcesConfig(config, input) {
-      config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
       config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
   }
 

--- a/app/docker/views/services/create/createServiceController.js
+++ b/app/docker/views/services/create/createServiceController.js
@@ -21,6 +21,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     HostsEntries: [],
     Ports: [],
     Parallelism: 1,
+    GenericResources: [],
     PlacementConstraints: [],
     PlacementPreferences: [],
     UpdateDelay: '0s',
@@ -109,6 +110,14 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
 
   $scope.removeEnvironmentVariable = function(index) {
     $scope.formValues.Env.splice(index, 1);
+  };
+
+  $scope.addGenericResource = function() {
+    $scope.formValues.GenericResources.push({key: '', value: ''});
+  };
+
+  $scope.removeGenericResource = function(index) {
+    $scope.formValues.GenericResources.splice(index, 1);
   };
 
   $scope.addPlacementConstraint = function() {
@@ -364,6 +373,14 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     }
   }
 
+
+    function prepareGenericResourcesConfig(config, input) {
+        config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+        config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+    }
+
+
+
   function prepareLogDriverConfig(config, input) {
     var logOpts = {};
     if (input.LogDriverName) {
@@ -391,8 +408,12 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
         },
         Placement: {},
         Resources: {
-          Limits: {},
-          Reservations: {}
+          Limits: {
+            GenericResources: []
+          },
+          Reservations: {
+            GenericResources: []
+          }
         }
       },
       Mode: {},
@@ -411,6 +432,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
     prepareConfigConfig(config, input);
     prepareSecretConfig(config, input);
     preparePlacementConfig(config, input);
+    prepareGenericResourcesConfig(config, input);
     prepareResourcesCpuConfig(config, input);
     prepareResourcesMemoryConfig(config, input);
     prepareRestartPolicy(config, input);

--- a/app/docker/views/services/create/createServiceController.js
+++ b/app/docker/views/services/create/createServiceController.js
@@ -113,7 +113,7 @@ function ($q, $scope, $state, $timeout, Service, ServiceHelper, ConfigService, C
   };
 
   $scope.addGenericResource = function() {
-    $scope.formValues.GenericResources.push({key: '', value: ''});
+    $scope.formValues.GenericResources.push({spec: '', key: '', value: ''});
   };
 
   $scope.removeGenericResource = function(index) {

--- a/app/docker/views/services/create/includes/resources-placement.html
+++ b/app/docker/views/services/create/includes/resources-placement.html
@@ -68,6 +68,38 @@
     </div>
   </div>
   <!-- !cpu-limit-input -->
+
+  <!-- Generic-resource -->
+  <div class="form-group">
+    <div class="col-sm-12" style="margin-top: 5px;">
+      <label class="control-label text-left">Generic resources</label>
+      <span class="label label-default interactive" style="margin-left: 10px;" ng-click="addGenericResource()">
+        <i class="fa fa-plus-circle" aria-hidden="true"></i> Generic resources
+      </span>
+    </div>
+    <div class="col-sm-12 form-inline" style="margin-top: 10px;">
+      <div ng-repeat="resource in formValues.GenericResources" style="margin-top: 2px;">
+        <div class="input-group col-sm-4 input-group-sm">
+          <span class="input-group-addon">name</span>
+          <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu">
+        </div><!--
+        <div class="input-group col-sm-1 input-group-sm">
+          <select name="resourceOperator" class="form-control" ng-model="resource.operator">
+            <option value="=">=</option>
+          </select>
+        </div>-->
+        <div class="input-group col-sm-5 input-group-sm">
+          <span class="input-group-addon">value</span>
+          <input type="text" class="form-control" ng-model="resource.value" placeholder="3">
+        </div>
+        <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource($index)">
+          <i class="fa fa-trash" aria-hidden="true"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+  <!-- !Generic-resource -->
+
   <div class="col-sm-12 form-section-title">
     Placement
   </div>

--- a/app/docker/views/services/create/includes/resources-placement.html
+++ b/app/docker/views/services/create/includes/resources-placement.html
@@ -82,12 +82,7 @@
         <div class="input-group col-sm-4 input-group-sm">
           <span class="input-group-addon">name</span>
           <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu">
-        </div><!--
-        <div class="input-group col-sm-1 input-group-sm">
-          <select name="resourceOperator" class="form-control" ng-model="resource.operator">
-            <option value="=">=</option>
-          </select>
-        </div>-->
+        </div>
         <div class="input-group col-sm-5 input-group-sm">
           <span class="input-group-addon">value</span>
           <input type="text" class="form-control" ng-model="resource.value" placeholder="3">

--- a/app/docker/views/services/create/includes/resources-placement.html
+++ b/app/docker/views/services/create/includes/resources-placement.html
@@ -79,13 +79,20 @@
     </div>
     <div class="col-sm-12 form-inline" style="margin-top: 10px;">
       <div ng-repeat="resource in formValues.GenericResources" style="margin-top: 2px;">
+        <div class="input-group col-sm-2 input-group-sm">
+          <select name="resourceSpec" class="form-control" ng-model="resource.spec">
+            <option value="NamedResourceSpec" ng-selected="true">Named resource spec</option>
+            <option value="DiscreteResourceSpec">Discrete resource spec</option>
+          </select>
+        </div>
         <div class="input-group col-sm-4 input-group-sm">
           <span class="input-group-addon">name</span>
           <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu">
         </div>
-        <div class="input-group col-sm-5 input-group-sm">
+        <div class="input-group col-sm-4 input-group-sm">
           <span class="input-group-addon">value</span>
-          <input type="text" class="form-control" ng-model="resource.value" placeholder="3">
+          <input type="text" class="form-control" ng-model="resource.value" placeholder="3" ng-if="resource.spec==='DiscreteResourceSpec'">
+          <input type="text" class="form-control" ng-model="resource.value" placeholder="UUID0" ng-if="resource.spec==='NamedResourceSpec'">
         </div>
         <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource($index)">
           <i class="fa fa-trash" aria-hidden="true"></i>

--- a/app/docker/views/services/edit/includes/genericResources.html
+++ b/app/docker/views/services/edit/includes/genericResources.html
@@ -15,7 +15,6 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th>Operator</th>
             <th>Value</th>
           </tr>
         </thead>

--- a/app/docker/views/services/edit/includes/genericResources.html
+++ b/app/docker/views/services/edit/includes/genericResources.html
@@ -1,0 +1,65 @@
+<div ng-if="service.ServiceGenericResources" id="service-generic-resources">
+  <rd-widget>
+    <rd-widget-header icon="fa-tasks" title-text="Generic resources">
+      <div class="nopadding">
+        <a class="btn btn-default btn-sm pull-right" ng-click="isUpdating || addGenericResource(service)" ng-disabled="isUpdating">
+          <i class="fa fa-plus-circle" aria-hidden="true"></i> generic resource
+        </a>
+      </div>
+    </rd-widget-header>
+    <rd-widget-body ng-if="service.ServiceGenericResources.length === 0">
+      <p>There are no generic resources for this service.</p>
+    </rd-widget-body>
+    <rd-widget-body ng-if="service.ServiceGenericResources.length > 0" classes="no-padding">
+      <table class="table" >
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Operator</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="resource in service.ServiceGenericResources">
+            <td>
+              <div class="input-group input-group-sm">
+                <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+              </div>
+            </td><!--
+            <td>
+              <div class="input-group input-group-sm">
+                <select name="constraintOperator" class="form-control" ng-model="resource.operator" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                  <option value="=">=</option>
+                </select>
+              </div>
+            </td>-->
+            <td>
+              <div class="input-group input-group-sm">
+                <input type="text" class="form-control" ng-model="resource.value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <span class="input-group-btn">
+                    <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource(service, $index)" ng-disabled="isUpdating">
+                      <i class="fa fa-trash" aria-hidden="true"></i>
+                    </button>
+                  </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </rd-widget-body>
+    <rd-widget-footer>
+      <div class="btn-toolbar" role="toolbar">
+        <div class="btn-group" role="group">
+          <button type="button" class="btn btn-primary btn-sm" ng-disabled="!hasChanges(service, ['ServiceGenericResources'])" ng-click="updateService(service)">Apply changes</button>
+          <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a ng-click="cancelChanges(service, ['ServiceGenericResources'])">Reset changes</a></li>
+            <li><a ng-click="cancelChanges(service)">Reset all changes</a></li>
+          </ul>
+        </div>
+      </div>
+    </rd-widget-footer>
+  </rd-widget>
+</div>

--- a/app/docker/views/services/edit/includes/genericResources.html
+++ b/app/docker/views/services/edit/includes/genericResources.html
@@ -14,6 +14,7 @@
       <table class="table" >
         <thead>
           <tr>
+            <th>Resource spec</th>
             <th>Name</th>
             <th>Value</th>
           </tr>
@@ -21,6 +22,12 @@
         <tbody>
 
           <tr ng-repeat="resource in service.ServiceGenericResources">
+            <td ng-if="resource.hasOwnProperty('DiscreteResourceSpec')">
+              <select name="resourceSpec" class="form-control" ng-model="resource.spec" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <option value="NamedResourceSpec">Named resource spec</option>
+                <option value="DiscreteResourceSpec" ng-selected="true">Discrete resource spec</option>
+              </select>
+            </td>
             <td ng-if="resource.hasOwnProperty('DiscreteResourceSpec')">
               <div class="input-group input-group-sm">
                 <input type="text" class="form-control" ng-model="resource.DiscreteResourceSpec.Kind" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
@@ -38,13 +45,19 @@
             </td>
 
             <td ng-if="!resource.hasOwnProperty('DiscreteResourceSpec')">
+              <select name="resourceSpec" class="form-control" ng-model="resource.spec" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <option value="NamedResourceSpec" ng-selected="true">Named resource spec</option>
+                <option value="DiscreteResourceSpec">Discrete resource spec</option>
+              </select>
+            </td>
+            <td ng-if="!resource.hasOwnProperty('DiscreteResourceSpec')">
               <div class="input-group input-group-sm">
                 <input type="text" class="form-control" ng-model="resource.NamedResourceSpec.Kind" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
               </div>
             </td>
-            <td ng-if="resource.hasOwnProperty('NamedResourceSpec')">
+            <td ng-if="!resource.hasOwnProperty('DiscreteResourceSpec')">
               <div class="input-group input-group-sm">
-                <input type="text" class="form-control" ng-model="resource.NamedResourceSpec.Value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <input type="text" class="form-control" ng-model="resource.NamedResourceSpec.Value" placeholder="e.g. UUID1" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
                 <span class="input-group-btn">
                   <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource(service, $index)" ng-disabled="isUpdating">
                     <i class="fa fa-trash" aria-hidden="true"></i>

--- a/app/docker/views/services/edit/includes/genericResources.html
+++ b/app/docker/views/services/edit/includes/genericResources.html
@@ -19,15 +19,16 @@
           </tr>
         </thead>
         <tbody>
+
           <tr ng-repeat="resource in service.ServiceGenericResources">
-            <td>
+            <td ng-if="resource.hasOwnProperty('DiscreteResourceSpec')">
               <div class="input-group input-group-sm">
-                <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <input type="text" class="form-control" ng-model="resource.DiscreteResourceSpec.Kind" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
               </div>
             </td>
-            <td>
+            <td ng-if="resource.hasOwnProperty('DiscreteResourceSpec')">
               <div class="input-group input-group-sm">
-                <input type="text" class="form-control" ng-model="resource.value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <input type="text" class="form-control" ng-model="resource.DiscreteResourceSpec.Value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
                 <span class="input-group-btn">
                     <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource(service, $index)" ng-disabled="isUpdating">
                       <i class="fa fa-trash" aria-hidden="true"></i>
@@ -35,7 +36,24 @@
                   </span>
               </div>
             </td>
+
+            <td ng-if="!resource.hasOwnProperty('DiscreteResourceSpec')">
+              <div class="input-group input-group-sm">
+                <input type="text" class="form-control" ng-model="resource.NamedResourceSpec.Kind" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+              </div>
+            </td>
+            <td ng-if="resource.hasOwnProperty('NamedResourceSpec')">
+              <div class="input-group input-group-sm">
+                <input type="text" class="form-control" ng-model="resource.NamedResourceSpec.Value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
+                <span class="input-group-btn">
+                  <button class="btn btn-sm btn-danger" type="button" ng-click="removeGenericResource(service, $index)" ng-disabled="isUpdating">
+                    <i class="fa fa-trash" aria-hidden="true"></i>
+                  </button>
+                </span>
+              </div>
+            </td>
           </tr>
+
         </tbody>
       </table>
     </rd-widget-body>

--- a/app/docker/views/services/edit/includes/genericResources.html
+++ b/app/docker/views/services/edit/includes/genericResources.html
@@ -25,14 +25,7 @@
               <div class="input-group input-group-sm">
                 <input type="text" class="form-control" ng-model="resource.key" placeholder="e.g. gpu" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
               </div>
-            </td><!--
-            <td>
-              <div class="input-group input-group-sm">
-                <select name="constraintOperator" class="form-control" ng-model="resource.operator" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">
-                  <option value="=">=</option>
-                </select>
-              </div>
-            </td>-->
+            </td>
             <td>
               <div class="input-group input-group-sm">
                 <input type="text" class="form-control" ng-model="resource.value" placeholder="e.g. 3" ng-change="updateGenericResource(service, resource)" ng-disabled="isUpdating">

--- a/app/docker/views/services/edit/service.html
+++ b/app/docker/views/services/edit/service.html
@@ -136,6 +136,7 @@
           <li><a href ng-click="goToItem('service-network-specs')">Network &amp; published ports</a></li>
           <li><a href ng-click="goToItem('service-resources')">Resource limits &amp; reservations</a></li>
           <li><a href ng-click="goToItem('service-placement-constraints')">Placement constraints</a></li>
+          <li><a href ng-click="goToItem('service-generic-resources')">Generic resources</a></li>
           <li ng-if="applicationState.endpoint.apiVersion >= 1.30"><a href ng-click="goToItem('service-placement-preferences')">Placement preferences</a></li>
           <li><a href ng-click="goToItem('service-restart-policy')">Restart policy</a></li>
           <li><a href ng-click="goToItem('service-update-config')">Update configuration</a></li>
@@ -186,6 +187,7 @@
     <h3 id="service-specs">Service specification</h3>
     <div id="service-resources" class="padding-top" ng-include="'app/docker/views/services/edit/includes/resources.html'"></div>
     <div id="service-placement-constraints" class="padding-top" ng-include="'app/docker/views/services/edit/includes/constraints.html'"></div>
+    <div id="service-generic-resources" class="padding-top" ng-include="'app/docker/views/services/edit/includes/genericResources.html'"></div>
     <div id="service-placement-preferences" ng-if="applicationState.endpoint.apiVersion >= 1.30" class="padding-top" ng-include="'app/docker/views/services/edit/includes/placementPreferences.html'"></div>
     <div id="service-restart-policy" class="padding-top" ng-include="'app/docker/views/services/edit/includes/restart.html'"></div>
     <div id="service-update-config" class="padding-top" ng-include="'app/docker/views/services/edit/includes/updateconfig.html'"></div>

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -129,15 +129,6 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     updateServiceArray(service, 'ServiceMounts', service.ServiceMounts);
   };
 
-
-
-
-
-
-
-
-
-
   $scope.addGenericResource = function addGenericResource(service) {
       service.ServiceGenericResources.push({key: '', value: ''});
       updateServiceArray(service, 'ServiceGenericResources', service.ServiceGenericResources);
@@ -151,9 +142,6 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   $scope.updateGenericResource = function(service) {
     updateServiceArray(service, 'ServiceGenericResource', service.ServiceGenericResources);
   };
-
-
-
 
   $scope.addPlacementConstraint = function addPlacementConstraint(service) {
     service.ServiceConstraints.push({ key: '', operator: '==', value: '' });
@@ -182,16 +170,6 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   $scope.updatePlacementPreference = function(service) {
     updateServiceArray(service, 'ServicePreferences', service.ServicePreferences);
   };
-
-
-
-
-
-
-
-
-
-
 
   $scope.addPublishedPort = function addPublishedPort(service) {
     if (!service.Ports) {

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -128,6 +128,33 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   $scope.updateMount = function updateMount(service) {
     updateServiceArray(service, 'ServiceMounts', service.ServiceMounts);
   };
+
+
+
+
+
+
+
+
+
+
+  $scope.addGenericResource = function addGenericResource(service) {
+      service.ServiceGenericResources.push({key: '', value: ''});
+      updateServiceArray(service, 'ServiceGenericResources', service.ServiceGenericResources);
+  };
+  $scope.removeGenericResource = function removeGenericResource(service, index) {
+    var removedElement = service.ServiceGenericResources.splice(index, 1);
+    if (removedElement !== null) {
+      updateServiceArray(service, 'ServiceGenericResource', service.ServiceGenericResources);
+    }
+  };
+  $scope.updateGenericResource = function(service) {
+    updateServiceArray(service, 'ServiceGenericResource', service.ServiceGenericResources);
+  };
+
+
+
+
   $scope.addPlacementConstraint = function addPlacementConstraint(service) {
     service.ServiceConstraints.push({ key: '', operator: '==', value: '' });
     updateServiceArray(service, 'ServiceConstraints', service.ServiceConstraints);
@@ -155,6 +182,16 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   $scope.updatePlacementPreference = function(service) {
     updateServiceArray(service, 'ServicePreferences', service.ServicePreferences);
   };
+
+
+
+
+
+
+
+
+
+
 
   $scope.addPublishedPort = function addPublishedPort(service) {
     if (!service.Ports) {
@@ -302,6 +339,9 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       };
     }
 
+    config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+    config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+
     if($scope.hasChanges(service, ['UpdateFailureAction', 'UpdateDelay', 'UpdateParallelism', 'UpdateOrder'])) {
       config.UpdateConfig = {
         Parallelism: service.UpdateParallelism,
@@ -431,6 +471,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     service.ServiceLabels = LabelHelper.fromLabelHashToKeyValue(service.Labels);
     service.ServiceContainerLabels = LabelHelper.fromLabelHashToKeyValue(service.ContainerLabels);
     service.ServiceMounts = angular.copy(service.Mounts);
+    service.ServiceGenericResources = ServiceHelper.translateKeyValueToGenericResources(service.GenericResources);
     service.ServiceConstraints = ServiceHelper.translateConstraintsToKeyValue(service.Constraints);
     service.ServicePreferences = ServiceHelper.translatePreferencesToKeyValue(service.Preferences);
     service.Hosts = ServiceHelper.translateHostsEntriesToHostnameIP(service.Hosts);

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -317,8 +317,9 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       };
     }
 
-    config.TaskTemplate.Resources.Limits.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
-    config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.translateKeyValueToGenericResources(input.GenericResources);
+    if ($scope.hasChanges(service, ['GenericResources'])) {
+        config.TaskTemplate.Resources.Reservations.GenericResources = service.GenericResources;
+    }
 
     if($scope.hasChanges(service, ['UpdateFailureAction', 'UpdateDelay', 'UpdateParallelism', 'UpdateOrder'])) {
       config.UpdateConfig = {

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -450,7 +450,7 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
     service.ServiceLabels = LabelHelper.fromLabelHashToKeyValue(service.Labels);
     service.ServiceContainerLabels = LabelHelper.fromLabelHashToKeyValue(service.ContainerLabels);
     service.ServiceMounts = angular.copy(service.Mounts);
-    service.ServiceGenericResources = ServiceHelper.translateKeyValueToGenericResources(service.GenericResources);
+    service.ServiceGenericResources = angular.copy(service.GenericResources);
     service.ServiceConstraints = ServiceHelper.translateConstraintsToKeyValue(service.Constraints);
     service.ServicePreferences = ServiceHelper.translatePreferencesToKeyValue(service.Preferences);
     service.Hosts = ServiceHelper.translateHostsEntriesToHostnameIP(service.Hosts);

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -130,17 +130,17 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
   };
 
   $scope.addGenericResource = function addGenericResource(service) {
-      service.ServiceGenericResources.push({key: '', value: ''});
+      service.ServiceGenericResources.push({spec: '', key: '', value: ''});
       updateServiceArray(service, 'ServiceGenericResources', service.ServiceGenericResources);
   };
   $scope.removeGenericResource = function removeGenericResource(service, index) {
     var removedElement = service.ServiceGenericResources.splice(index, 1);
     if (removedElement !== null) {
-      updateServiceArray(service, 'ServiceGenericResource', service.ServiceGenericResources);
+      updateServiceArray(service, 'ServiceGenericResources', service.ServiceGenericResources);
     }
   };
   $scope.updateGenericResource = function(service) {
-    updateServiceArray(service, 'ServiceGenericResource', service.ServiceGenericResources);
+    updateServiceArray(service, 'ServiceGenericResources', service.ServiceGenericResources);
   };
 
   $scope.addPlacementConstraint = function addPlacementConstraint(service) {
@@ -317,8 +317,8 @@ function ($q, $scope, $transition$, $state, $location, $timeout, $anchorScroll, 
       };
     }
 
-    if ($scope.hasChanges(service, ['GenericResources'])) {
-        config.TaskTemplate.Resources.Reservations.GenericResources = service.GenericResources;
+    if ($scope.hasChanges(service, ['ServiceGenericResources'])) {
+        config.TaskTemplate.Resources.Reservations.GenericResources = ServiceHelper.transformGenericResources(service.ServiceGenericResources);
     }
 
     if($scope.hasChanges(service, ['UpdateFailureAction', 'UpdateDelay', 'UpdateParallelism', 'UpdateOrder'])) {

--- a/app/docker/views/swarm/swarmController.js
+++ b/app/docker/views/swarm/swarmController.js
@@ -5,6 +5,7 @@ function ($q, $scope, SystemService, NodeService, Notifications, StateManager, A
   $scope.docker = {};
   $scope.swarm = {};
   $scope.totalCPU = 0;
+  $scope.totalGPU = 0;
   $scope.totalMemory = 0;
 
   function extractSwarmInfo(info) {

--- a/app/docker/views/swarm/swarmController.js
+++ b/app/docker/views/swarm/swarmController.js
@@ -5,7 +5,6 @@ function ($q, $scope, SystemService, NodeService, Notifications, StateManager, A
   $scope.docker = {};
   $scope.swarm = {};
   $scope.totalCPU = 0;
-  $scope.totalGPU = 0;
   $scope.totalMemory = 0;
 
   function extractSwarmInfo(info) {


### PR DESCRIPTION
I implemented this feature. Strangely it does not work. It has the following config which works on my local computer when using it with curl but in portainer it does not. The config is the following in the line `Service.create(config).$promise ... ` in `/app/docker/views/services/create/createServiceController.js`
I would be grateful for help.

```
"{
 "Name": "",
 "TaskTemplate": {
   "ContainerSpec": {
     "Mounts": [],
     "Image": "docker.io/hello-world:latest",
     "Env": [],
     "Labels": {},
     "Configs": [],
     "Secrets": []
   },
   "Placement": {
     "Constraints": [],
     "Preferences": []
   },
   "Resources": {
     "Limits": {
       "GenericResources": [
         {
           "DiscreteResourceSpec": {
             "Kind": "gpu",
             "Value": 3
           }
         }
       ]
     },
     "Reservations": {
       "GenericResources": [
         {
           "DiscreteResourceSpec": {
             "Kind": "gpu",
             "Value": 3
           }
         }
       ]
     }
   },
   "RestartPolicy": {
     "Condition": "any",
     "Delay": 5000000000,
     "MaxAttempts": 0,
     "Window": 0
   }
 },
 "Mode": {
   "Replicated": {
     "Replicas": 1
   }
 },
 "EndpointSpec": {
   "Ports": []
 },
 "Labels": {},
 "Networks": [],
 "UpdateConfig": {
   "Parallelism": 1,
   "Delay": 0,
   "FailureAction": "pause",
   "Order": "stop-first"
 }
}"
```

Close #2481 