### PR TITLE
feat(node-details): engine labels

### DIFF
--- a/app/docker/components/host-view-panels/engine-details-panel/engine-details-panel.html
+++ b/app/docker/components/host-view-panels/engine-details-panel/engine-details-panel.html
@@ -29,6 +29,10 @@
               <td>Network Plugins</td>
               <td>{{ $ctrl.engine.networkPlugins | arraytostr: ', ' }}</td>
             </tr>
+            <tr ng-if="$ctrl.engine.engineLabels.length">
+              <td>Engine Labels</td>
+              <td>{{ $ctrl.engine.engineLabels | labelsToStr:', ' }}</td>
+            </tr>
           </tbody>
         </table>
       </rd-widget-body>

--- a/app/docker/components/host-view-panels/swarm-node-details-panel/swarm-node-details-panel.html
+++ b/app/docker/components/host-view-panels/swarm-node-details-panel/swarm-node-details-panel.html
@@ -26,10 +26,6 @@
               <td><span class="label label-{{ $ctrl.details.status | nodestatusbadge }}">{{
                   $ctrl.details.status }}</span></td>
             </tr>
-            <tr ng-if=" $ctrl.details.engineLabels.length">
-              <td>Engine Labels</td>
-              <td>{{ $ctrl.details.engineLabels | labelsToStr:', ' }}</td>
-            </tr>
             <tr>
               <td>
                 <div class="nopadding">

--- a/app/docker/views/nodes/node-details/node-details-view-controller.js
+++ b/app/docker/views/nodes/node-details/node-details-view-controller.js
@@ -62,7 +62,8 @@ angular.module('portainer.docker').controller('NodeDetailsViewController', [
       return {
         releaseVersion: node.EngineVersion,
         volumePlugins: transformPlugins(node.Plugins, 'Volume'),
-        networkPlugins: transformPlugins(node.Plugins, 'Network')
+        networkPlugins: transformPlugins(node.Plugins, 'Network'),
+        engineLabels: node.EngineLabels,
       };
     }
 
@@ -73,7 +74,6 @@ angular.module('portainer.docker').controller('NodeDetailsViewController', [
         managerAddress: node.ManagerAddr,
         availability: node.Availability,
         status: node.Status,
-        engineLabels: node.EngineLabels,
         nodeLabels: node.Labels
       };
     }


### PR DESCRIPTION
Move engine labels from node-details panel to engine-details panel.

Closes #2964 .