### PR TITLE
docs(api): fix invalid example value for AutoCreateUsers property

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3146,7 +3146,7 @@ definitions:
           $ref: "#/definitions/LDAPGroupSearchSettings"
       AutoCreateUsers:
         type: "boolean"
-        example: "true"
+        example: true
         description: "Automatically provision users and assign them to matching LDAP group names"
 
   Settings:


### PR DESCRIPTION
Close #2615 