### PR TITLE
fix(auth): Do not double redirect to portainer.auth

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -44,7 +44,7 @@ function initAuthentication(authManager, Authentication, $rootScope, $state) {
   // authManager.redirectWhenUnauthenticated() + unauthenticatedRedirector
   // to have more controls on which URL should trigger the unauthenticated state.
   $rootScope.$on('unauthenticated', function (event, data) {
-    if (!_.includes(data.config.url, '/v2/')) {
+    if (!_.includes(data.config.url, '/v2/') && ($state.current.name !== 'portainer.auth')) {
       $state.go('portainer.auth', {error: 'Your session has expired', redirect: $state.current.name});
     }
   });


### PR DESCRIPTION
Fix #2700 