### PR TITLE
fix(volume-browser): Zip files corrupted when downloaded from a docker volume 

### DIFF
--- a/app/agent/components/volume-browser/volumeBrowserController.js
+++ b/app/agent/components/volume-browser/volumeBrowserController.js
@@ -42,7 +42,7 @@ function (HttpRequestHelper, VolumeBrowserService, FileSaver, Blob, ModalService
     var filePath = this.state.path === '/' ? file : this.state.path + '/' + file;
     VolumeBrowserService.get(this.volumeId, filePath)
     .then(function success(data) {
-      var downloadData = new Blob([data.file], { type: 'text/plain;charset=utf-8' });
+      var downloadData = new Blob([data.file]);
       FileSaver.saveAs(downloadData, file);
     })
     .catch(function error(err) {

--- a/app/agent/rest/browse.js
+++ b/app/agent/rest/browse.js
@@ -14,7 +14,8 @@ angular.module('portainer.agent')
     },
     get: {
       method: 'GET', params: { action: 'get' },
-      transformResponse: browseGetResponse
+      transformResponse: browseGetResponse,
+      responseType: 'arraybuffer'
     },
     delete: {
       method: 'DELETE', params: { action: 'delete' }

--- a/app/agent/rest/v1/browse.js
+++ b/app/agent/rest/v1/browse.js
@@ -12,7 +12,8 @@ angular.module('portainer.agent')
     },
     get: {
       method: 'GET', params: { action: 'get' },
-      transformResponse: browseGetResponse
+      transformResponse: browseGetResponse,
+      responseType: 'arraybuffer'
     },
     delete: {
       method: 'DELETE', params: { action: 'delete' }


### PR DESCRIPTION
This fixes #2661.

FileSaver.js expects the data to be an Blob or ArrayBuffer
https://github.com/eligrey/FileSaver.js/issues/367#issuecomment-360390179

I had to remove the fixed declaration of the type as well (text/plain;charset=utf-8), since it can cause problems while saving files likes tar.gz or mp3.

I have tested it with txt, zip, tar.gz, mp3 and files without extension.