### PR TITLE
fix(api): re-use previous password when ldap settings update use empt…

### DIFF
--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -66,7 +66,12 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.LDAPSettings != nil {
+		ldapPassword := settings.LDAPSettings.Password
+		if payload.LDAPSettings.Password != "" {
+			ldapPassword = payload.LDAPSettings.Password
+		}
 		settings.LDAPSettings = *payload.LDAPSettings
+		settings.LDAPSettings.Password = ldapPassword
 	}
 
 	if payload.AllowBindMountsForRegularUsers != nil {


### PR DESCRIPTION
…y password

Fixes #2580 