### PR TITLE
feat(containers): hide the attach quick action by default

### DIFF
--- a/app/docker/components/container-quick-actions/containerQuickActions.html
+++ b/app/docker/components/container-quick-actions/containerQuickActions.html
@@ -41,7 +41,7 @@
   </a>
   <a
     authorization="DockerExecStart"
-    ng-if="$ctrl.state.showQuickActionConsole && ['starting', 'running', 'healthy', 'unhealthy'].indexOf($ctrl.status) !== -1 && $ctrl.taskId === undefined"
+    ng-if="$ctrl.state.showQuickActionExec && ['starting', 'running', 'healthy', 'unhealthy'].indexOf($ctrl.status) !== -1 && $ctrl.taskId === undefined"
     style="margin: 0 2.5px;"
     ui-sref="docker.containers.container.exec({id: $ctrl.containerId, nodeName: $ctrl.nodeName})"
     title="Exec Console">
@@ -49,7 +49,7 @@
   </a>
   <a
     authorization="DockerContainerAttach"
-    ng-if="$ctrl.state.showQuickActionConsole && ['starting', 'running', 'healthy', 'unhealthy'].indexOf($ctrl.status) !== -1 && $ctrl.taskId === undefined"
+    ng-if="$ctrl.state.showQuickActionAttach && ['starting', 'running', 'healthy', 'unhealthy'].indexOf($ctrl.status) !== -1 && $ctrl.taskId === undefined"
     style="margin: 0 2.5px;"
     ui-sref="docker.containers.container.attach({id: $ctrl.containerId, nodeName: $ctrl.nodeName})"
     title="Attach Console">

--- a/app/docker/components/datatables/containers-datatable/containersDatatable.html
+++ b/app/docker/components/datatables/containers-datatable/containersDatatable.html
@@ -84,12 +84,16 @@
                       <label for="setting_show_logs">Logs</label>
                     </div>
                     <div class="md-checkbox" authorization="DockerExecStart">
-                      <input id="setting_show_console" type="checkbox" ng-model="$ctrl.settings.showQuickActionConsole" ng-change="$ctrl.onSettingsQuickActionChange()"/>
+                      <input id="setting_show_console" type="checkbox" ng-model="$ctrl.settings.showQuickActionExec" ng-change="$ctrl.onSettingsQuickActionChange()"/>
                       <label for="setting_show_console">Console</label>
                     </div>
                     <div class="md-checkbox" authorization="DockerContainerInspect">
                       <input id="setting_show_inspect" type="checkbox" ng-model="$ctrl.settings.showQuickActionInspect" ng-change="$ctrl.onSettingsQuickActionChange()"/>
                       <label for="setting_show_inspect">Inspect</label>
+                    </div>
+                    <div class="md-checkbox" authorization="DockerContainerAttach">
+                      <input id="setting_show_attach" type="checkbox" ng-model="$ctrl.settings.showQuickActionAttach" ng-change="$ctrl.onSettingsQuickActionChange()"/>
+                      <label for="setting_show_attach">Attach</label>
                     </div>
                   </div>
                 </div>
@@ -155,7 +159,7 @@
                   </div>
                 </div>
               </th>
-              <th ng-if="$ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionConsole || $ctrl.settings.showQuickActionInspect" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
+              <th ng-if="$ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionInspect" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
                 Quick actions
               </th>
               <th ng-show="$ctrl.columnVisibility.columns.stack.display">
@@ -223,7 +227,7 @@
                 <span ng-if="['starting','healthy','unhealthy'].indexOf(item.Status) !== -1" class="label label-{{ item.Status|containerstatusbadge }} interactive" uib-tooltip="This container has a health check">{{ item.Status }}</span>
                 <span ng-if="['starting','healthy','unhealthy'].indexOf(item.Status) === -1" class="label label-{{ item.Status|containerstatusbadge }}">{{ item.Status }}</span>
               </td>
-              <td ng-if="!$ctrl.offlineMode && ($ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionConsole || $ctrl.settings.showQuickActionInspect)" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
+              <td ng-if="!$ctrl.offlineMode && ($ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionInspect)" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
                 <container-quick-actions container-id="item.Id" node-name="item.NodeName" status="item.Status" state="$ctrl.settings"></container-quick-actions>
               </td>
               <td ng-if="$ctrl.offlineMode">

--- a/app/docker/components/datatables/containers-datatable/containersDatatable.html
+++ b/app/docker/components/datatables/containers-datatable/containersDatatable.html
@@ -70,7 +70,7 @@
                     <label for="setting_container_trunc">Truncate container name</label>
                   </div>
                 </div>
-                <div authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
+                <div authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs, DockerContainerAttach">
                   <div class="menuHeader">
                     Quick actions
                   </div>
@@ -159,7 +159,7 @@
                   </div>
                 </div>
               </th>
-              <th ng-if="$ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionInspect" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
+              <th ng-if="$ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionAttach|| $ctrl.settings.showQuickActionInspect" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs, DockerContainerAttach">
                 Quick actions
               </th>
               <th ng-show="$ctrl.columnVisibility.columns.stack.display">
@@ -227,7 +227,7 @@
                 <span ng-if="['starting','healthy','unhealthy'].indexOf(item.Status) !== -1" class="label label-{{ item.Status|containerstatusbadge }} interactive" uib-tooltip="This container has a health check">{{ item.Status }}</span>
                 <span ng-if="['starting','healthy','unhealthy'].indexOf(item.Status) === -1" class="label label-{{ item.Status|containerstatusbadge }}">{{ item.Status }}</span>
               </td>
-              <td ng-if="!$ctrl.offlineMode && ($ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionInspect)" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
+              <td ng-if="!$ctrl.offlineMode && ($ctrl.settings.showQuickActionStats || $ctrl.settings.showQuickActionLogs || $ctrl.settings.showQuickActionExec || $ctrl.settings.showQuickActionAttach || $ctrl.settings.showQuickActionInspect)" ng-show="$ctrl.columnVisibility.columns.actions.display" authorization="DockerContainerStats, DockerContainerLogs, DockerExecStart, DockerContainerInspect, DockerTaskInspect, DockerTaskLogs">
                 <container-quick-actions container-id="item.Id" node-name="item.NodeName" status="item.Status" state="$ctrl.settings"></container-quick-actions>
               </td>
               <td ng-if="$ctrl.offlineMode">

--- a/app/docker/components/datatables/containers-datatable/containersDatatableController.js
+++ b/app/docker/components/datatables/containers-datatable/containersDatatableController.js
@@ -24,8 +24,9 @@ function (PaginationService, DatatableService, EndpointProvider) {
     containerNameTruncateSize: 32,
     showQuickActionStats: true,
     showQuickActionLogs: true,
-    showQuickActionConsole: true,
-    showQuickActionInspect: true
+    showQuickActionExec: true,
+    showQuickActionInspect: true,
+    showQuickActionAttach: false
   };
 
   this.filters = {

--- a/app/docker/components/datatables/service-tasks-datatable/serviceTasksDatatableController.js
+++ b/app/docker/components/datatables/service-tasks-datatable/serviceTasksDatatableController.js
@@ -9,7 +9,7 @@ function (DatatableService) {
     orderBy: this.orderBy,
     showQuickActionStats: true,
     showQuickActionLogs: true,
-    showQuickActionConsole: true,
+    showQuickActionExec: true,
     showQuickActionInspect: true
   };
 

--- a/app/docker/components/datatables/service-tasks-datatable/serviceTasksDatatableController.js
+++ b/app/docker/components/datatables/service-tasks-datatable/serviceTasksDatatableController.js
@@ -10,7 +10,8 @@ function (DatatableService) {
     showQuickActionStats: true,
     showQuickActionLogs: true,
     showQuickActionExec: true,
-    showQuickActionInspect: true
+    showQuickActionInspect: true,
+    showQuickActionAttach: false
   };
 
   this.filters = {

--- a/app/docker/components/datatables/tasks-datatable/tasksDatatableController.js
+++ b/app/docker/components/datatables/tasks-datatable/tasksDatatableController.js
@@ -4,7 +4,7 @@ function (PaginationService, DatatableService) {
   this.state = {
     showQuickActionStats: true,
     showQuickActionLogs: true,
-    showQuickActionConsole: true,
+    showQuickActionExec: true,
     showQuickActionInspect: true,
     selectAll: false,
     orderBy: this.orderBy,

--- a/app/docker/components/datatables/tasks-datatable/tasksDatatableController.js
+++ b/app/docker/components/datatables/tasks-datatable/tasksDatatableController.js
@@ -6,6 +6,7 @@ function (PaginationService, DatatableService) {
     showQuickActionLogs: true,
     showQuickActionExec: true,
     showQuickActionInspect: true,
+    showQuickActionAttach: false,
     selectAll: false,
     orderBy: this.orderBy,
     paginatedItemLimit: PaginationService.getPaginationLimit(this.tableKey),


### PR DESCRIPTION
As this feature can be confusing for new users (you usually need to start a container in a specific way to use it), it will be hidden by default and can be toggled on via the containers datatable settings for quick actions.

The attach link is still available in the container details view.

Related to #592