### PR TITLE
dep(bootstrap): update bootstrap version to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "angularjs-scroll-glue": "^2.2.0",
     "angularjs-slider": "^6.4.0",
     "bootbox": "^4.4.0",
-    "bootstrap": "~3.3.6",
+    "bootstrap": "^3.4.0",
     "chart.js": "~2.6.0",
     "codemirror": "~5.30.0",
     "filesize": "~3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,7 +139,6 @@ angular-mocks@~1.5.0:
 angular-moment-picker@^0.10.2:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/angular-moment-picker/-/angular-moment-picker-0.10.2.tgz#54c8b3c228b33dffa3b7b3d0773a585323815c33"
-  integrity sha512-WvmrQM0zEcFqi50yDELaF34Ilrx4PtL7mWLcpTZCJGQDvMlIsxJrB30LxOkoJv8yrrLxD2s6nnR3t1/SqioWWw==
   dependencies:
     angular "^1.3"
     moment "^2.16.0"
@@ -167,7 +166,6 @@ angular@1.x, angular@~1.5.0:
 angular@^1.3:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.5.tgz#d1c1c01c6f5dc835638f3f9aa51012857bdac49e"
-  integrity sha512-760183yxtGzni740IBTieNuWLtPNAoMqvmC0Z62UoU0I3nqk+VJuO3JbQAXOyvo3Oy/ZsdNQwrSTh/B0OQZjNw==
 
 angularjs-scroll-glue@^2.2.0:
   version "2.2.0"
@@ -407,9 +405,9 @@ bootbox@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/bootbox/-/bootbox-4.4.0.tgz#ff7f898fb87d4527e547feb64158f88450d1a0c9"
 
-bootstrap@~3.3.6:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+bootstrap@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
@@ -2921,7 +2919,6 @@ moment@^2.10.6:
 moment@^2.16.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 moment@^2.21.0:
   version "2.21.0"
@@ -4527,7 +4524,6 @@ xtend@~3.0.0:
 xterm@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.8.0.tgz#55d1de518bdc9c9793823f5e4e97d6898972938d"
-  integrity sha512-rS3HLryuMWbLsv98+jVVSUXCxmoyXPwqwJNC0ad0VSMdXgl65LefPztQVwfurkaF7kM7ZSgM8eJjnJ9kkdoR1w==
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Upgrades bootstrap version to 3.4.0 to fix a potential XSS attack.

Related links:

* https://snyk.io/vuln/npm:bootstrap:20160627
* https://github.com/twbs/bootstrap/issues/20184