### PR TITLE
Container label value allow null

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -228,8 +228,13 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
   function prepareLabels(config) {
     var labels = {};
     $scope.formValues.Labels.forEach(function (label) {
-      if (label.name && label.value) {
-        labels[label.name] = label.value;
+      if (label.name) {
+        if (label.value) {
+            labels[label.name] = label.value;
+        }
+        else {
+            labels[label.name] = '';
+        }
       }
     });
     config.Labels = labels;

--- a/app/portainer/helpers/templateHelper.js
+++ b/app/portainer/helpers/templateHelper.js
@@ -50,8 +50,13 @@ angular.module('portainer.app')
   helper.updateContainerConfigurationWithLabels = function(labelsArray) {
     var labels = {};
     labelsArray.forEach(function (l) {
-      if (l.name && l.value) {
-        labels[l.name] = l.value;
+      if (l.name) {
+        if (l.value) {
+            labels[l.name] = l.value;
+        }
+        else {
+            labels[l.name] = '';
+        }
       }
     });
     return labels;


### PR DESCRIPTION
This small patch will allow empty values to be set on container labels during container creation or during App Template creation.

This addresses #2646

Currently the inspect does not retain empty values when re-creating containers or inspecting containers. Looks like ```api/http/proxy/response.go``` has ```extractJSONField``` and it's somehow eating empty labels. Not sure what to do with this last piece.