### PR TITLE
fix(app): wrapper for UI refresh trigger with async/await

### DIFF
--- a/app/portainer/services/async.js
+++ b/app/portainer/services/async.js
@@ -1,0 +1,16 @@
+angular.module('portainer').factory('$async', ['$q',
+  function($q) {
+    return function(asyncFunc) {
+      const wrapper = function() {
+        const deferred = $q.defer();
+        asyncFunc()
+          .then(deferred.resolve)
+          .catch(deferred.reject);
+        return deferred.promise;
+      };
+      wrapper().then(() => {
+        /*no op*/
+      });
+    };
+  }
+]);


### PR DESCRIPTION
Closes #2944 .

Solution inspired by [angular-async-await](https://github.com/ben-hunter-hansen/angular-async-await) without the manual call of `$scope.$apply()` or `$scope.$digest()` as it is bad to do so.

### How to use it

* Inject `$async` as any service/factory
* Async functions must be wrapped inside a non async function containing only the wrapper call
* Async functions wrapped must have the `bind()` call to avoid loosing `this` context when executed inside the `$async` wrapper.
```
class MyController {
  /* @ngInject */
  constructor($async) {
    this.$async = $async;
    this.myFuncAsync = this.myFuncAsync.bind(this);
  }

  myFunc() {
    this.$async(this.myFuncAsync);
  }

  async myFuncAsync() {
    try {
      await anyAsyncCall();
      ...
    } catch (err) {
      ...
    } finally {
      ...
    }
  }
}

export default MyController;
angular
  .module("my.module")
  .controller("MyController", MyController);

```