### PR TITLE
Feat(UI): add driver name in the volume selector

### DIFF
--- a/app/docker/views/containers/create/createcontainer.html
+++ b/app/docker/views/containers/create/createcontainer.html
@@ -320,7 +320,7 @@
                         <span class="input-group-addon">volume</span>
                         <select class="form-control" ng-model="volume.name">
                           <option selected disabled hidden value="">Select a volume</option>
-                          <option ng-repeat="vol in availableVolumes" ng-value="vol.Name">{{ vol.Name|truncate:30}}</option>
+                          <option ng-repeat="vol in availableVolumes" ng-value="vol.Name">{{ vol.Name|truncate:30}} - {{ vol.Driver|truncate:30}}</option>
                         </select>
                       </div>
                       <!-- !volume -->

--- a/app/docker/views/services/create/createservice.html
+++ b/app/docker/views/services/create/createservice.html
@@ -315,8 +315,9 @@
                         <!-- volume -->
                         <div class="input-group input-group-sm col-sm-6" ng-if="volume.Type === 'volume'">
                           <span class="input-group-addon">volume</span>
-                          <select class="form-control" ng-model="volume.Source" ng-options="vol.Id|truncate:30 for vol in availableVolumes">
+                          <select class="form-control" ng-model="volume.Source">
                             <option selected disabled hidden value="">Select a volume</option>
+                            <option ng-repeat="vol in availableVolumes" ng-value="vol.Id">{{ vol.Id|truncate:30}} - {{ vol.Driver|truncate:30}}</option>
                           </select>
                         </div>
                         <!-- !volume -->


### PR DESCRIPTION
**What implement this feature ?**

This feature just adding the driver name on the volume selector when you creating a new container or service. 

**Why this feature ?**

This can be useful in case when you have a same name on your volumes but not same volume driver.

**Example :**

In my case, I had many volumes with the same same name, provisioning by `rexray/s3fs` plugins (each volumes have a different rexray instance). With this feature I can differentiate them by their driver name who corresponding to an alias.