### PR TITLE
fix: remove default protocol from published ports

### DIFF
--- a/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.html
+++ b/app/azure/components/datatables/containergroups-datatable/containerGroupsDatatable.html
@@ -57,7 +57,7 @@
               </td>
               <td>{{ item.Location }}</td>
               <td>
-                <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="http://{{ item.IPAddress }}:{{ p.port }}" target="_blank">
+                <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="{{ item.IPAddress }}:{{ p.port }}" target="_blank">
                   <i class="fa fa-external-link-alt" aria-hidden="true"></i> :{{ p.port }}
                 </a>
                 <span ng-if="item.Ports.length == 0" >-</span>

--- a/app/docker/components/datatables/containers-datatable/containersDatatable.html
+++ b/app/docker/components/datatables/containers-datatable/containersDatatable.html
@@ -237,7 +237,7 @@
               <td ng-show="$ctrl.columnVisibility.columns.ip.display">{{ item.IP ? item.IP : '-' }}</td>
               <td ng-if="$ctrl.showHostColumn" ng-show="$ctrl.columnVisibility.columns.host.display">{{ item.NodeName ? item.NodeName : '-' }}</td>
               <td ng-show="$ctrl.columnVisibility.columns.ports.display">
-                <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="http://{{ $ctrl.state.publicURL || p.host }}:{{p.public}}" target="_blank">
+                <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="{{ $ctrl.state.publicURL || p.host }}:{{p.public}}" target="_blank">
                   <i class="fa fa-external-link-alt" aria-hidden="true"></i> {{ p.public }}:{{ p.private }}
                 </a>
                 <span ng-if="item.Ports.length == 0" >-</span>

--- a/app/docker/components/datatables/services-datatable/servicesDatatable.html
+++ b/app/docker/components/datatables/services-datatable/servicesDatatable.html
@@ -109,7 +109,7 @@
                 </span>
               </td>
               <td>
-                <a ng-if="item.Ports && item.Ports.length > 0 && p.PublishedPort" ng-repeat="p in item.Ports" class="image-tag" ng-href="http://{{ $ctrl.state.publicURL }}:{{ p.PublishedPort }}" target="_blank" ng-click="$event.stopPropagation();">
+                <a ng-if="item.Ports && item.Ports.length > 0 && p.PublishedPort" ng-repeat="p in item.Ports" class="image-tag" ng-href="{{ $ctrl.state.publicURL }}:{{ p.PublishedPort }}" target="_blank" ng-click="$event.stopPropagation();">
                   <i class="fa fa-external-link-alt" aria-hidden="true"></i> {{ p.PublishedPort }}:{{ p.TargetPort }}
                 </a>
                 <span ng-if="!item.Ports || item.Ports.length === 0">-</span>


### PR DESCRIPTION
Hi,

if you assign a domain or something to a certain container, under published ports column, you start to see it like this:

```html
<td ng-show="$ctrl.columnVisibility.columns.ports.display">
    <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="http://https://example.com:443" target="_blank" href="http://https://example.com:443">
        <i class="fa fa-external-link-alt" aria-hidden="true"></i> 443:443
    </a>
    <a ng-if="item.Ports.length > 0" ng-repeat="p in item.Ports" class="image-tag" ng-href="http://https://example.com:80" target="_blank" href="http://https://example.com:80">
        <i class="fa fa-external-link-alt" aria-hidden="true"></i> 80:80
    </a>
</td>
```

I, personally, think it doesn't matter if there's a default protocol or not. Browser will redirect them to their correct places anyway when you click those link(s). 

I hope you'll find this useful.

Best,
G.

Fix #2721 