### PR TITLE
Redirect to home if no endpoint is set

### DIFF
--- a/app/docker/__module.js
+++ b/app/docker/__module.js
@@ -7,11 +7,10 @@ angular.module('portainer.docker', ['portainer.app'])
     parent: 'root',
     abstract: true,
     resolve: {
-      endpointID: ['EndpointProvider', '$state', 'Notifications', 
-        function (EndpointProvider, $state, Notifications) {
+      endpointID: ['EndpointProvider', '$state',
+        function (EndpointProvider, $state) {
           var id = EndpointProvider.endpointID();
           if (!id) {
-            Notifications.warning('Endpoint is not set');
             return $state.go('portainer.home');
           }
         }

--- a/app/docker/__module.js
+++ b/app/docker/__module.js
@@ -5,7 +5,18 @@ angular.module('portainer.docker', ['portainer.app'])
   var docker = {
     name: 'docker',
     parent: 'root',
-    abstract: true
+    abstract: true,
+    resolve: {
+      endpointID: ['EndpointProvider', '$state', 'Notifications', 
+        function (EndpointProvider, $state, Notifications) {
+          var id = EndpointProvider.endpointID();
+          if (!id) {
+            Notifications.warning('Endpoint is not set');
+            return $state.go('portainer.home');
+          }
+        }
+      ]
+    }
   };
 
   var configs = {

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -329,11 +329,10 @@ angular.module('portainer.app', [])
       }
     },
     resolve: {
-      endpointID: ['EndpointProvider', '$state', 'Notifications', 
-        function (EndpointProvider, $state, Notifications) {
+      endpointID: ['EndpointProvider', '$state', 
+        function (EndpointProvider, $state) {
           var id = EndpointProvider.endpointID();
           if (!id) {
-            Notifications.warning('Endpoint is not set');
             return $state.go('portainer.home');
           }
         }

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -327,6 +327,17 @@ angular.module('portainer.app', [])
         templateUrl: 'app/portainer/views/stacks/stacks.html',
         controller: 'StacksController'
       }
+    },
+    resolve: {
+      endpointID: ['EndpointProvider', '$state', 'Notifications', 
+        function (EndpointProvider, $state, Notifications) {
+          var id = EndpointProvider.endpointID();
+          if (!id) {
+            Notifications.warning('Endpoint is not set');
+            return $state.go('portainer.home');
+          }
+        }
+      ]
     }
   };
 

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -342,7 +342,7 @@ angular.module('portainer.app', [])
   };
 
   var stackCreation = {
-    name: 'portainer.newstack',
+    name: 'portainer.stacks.newstack',
     url: '/newstack',
     views: {
       'content@': {

--- a/app/portainer/components/datatables/stacks-datatable/stacksDatatable.html
+++ b/app/portainer/components/datatables/stacks-datatable/stacksDatatable.html
@@ -11,7 +11,7 @@
           ng-disabled="$ctrl.state.selectedItemCount === 0" ng-click="$ctrl.removeAction($ctrl.state.selectedItems)">
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
-        <button type="button" class="btn btn-sm btn-primary" ui-sref="portainer.newstack">
+        <button type="button" class="btn btn-sm btn-primary" ui-sref="portainer.stacks.newstack">
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Add stack
         </button>
       </div>


### PR DESCRIPTION
closes #2494 

it adds a resolve to docker states to check if `endpointID` is set, if not, redirects to `portainer.home` with a warning notification.

For some reason the stacks state is in the portainer module instead of docker. I think it should move, but nevertheless I added the same resolve to the stacks state. I did move `portainer.newstack` to `portainer.stacks.newstack`, seems more logical and removes another duplication of the resolve function