### PR TITLE
auto select registry when selected an image

### DIFF
--- a/app/docker/components/imageRegistry/porImageRegistry.html
+++ b/app/docker/components/imageRegistry/porImageRegistry.html
@@ -2,7 +2,7 @@
   <label for="image_name" ng-class="$ctrl.labelClass" class="control-label text-left">Image</label>
   <div ng-class="$ctrl.inputClass">
     <input type="text" class="form-control" uib-typeahead="image for image in $ctrl.availableImages | filter:$viewValue | limitTo:5"
-      ng-model="$ctrl.image" name="image_name" placeholder="e.g. myImage:myTag" required>
+      ng-blur="$ctrl.imageChanged($ctrl.image)" ng-model="$ctrl.image" id="image_name" name="image_name" placeholder="e.g. myImage:myTag" required>
   </div>
   <label for="image_registry" class="margin-sm-top control-label text-right" ng-class="$ctrl.labelClass">
     Registry

--- a/app/docker/components/imageRegistry/porImageRegistryController.js
+++ b/app/docker/components/imageRegistry/porImageRegistryController.js
@@ -3,6 +3,22 @@ angular.module('portainer.docker')
 function ($q, RegistryService, DockerHubService, ImageService, Notifications) {
   var ctrl = this;
 
+  ctrl.imageChanged = function($value) {
+    if ($value === '') {
+      return;
+    }
+
+    ctrl.availableRegistries.filter(function(registry) {
+      var regex = new RegExp('^' + registry.URL + '\/(.*)$');
+      return (registry.URL !== '' && $value.match(regex));
+    }).map(function(registry) {
+      var regex = new RegExp('^' + registry.URL + '\/(.*)$');
+
+      ctrl.registry = registry;
+      ctrl.image = $value.replace(regex, '$1');
+    });
+  };
+
   function initComponent() {
     $q.all({
       registries: RegistryService.registries(),


### PR DESCRIPTION
When I selected an image from private registry, image text is  [registry url]/[image name]:[tag]
And then I change registry to private registry and deploy this container
But I got a error message because image was wrong(see screenshot)

So, I try to split and replace image text on input blur event when I selected an image
, and auto change registry field if the image text is match an available registry

![2019-01-19 13 19 20](https://user-images.githubusercontent.com/5763574/51422703-0a457000-1bee-11e9-8693-438112003cdd.png)
![2019-01-19 13 22 20](https://user-images.githubusercontent.com/5763574/51422736-e6365e80-1bee-11e9-88ed-0d46850bf779.png)
![2019-01-19 13 22 33](https://user-images.githubusercontent.com/5763574/51422737-eb93a900-1bee-11e9-9c9c-73f043326cc6.png)

