### PR TITLE
fix(swarmvisualizer): nodes are now sorted by roles then by hostname

### DIFF
--- a/app/docker/views/swarm/visualizer/swarmvisualizer.html
+++ b/app/docker/views/swarm/visualizer/swarmvisualizer.html
@@ -80,7 +80,7 @@
       <rd-widget-header icon="fa-object-group" title-text="Cluster visualizer"></rd-widget-header>
       <rd-widget-body>
         <div class="visualizer_container">
-          <div class="node" ng-repeat="node in visualizerData.nodes track by $index">
+          <div class="node" ng-repeat="node in visualizerData.nodes | orderBy : ['Role', 'Hostname'] track by $index">
             <div class="node_info">
               <div>
                 <div>


### PR DESCRIPTION
Closes https://github.com/portainer/portainer/issues/2862