### PR TITLE
Feature #2403: External registries

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -218,11 +218,12 @@ func loadSchedulesFromDatabase(jobScheduler portainer.JobScheduler, jobService p
 	return nil
 }
 
-func initStatus(endpointManagement, snapshot bool, flags *portainer.CLIFlags) *portainer.Status {
+func initStatus(endpointManagement, registryManagement, snapshot bool, flags *portainer.CLIFlags) *portainer.Status {
 	return &portainer.Status{
 		Analytics:          !*flags.NoAnalytics,
 		Authentication:     !*flags.NoAuth,
 		EndpointManagement: endpointManagement,
+		RegistryManagement: registryManagement,
 		Snapshot:           snapshot,
 		Version:            portainer.APIVersion,
 	}
@@ -550,6 +551,11 @@ func main() {
 		endpointManagement = false
 	}
 
+	registryManagement := true
+	if *flags.ExternalRegistries != "" {
+		registryManagement = false
+	}
+
 	swarmStackManager, err := initSwarmStackManager(*flags.Assets, *flags.Data, digitalSignatureService, fileService)
 	if err != nil {
 		log.Fatal(err)
@@ -593,7 +599,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	applicationStatus := initStatus(endpointManagement, *flags.Snapshot, flags)
+	applicationStatus := initStatus(endpointManagement, registryManagement, *flags.Snapshot, flags)
 
 	err = initEndpoint(flags, store.EndpointService, snapshotter)
 	if err != nil {
@@ -646,6 +652,7 @@ func main() {
 		AssetsPath:             *flags.Assets,
 		AuthDisabled:           *flags.NoAuth,
 		EndpointManagement:     endpointManagement,
+		RegistryManagement:     registryManagement,
 		UserService:            store.UserService,
 		TeamService:            store.TeamService,
 		TeamMembershipService:  store.TeamMembershipService,

--- a/api/cron/job_endpoint_sync.go
+++ b/api/cron/job_endpoint_sync.go
@@ -37,7 +37,7 @@ func NewEndpointSyncJobRunner(schedule *portainer.Schedule, context *EndpointSyn
 	}
 }
 
-type synchronization struct {
+type endpointSynchronization struct {
 	endpointsToCreate []*portainer.Endpoint
 	endpointsToUpdate []*portainer.Endpoint
 	endpointsToDelete []*portainer.Endpoint
@@ -83,7 +83,7 @@ func (runner *EndpointSyncJobRunner) Run() {
 
 	convertedFileEndpoints := convertFileEndpoints(fileEndpoints)
 
-	sync := prepareSyncData(storedEndpoints, convertedFileEndpoints)
+	sync := prepareEndpointSyncData(storedEndpoints, convertedFileEndpoints)
 	if sync.requireSync() {
 		err = runner.context.endpointService.Synchronize(sync.endpointsToCreate, sync.endpointsToUpdate, sync.endpointsToDelete)
 		if endpointSyncError(err) {
@@ -168,14 +168,14 @@ func mergeEndpointIfRequired(original, updated *portainer.Endpoint) *portainer.E
 	return endpoint
 }
 
-func (sync synchronization) requireSync() bool {
+func (sync endpointSynchronization) requireSync() bool {
 	if len(sync.endpointsToCreate) != 0 || len(sync.endpointsToUpdate) != 0 || len(sync.endpointsToDelete) != 0 {
 		return true
 	}
 	return false
 }
 
-func prepareSyncData(storedEndpoints, fileEndpoints []portainer.Endpoint) *synchronization {
+func prepareEndpointSyncData(storedEndpoints, fileEndpoints []portainer.Endpoint) *endpointSynchronization {
 	endpointsToCreate := make([]*portainer.Endpoint, 0)
 	endpointsToUpdate := make([]*portainer.Endpoint, 0)
 	endpointsToDelete := make([]*portainer.Endpoint, 0)
@@ -206,7 +206,7 @@ func prepareSyncData(storedEndpoints, fileEndpoints []portainer.Endpoint) *synch
 		}
 	}
 
-	return &synchronization{
+	return &endpointSynchronization{
 		endpointsToCreate: endpointsToCreate,
 		endpointsToUpdate: endpointsToUpdate,
 		endpointsToDelete: endpointsToDelete,

--- a/api/cron/job_registry_sync.go
+++ b/api/cron/job_registry_sync.go
@@ -1,0 +1,193 @@
+package cron
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	"github.com/portainer/portainer"
+)
+
+// RegistrySyncJobRunner is used to run a RegistrySyncJob
+type RegistrySyncJobRunner struct {
+	schedule *portainer.Schedule
+	context  *RegistrySyncJobContext
+}
+
+// RegistrySyncJobContext represents the context of execution of a RegistrySyncJob
+type RegistrySyncJobContext struct {
+	registryService  portainer.RegistryService
+	registryFilePath string
+}
+
+// NewRegistrySyncJobContext returns a new context that can be used to execute a RegistrySyncJob
+func NewRegistrySyncJobContext(registryService portainer.RegistryService, registryFilePath string) *RegistrySyncJobContext {
+	return &RegistrySyncJobContext{
+		registryService:  registryService,
+		registryFilePath: registryFilePath,
+	}
+}
+
+// NewRegistrySyncJobRunner returns a new runner that can be scheduled
+func NewRegistrySyncJobRunner(schedule *portainer.Schedule, context *RegistrySyncJobContext) *RegistrySyncJobRunner {
+	return &RegistrySyncJobRunner{
+		schedule: schedule,
+		context:  context,
+	}
+}
+
+type registrySynchronization struct {
+	registrysToCreate []*portainer.Registry
+	registrysToUpdate []*portainer.Registry
+	registrysToDelete []*portainer.Registry
+}
+
+type fileRegistry struct {
+	Type     string `json:"Type"`
+	Name     string `json:"Name"`
+	URL      string `json:"URL"`
+	Username string `json:"Username,omitempty"`
+	Password string `json:"Password,omitempty"`
+}
+
+// GetSchedule returns the schedule associated to the runner
+func (runner *RegistrySyncJobRunner) GetSchedule() *portainer.Schedule {
+	return runner.schedule
+}
+
+// Run triggers the execution of the registry synchronization process.
+func (runner *RegistrySyncJobRunner) Run() {
+	log.Printf("Registry sync")
+
+	data, err := ioutil.ReadFile(runner.context.registryFilePath)
+	if registrySyncError(err) {
+		return
+	}
+
+	var fileRegistrys []fileRegistry
+	err = json.Unmarshal(data, &fileRegistrys)
+	if registrySyncError(err) {
+		return
+	}
+
+	if len(fileRegistrys) == 0 {
+		log.Println("background job error (registry synchronization). External registry source is empty")
+		return
+	}
+
+	storedRegistrys, err := runner.context.registryService.Registries()
+	if registrySyncError(err) {
+		return
+	}
+
+	convertedFileRegistrys := convertFileRegistrys(fileRegistrys)
+
+	sync := prepareRegistrySyncData(storedRegistrys, convertedFileRegistrys)
+	if sync.requireSync() {
+		err = runner.context.registryService.Synchronize(sync.registrysToCreate, sync.registrysToUpdate, sync.registrysToDelete)
+		if registrySyncError(err) {
+			return
+		}
+		log.Printf("Registry synchronization ended. [created: %v] [updated: %v] [deleted: %v]", len(sync.registrysToCreate), len(sync.registrysToUpdate), len(sync.registrysToDelete))
+	}
+}
+
+func registrySyncError(err error) bool {
+	if err != nil {
+		log.Printf("background job error (registry synchronization). Unable to synchronize registrys (err=%s)\n", err)
+		return true
+	}
+	return false
+}
+
+func isValidRegistry(registry *portainer.Registry) bool {
+	if registry.Name != "" && registry.URL != "" {
+		return true
+	}
+	return false
+}
+
+func convertFileRegistrys(fileRegistrys []fileRegistry) []portainer.Registry {
+	convertedRegistrys := make([]portainer.Registry, 0)
+
+	for _, e := range fileRegistrys {
+		registry := portainer.Registry{
+			Type:     portainer.CustomRegistry,
+			Name:     e.Name,
+			URL:      e.URL,
+			Username: e.Username,
+			Password: e.Password,
+		}
+		registry.Authentication = registry.Username != ""
+		convertedRegistrys = append(convertedRegistrys, registry)
+	}
+
+	return convertedRegistrys
+}
+
+func registryExists(registry *portainer.Registry, registrys []portainer.Registry) int {
+	for idx, v := range registrys {
+		if registry.Name == v.Name && isValidRegistry(&v) {
+			return idx
+		}
+	}
+	return -1
+}
+
+func mergeRegistryIfRequired(original, updated *portainer.Registry) *portainer.Registry {
+	var registry *portainer.Registry
+	if original.URL != updated.URL || original.Username != updated.Username ||
+		updated.Password != original.Password || original.Authentication != updated.Authentication {
+		registry = original
+		registry.URL = updated.URL
+		registry.Username = updated.Username
+		registry.Password = updated.Password
+		registry.Authentication = updated.Authentication
+	}
+	return registry
+}
+
+func (sync registrySynchronization) requireSync() bool {
+	if len(sync.registrysToCreate) != 0 || len(sync.registrysToUpdate) != 0 || len(sync.registrysToDelete) != 0 {
+		return true
+	}
+	return false
+}
+
+func prepareRegistrySyncData(storedRegistrys, fileRegistrys []portainer.Registry) *registrySynchronization {
+	registrysToCreate := make([]*portainer.Registry, 0)
+	registrysToUpdate := make([]*portainer.Registry, 0)
+	registrysToDelete := make([]*portainer.Registry, 0)
+
+	for idx := range storedRegistrys {
+		fidx := registryExists(&storedRegistrys[idx], fileRegistrys)
+		if fidx != -1 {
+			registry := mergeRegistryIfRequired(&storedRegistrys[idx], &fileRegistrys[fidx])
+			if registry != nil {
+				log.Printf("New definition for a stored registry found in file, updating database. [name: %v] [url: %v]\n", registry.Name, registry.URL)
+				registrysToUpdate = append(registrysToUpdate, registry)
+			}
+		} else {
+			log.Printf("Stored registry not found in file (definition might be invalid), removing from database. [name: %v] [url: %v]", storedRegistrys[idx].Name, storedRegistrys[idx].URL)
+			registrysToDelete = append(registrysToDelete, &storedRegistrys[idx])
+		}
+	}
+
+	for idx, registry := range fileRegistrys {
+		if !isValidRegistry(&registry) {
+			log.Printf("Invalid file registry definition, skipping. [name: %v] [url: %v]", registry.Name, registry.URL)
+			continue
+		}
+		sidx := registryExists(&fileRegistrys[idx], storedRegistrys)
+		if sidx == -1 {
+			log.Printf("File registry not found in database, adding to database. [name: %v] [url: %v]", fileRegistrys[idx].Name, fileRegistrys[idx].URL)
+			registrysToCreate = append(registrysToCreate, &fileRegistrys[idx])
+		}
+	}
+
+	return &registrySynchronization{
+		registrysToCreate: registrysToCreate,
+		registrysToUpdate: registrysToUpdate,
+		registrysToDelete: registrysToDelete,
+	}
+}

--- a/api/http/handler/registries/handler.go
+++ b/api/http/handler/registries/handler.go
@@ -18,16 +18,18 @@ func hideFields(registry *portainer.Registry) {
 // Handler is the HTTP handler used to handle registry operations.
 type Handler struct {
 	*mux.Router
-	RegistryService  portainer.RegistryService
-	ExtensionService portainer.ExtensionService
-	FileService      portainer.FileService
-	ProxyManager     *proxy.Manager
+	authorizeRegistryManagement bool
+	RegistryService             portainer.RegistryService
+	ExtensionService            portainer.ExtensionService
+	FileService                 portainer.FileService
+	ProxyManager                *proxy.Manager
 }
 
 // NewHandler creates a handler to manage registry operations.
-func NewHandler(bouncer *security.RequestBouncer) *Handler {
+func NewHandler(bouncer *security.RequestBouncer, authorizeRegistryManagement bool) *Handler {
 	h := &Handler{
 		Router: mux.NewRouter(),
+		authorizeRegistryManagement: authorizeRegistryManagement,
 	}
 
 	h.Handle("/registries",

--- a/api/http/handler/registries/registry_configure.go
+++ b/api/http/handler/registries/registry_configure.go
@@ -67,6 +67,10 @@ func (payload *registryConfigurePayload) Validate(r *http.Request) error {
 
 // POST request on /api/registries/:id/configure
 func (handler *Handler) registryConfigure(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !handler.authorizeRegistryManagement {
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Registry management is disabled", ErrRegistryManagementDisabled}
+	}
+
 	registryID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid registry identifier route variable", err}

--- a/api/http/handler/registries/registry_create.go
+++ b/api/http/handler/registries/registry_create.go
@@ -10,6 +10,12 @@ import (
 	"github.com/portainer/portainer"
 )
 
+const (
+	// ErrRegistryManagementDisabled is an error raised when trying to access the registry management endpoints
+	// when the server has been started with the --external-registries flag
+	ErrRegistryManagementDisabled = portainer.Error("Registry management is disabled")
+)
+
 type registryCreatePayload struct {
 	Name           string
 	Type           int
@@ -36,6 +42,10 @@ func (payload *registryCreatePayload) Validate(r *http.Request) error {
 }
 
 func (handler *Handler) registryCreate(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !handler.authorizeRegistryManagement {
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Registry management is disabled", ErrRegistryManagementDisabled}
+	}
+
 	var payload registryCreatePayload
 	err := request.DecodeAndValidateJSONPayload(r, &payload)
 	if err != nil {

--- a/api/http/handler/registries/registry_delete.go
+++ b/api/http/handler/registries/registry_delete.go
@@ -11,6 +11,10 @@ import (
 
 // DELETE request on /api/registries/:id
 func (handler *Handler) registryDelete(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !handler.authorizeRegistryManagement {
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Registry management is disabled", ErrRegistryManagementDisabled}
+	}
+
 	registryID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid registry identifier route variable", err}

--- a/api/http/handler/registries/registry_update.go
+++ b/api/http/handler/registries/registry_update.go
@@ -27,6 +27,10 @@ func (payload *registryUpdatePayload) Validate(r *http.Request) error {
 
 // PUT request on /api/registries/:id
 func (handler *Handler) registryUpdate(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !handler.authorizeRegistryManagement {
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Registry management is disabled", ErrRegistryManagementDisabled}
+	}
+
 	registryID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid registry identifier route variable", err}

--- a/api/http/handler/registries/registry_update_access.go
+++ b/api/http/handler/registries/registry_update_access.go
@@ -20,6 +20,10 @@ func (payload *registryUpdateAccessPayload) Validate(r *http.Request) error {
 
 // PUT request on /api/registries/:id/access
 func (handler *Handler) registryUpdateAccess(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !handler.authorizeRegistryManagement {
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Registry management is disabled", ErrRegistryManagementDisabled}
+	}
+
 	registryID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid registry identifier route variable", err}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -41,6 +41,7 @@ type Server struct {
 	AssetsPath             string
 	AuthDisabled           bool
 	EndpointManagement     bool
+	RegistryManagement     bool
 	Status                 *portainer.Status
 	ExtensionManager       portainer.ExtensionManager
 	ComposeStackManager    portainer.ComposeStackManager

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -136,7 +136,7 @@ func (server *Server) Start() error {
 	extensionHandler.ExtensionService = server.ExtensionService
 	extensionHandler.ExtensionManager = server.ExtensionManager
 
-	var registryHandler = registries.NewHandler(requestBouncer)
+	var registryHandler = registries.NewHandler(requestBouncer, server.RegistryManagement)
 	registryHandler.RegistryService = server.RegistryService
 	registryHandler.ExtensionService = server.ExtensionService
 	registryHandler.FileService = server.FileService

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -9,36 +9,38 @@ type (
 
 	// CLIFlags represents the available flags on the CLI
 	CLIFlags struct {
-		Addr              *string
-		AdminPassword     *string
-		AdminPasswordFile *string
-		Assets            *string
-		Data              *string
-		EndpointURL       *string
-		ExternalEndpoints *string
-		Labels            *[]Pair
-		Logo              *string
-		NoAuth            *bool
-		NoAnalytics       *bool
-		Templates         *string
-		TemplateFile      *string
-		TLS               *bool
-		TLSSkipVerify     *bool
-		TLSCacert         *string
-		TLSCert           *string
-		TLSKey            *string
-		SSL               *bool
-		SSLCert           *string
-		SSLKey            *string
-		SyncInterval      *string
-		Snapshot          *bool
-		SnapshotInterval  *string
+		Addr               *string
+		AdminPassword      *string
+		AdminPasswordFile  *string
+		Assets             *string
+		Data               *string
+		EndpointURL        *string
+		ExternalEndpoints  *string
+		ExternalRegistries *string
+		Labels             *[]Pair
+		Logo               *string
+		NoAuth             *bool
+		NoAnalytics        *bool
+		Templates          *string
+		TemplateFile       *string
+		TLS                *bool
+		TLSSkipVerify      *bool
+		TLSCacert          *string
+		TLSCert            *string
+		TLSKey             *string
+		SSL                *bool
+		SSLCert            *string
+		SSLKey             *string
+		SyncInterval       *string
+		Snapshot           *bool
+		SnapshotInterval   *string
 	}
 
 	// Status represents the application status
 	Status struct {
 		Authentication     bool   `json:"Authentication"`
 		EndpointManagement bool   `json:"EndpointManagement"`
+		RegistryManagement bool   `json:"RegistryManagement"`
 		Snapshot           bool   `json:"Snapshot"`
 		Analytics          bool   `json:"Analytics"`
 		Version            string `json:"Version"`

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -588,6 +588,7 @@ type (
 		CreateRegistry(registry *Registry) error
 		UpdateRegistry(ID RegistryID, registry *Registry) error
 		DeleteRegistry(ID RegistryID) error
+		Synchronize(toCreate, toUpdate, toDelete []*Registry) error
 	}
 
 	// StackService represents a service for managing stack data

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -259,6 +259,8 @@ type (
 	// EndpointSyncJob represents a scheduled job that synchronize endpoints based on an external file
 	EndpointSyncJob struct{}
 
+	// RegistrySyncJob represents a scheduled job that synchronizes registries based on an external file
+	RegistrySyncJob struct{}
 	// Schedule represents a scheduled job.
 	// It only contains a pointer to one of the JobRunner implementations
 	// based on the JobType.
@@ -273,6 +275,7 @@ type (
 		ScriptExecutionJob *ScriptExecutionJob
 		SnapshotJob        *SnapshotJob
 		EndpointSyncJob    *EndpointSyncJob
+		RegistrySyncJob    *RegistrySyncJob
 	}
 
 	// WebhookID represents a webhook identifier.
@@ -927,6 +930,9 @@ const (
 	// EndpointSyncJobType is a system job used to synchronize endpoints from
 	// an external definition store
 	EndpointSyncJobType
+	// RegistrySyncJobType is a system job used to synchronize registries from
+	// an external definition store
+	RegistrySyncJobType
 )
 
 const (

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -256,7 +256,7 @@ type (
 	// SnapshotJob represents a scheduled job that can create endpoint snapshots
 	SnapshotJob struct{}
 
-	// EndpointSyncJob represents a scheduled job that synchronize endpoints based on an external file
+	// EndpointSyncJob represents a scheduled job that synchronizes endpoints based on an external file
 	EndpointSyncJob struct{}
 
 	// RegistrySyncJob represents a scheduled job that synchronizes registries based on an external file


### PR DESCRIPTION
As suggested in #2403, this adds an --external-registries option for specifying zero or more registries in an external file. Basically the same code as for --external-endpoints.