### PR TITLE
fix(registry-management): cache-control header + manifests versions

### DIFF
--- a/app/extensions/registry-management/helpers/localRegistryHelper.js
+++ b/app/extensions/registry-management/helpers/localRegistryHelper.js
@@ -17,6 +17,10 @@ angular.module('portainer.extensions.registrymanagement')
       var v1 = manifests.v1;
       var v2 = manifests.v2;
 
+      if (v1.schemaVersion !== 1 || v2.schemaVersion !== 2) {
+        return null;
+      }
+
       var history = historyRawToParsed(v1.history);
       var imageId = history[0].id;
       var name = v1.tag;

--- a/app/extensions/registry-management/rest/manifest.js
+++ b/app/extensions/registry-management/rest/manifest.js
@@ -10,7 +10,9 @@ angular.module('portainer.extensions.registrymanagement')
         tag: '@tag'
       },
       headers: {
-        'Cache-Control': 'no-cache'
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': 0
       },
       transformResponse: function (data, headers) {
         var response = angular.fromJson(data);
@@ -27,7 +29,9 @@ angular.module('portainer.extensions.registrymanagement')
       },
       headers: {
         'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
-        'Cache-Control': 'no-cache'
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': 0
       },
       transformResponse: function (data, headers) {
         var response = angular.fromJson(data);

--- a/app/extensions/registry-management/services/registryAPIService.js
+++ b/app/extensions/registry-management/services/registryAPIService.js
@@ -85,7 +85,14 @@ function RegistryV2ServiceFactory($q, RegistryCatalog, RegistryTags, RegistryMan
     $q.all(promises)
     .then(function success(data) {
       var tag = RegistryV2Helper.manifestsToTag(data);
-      deferred.resolve(tag);
+      if (tag === null) {
+        deferred.reject({
+          msg: 'Unable to retrieve tags, refresh the page',
+          err: err
+        });
+      } else {
+        deferred.resolve(tag);
+      }
     }).catch(function error(err) {
       deferred.reject({
         msg: 'Unable to retrieve tag ' + tag,


### PR DESCRIPTION
Fix a bug where repository tags requests are retrieved from cache by browser and not passed to the registry API.