### PR TITLE
Stop container only after pull

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -659,7 +659,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       }
       $scope.state.actionInProgress = true;
       return pullImageIfNeeded()
-        .then(stopAndRenameContainer.bind(null, oldContainer))
+        .then(stopAndRenameContainer)
         .then(createNewContainer)
         .then(applyResourceControl)
         .then(connectToExtraNetworks)
@@ -695,7 +695,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       }
     }
 
-    function stopAndRenameContainer(oldContainer) {
+    function stopAndRenameContainer() {
       if (!oldContainer) {
         return $q.when();
       }

--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -659,7 +659,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
       }
       $scope.state.actionInProgress = true;
       return pullImageIfNeeded()
-        .then(stopAndRenameContainer(oldContainer))
+        .then(stopAndRenameContainer.bind(null, oldContainer))
         .then(createNewContainer)
         .then(applyResourceControl)
         .then(connectToExtraNetworks)


### PR DESCRIPTION
fix #2379
I made a mistake in a fix I did a few weeks back, where I was calling the stopContainer function in the promise chain, instead of just passing it. It didn't cause many bugs (except #2379) because it did return a promise, so most times it means just stopping the container before pulling the image.