### PR TITLE
style(main): fix spelling of endointSyncSchedule

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -175,7 +175,7 @@ func loadEndpointSyncSystemSchedule(jobScheduler portainer.JobScheduler, schedul
 
 	endpointSyncJob := &portainer.EndpointSyncJob{}
 
-	endointSyncSchedule := &portainer.Schedule{
+	endpointSyncSchedule := &portainer.Schedule{
 		ID:              portainer.ScheduleID(scheduleService.GetNextIdentifier()),
 		Name:            "system_endpointsync",
 		CronExpression:  "@every " + *flags.SyncInterval,
@@ -186,14 +186,14 @@ func loadEndpointSyncSystemSchedule(jobScheduler portainer.JobScheduler, schedul
 	}
 
 	endpointSyncJobContext := cron.NewEndpointSyncJobContext(endpointService, *flags.ExternalEndpoints)
-	endpointSyncJobRunner := cron.NewEndpointSyncJobRunner(endointSyncSchedule, endpointSyncJobContext)
+	endpointSyncJobRunner := cron.NewEndpointSyncJobRunner(endpointSyncSchedule, endpointSyncJobContext)
 
 	err = jobScheduler.ScheduleJob(endpointSyncJobRunner)
 	if err != nil {
 		return err
 	}
 
-	return scheduleService.CreateSchedule(endointSyncSchedule)
+	return scheduleService.CreateSchedule(endpointSyncSchedule)
 }
 
 func loadSchedulesFromDatabase(jobScheduler portainer.JobScheduler, jobService portainer.JobService, scheduleService portainer.ScheduleService, endpointService portainer.EndpointService, fileService portainer.FileService) error {


### PR DESCRIPTION
Just a trivial speling mistake.