### PR TITLE
fix(networks): disable removing predefined networks (#1838)

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -20,4 +20,5 @@ angular.module('portainer')
 .constant('DEFAULT_TEMPLATES_URL', 'https://raw.githubusercontent.com/portainer/templates/master/templates.json')
 .constant('PAGINATION_MAX_ITEMS', 10)
 .constant('APPLICATION_CACHE_VALIDITY', 3600)
-.constant('CONSOLE_COMMANDS_LABEL_PREFIX', 'io.portainer.commands.');
+.constant('CONSOLE_COMMANDS_LABEL_PREFIX', 'io.portainer.commands.')
+.constant('PREDEFINED_NETWORKS', ['host', 'bridge', 'none']);

--- a/app/docker/components/datatables/networks-datatable/networksDatatable.html
+++ b/app/docker/components/datatables/networks-datatable/networksDatatable.html
@@ -110,7 +110,7 @@
             <tr dir-paginate="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit))" ng-class="{active: item.Checked}">
               <td>
                 <span class="md-checkbox" ng-if="!$ctrl.offlineMode">
-                  <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)"/>
+                  <input id="select_{{ $index }}" type="checkbox" ng-model="item.Checked" ng-change="$ctrl.selectItem(item)" ng-disabled="$ctrl.disableRemove(item)"/>
                   <label for="select_{{ $index }}"></label>
                 </span>
                 <a ng-if="!$ctrl.offlineMode" ui-sref="docker.networks.network({ id: item.Id, nodeName: item.NodeName })" title="{{ item.Name }}">{{ item.Name | truncate:40 }}</a>

--- a/app/docker/components/datatables/networks-datatable/networksDatatable.js
+++ b/app/docker/components/datatables/networks-datatable/networksDatatable.js
@@ -1,6 +1,6 @@
 angular.module('portainer.docker').component('networksDatatable', {
   templateUrl: 'app/docker/components/datatables/networks-datatable/networksDatatable.html',
-  controller: 'GenericDatatableController',
+  controller: 'NetworksDatatableController',
   bindings: {
     titleText: '@',
     titleIcon: '@',

--- a/app/docker/components/datatables/networks-datatable/networksDatatableController.js
+++ b/app/docker/components/datatables/networks-datatable/networksDatatableController.js
@@ -8,5 +8,15 @@ angular.module('portainer.docker')
       this.disableRemove = function(item) {
         return PREDEFINED_NETWORKS.includes(item.Name);
       };
+
+      this.selectAll = function() {
+        for (var i = 0; i < this.state.filteredDataSet.length; i++) {
+          var item = this.state.filteredDataSet[i];
+          if (!this.disableRemove(item) && item.Checked !== this.state.selectAll) {
+            item.Checked = this.state.selectAll;
+            this.selectItem(item);
+          }
+        }
+      };
   }
 ]);

--- a/app/docker/components/datatables/networks-datatable/networksDatatableController.js
+++ b/app/docker/components/datatables/networks-datatable/networksDatatableController.js
@@ -1,0 +1,12 @@
+angular.module('portainer.docker')
+  .controller('NetworksDatatableController', ['$scope', '$controller',
+    function ($scope, $controller) {
+      angular.extend(this, $controller('GenericDatatableController', {$scope: $scope}));
+
+      var PREDEFINED_NETWORKS = ['host', 'bridge', 'none'];
+
+      this.disableRemove = function(item) {
+        return PREDEFINED_NETWORKS.includes(item.Name);
+      };
+  }
+]);

--- a/app/docker/components/datatables/networks-datatable/networksDatatableController.js
+++ b/app/docker/components/datatables/networks-datatable/networksDatatableController.js
@@ -1,9 +1,7 @@
 angular.module('portainer.docker')
-  .controller('NetworksDatatableController', ['$scope', '$controller',
-    function ($scope, $controller) {
+  .controller('NetworksDatatableController', ['$scope', '$controller', 'PREDEFINED_NETWORKS',
+    function ($scope, $controller, PREDEFINED_NETWORKS) {
       angular.extend(this, $controller('GenericDatatableController', {$scope: $scope}));
-
-      var PREDEFINED_NETWORKS = ['host', 'bridge', 'none'];
 
       this.disableRemove = function(item) {
         return PREDEFINED_NETWORKS.includes(item.Name);

--- a/app/docker/views/networks/edit/network.html
+++ b/app/docker/views/networks/edit/network.html
@@ -20,7 +20,7 @@
               <td>ID</td>
               <td>
                 {{ network.Id }}
-                <button class="btn btn-xs btn-danger" ng-click="removeNetwork(network.Id)"><i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Delete this network</button>
+                <button ng-if="allowRemove(network)" class="btn btn-xs btn-danger" ng-click="removeNetwork(network.Id)"><i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Delete this network</button>
               </td>
             </tr>
             <tr>

--- a/app/docker/views/networks/edit/networkController.js
+++ b/app/docker/views/networks/edit/networkController.js
@@ -1,6 +1,6 @@
 angular.module('portainer.docker')
-.controller('NetworkController', ['$scope', '$state', '$transition$', '$filter', 'NetworkService', 'Container', 'Notifications', 'HttpRequestHelper',
-function ($scope, $state, $transition$, $filter, NetworkService, Container, Notifications, HttpRequestHelper) {
+.controller('NetworkController', ['$scope', '$state', '$transition$', '$filter', 'NetworkService', 'Container', 'Notifications', 'HttpRequestHelper', 'PREDEFINED_NETWORKS',
+function ($scope, $state, $transition$, $filter, NetworkService, Container, Notifications, HttpRequestHelper, PREDEFINED_NETWORKS) {
 
   $scope.removeNetwork = function removeNetwork() {
     NetworkService.remove($transition$.params().id, $transition$.params().id)
@@ -23,6 +23,10 @@ function ($scope, $state, $transition$, $filter, NetworkService, Container, Noti
     .catch(function error(err) {
       Notifications.error('Failure', err, 'Unable to disconnect container from network');
     });
+  };
+
+  $scope.allowRemove = function allowRemove(item) {
+    return !PREDEFINED_NETWORKS.includes(item.Name);
   };
 
   function filterContainersInNetwork(network, containers) {


### PR DESCRIPTION
This adds a disabled property based on the name of the network since there is no other way to distinguish between a user-created-network or predefined-network. This fixes #1838.

![screenshot 2019-02-08 at 14 00 07](https://user-images.githubusercontent.com/951290/52480119-18622d00-2bab-11e9-836a-e5999fdf6242.png)
