### PR TITLE
fix2616: fix missing capabilities on duplicate 

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -493,6 +493,19 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
         $scope.formValues.capabilities.push(new ContainerCapability(cap, false));
       });
     }
+
+    function hasCapability(item) {
+      return item.capability === cap.capability;
+    }
+
+    var capabilities = new ContainerCapabilities();
+    for (var i = 0; i < capabilities.length; i++) {
+      var cap = capabilities[i];
+      if (!_.find($scope.formValues.capabilities, hasCapability)) {
+        $scope.formValues.capabilities.push(cap);
+      }
+    }
+
     $scope.formValues.capabilities.sort(function(a, b) {
       return a.capability < b.capability ? -1 : 1;
     });


### PR DESCRIPTION
Closes #2616 

Fix missing capabilities on duplicate for containers created ouside or before Portainer 1.19.2