### PR TITLE
fix(edit): fix incorrect quotation of commands

### DIFF
--- a/app/docker/helpers/containerHelper.js
+++ b/app/docker/helpers/containerHelper.js
@@ -8,9 +8,7 @@ angular.module('portainer.docker')
   };
 
   helper.commandArrayToString = function(array) {
-    return array.map(function(elem) {
-      return '\'' + elem + '\'';
-    }).join(' ');
+    return array.join(' ');
   };
 
   helper.configFromContainer = function(container) {


### PR DESCRIPTION
Fix for issue #2552 by removing the single quotation marks that get printed while joining the commands array.