### PR TITLE
fix(build-system): Install docker binary when on macOS

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -305,7 +305,7 @@ function shell_downloadDockerBinary(p, a) {
   var ip = ((ps[p] === undefined) ? p : ps[p]);
   var ia = ((as[a] === undefined) ? a : as[a]);
   var binaryVersion = ((p === 'windows' ? '<%= shippedDockerVersionWindows %>' : '<%= shippedDockerVersion %>'));
-  if (p === 'linux') {
+  if (p === 'linux' || p === 'mac') {
     return [
       'if [ -f dist/docker ]; then',
       'echo "Docker binary exists";',


### PR DESCRIPTION
Install docker binary when on macOS based system.
fix #2774 