### PR TITLE
fix(container): remove new container only if exist

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -686,7 +686,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
 
     function removeNewContainer() {
       return findCurrentContainer().then(function onConatinerLoaded(container) {
-        if (!oldContainer || container.Id !== oldContainer.Id) {
+        if (container && (!oldContainer || container.Id !== oldContainer.Id)) {
           return ContainerService.remove(container, true);
         }
       });


### PR DESCRIPTION
Base on #2565, if create new container failed, findCurrentContainer() will return undefined