### PR TITLE
docs(README): update logo src

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-  <img title="portainer" src='https://portainer.io/images/logo_alt.png' />
+  <img title="portainer" src='https://github.com/portainer/portainer/blob/develop/assets/images/logo_alt.png?raw=true' />
 </p>
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/portainer/portainer.svg)](https://hub.docker.com/r/portainer/portainer/)


### PR DESCRIPTION
The current logo src is 404: https://portainer.io/images/logo_alt.png

<img width="1044" alt="screen shot 2019-02-17 at 13 59 27" src="https://user-images.githubusercontent.com/24260/52909521-4dadff80-32bc-11e9-98af-a5df83b8cd2b.png">

The repo already includes the logo: https://github.com/portainer/portainer/blob/develop/assets/images/logo_alt.png?raw=true