### PR TITLE
2584 fix(endpoints): correct agent stack download url

### DIFF
--- a/app/portainer/views/endpoints/create/createEndpointController.js
+++ b/app/portainer/views/endpoints/create/createEndpointController.js
@@ -20,7 +20,7 @@ function ($q, $scope, $state, $filter, clipboard, EndpointService, GroupService,
   };
 
   $scope.copyAgentCommand = function() {
-    clipboard.copyText('curl -L https://downloads.portainer.io/portainer-agent-stack.yml -o portainer-agent-stack.yml&& docker stack deploy --compose-file=portainer-agent-stack.yml portainer-agent');
+    clipboard.copyText('curl -L https://downloads.portainer.io/agent-stack.yml -o agent-stack.yml && docker stack deploy --compose-file=agent-stack.yml portainer-agent');
     $('#copyNotification').show();
     $('#copyNotification').fadeOut(2000);
   };

--- a/app/portainer/views/endpoints/create/createEndpointController.js
+++ b/app/portainer/views/endpoints/create/createEndpointController.js
@@ -20,7 +20,7 @@ function ($q, $scope, $state, $filter, clipboard, EndpointService, GroupService,
   };
 
   $scope.copyAgentCommand = function() {
-    clipboard.copyText('curl -L https://portainer.io/download/agent-stack.yml -o agent-stack.yml && docker stack deploy --compose-file=agent-stack.yml portainer-agent');
+    clipboard.copyText('curl -L https://downloads.portainer.io/portainer-agent-stack.yml -o portainer-agent-stack.yml&& docker stack deploy --compose-file=portainer-agent-stack.yml portainer-agent');
     $('#copyNotification').show();
     $('#copyNotification').fadeOut(2000);
   };


### PR DESCRIPTION
The directions for installing the agent stack from the endpoints view used an old url. Update to the new url.

Fixes https://github.com/portainer/portainer/issues/2584