### PR TITLE
feat(stacks): Introduce Deployment Keys

### DIFF
--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/deploymentkey"
 	"github.com/portainer/portainer/api/bolt/dockerhub"
 	"github.com/portainer/portainer/api/bolt/endpoint"
 	"github.com/portainer/portainer/api/bolt/endpointgroup"
@@ -39,6 +40,7 @@ type Store struct {
 	checkForDataMigration  bool
 	fileService            portainer.FileService
 	RoleService            *role.Service
+	DeploymentKeyService   *deploymentkey.Service
 	DockerHubService       *dockerhub.Service
 	EndpointGroupService   *endpointgroup.Service
 	EndpointService        *endpoint.Service
@@ -147,6 +149,12 @@ func (store *Store) initServices() error {
 		return err
 	}
 	store.RoleService = authorizationsetService
+
+	deploymentkeyService, err := deploymentkey.NewService(store.db)
+	if err != nil {
+		return err
+	}
+	store.DeploymentKeyService = deploymentkeyService
 
 	dockerhubService, err := dockerhub.NewService(store.db)
 	if err != nil {

--- a/api/bolt/deploymentkey/deploymentkey.go
+++ b/api/bolt/deploymentkey/deploymentkey.go
@@ -1,0 +1,120 @@
+package deploymentkey
+
+import (
+	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/internal"
+
+	"github.com/boltdb/bolt"
+)
+
+const (
+	// BucketName represents the name of the bucket where this service stores data.
+	BucketName = "deploymentkey"
+)
+
+// Service represents a service for managing deploymentkey data.
+type Service struct {
+	db *bolt.DB
+}
+
+// NewService creates a new instance of a service.
+func NewService(db *bolt.DB) (*Service, error) {
+	err := internal.CreateBucket(db, BucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{
+		db: db,
+	}, nil
+}
+
+// DeploymentKeys return all the deployment keys that are created.
+func (service *Service) DeploymentKeys() ([]portainer.DeploymentKey, error) {
+	var deploymentkeys = make([]portainer.DeploymentKey, 0)
+
+	err := service.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			var deploymentkey portainer.DeploymentKey
+			err := internal.UnmarshalObject(v, &deploymentkey)
+			if err != nil {
+				return err
+			}
+			deploymentkeys = append(deploymentkeys, deploymentkey)
+		}
+
+		return nil
+	})
+
+	return deploymentkeys, err
+}
+
+// DeploymentKey returns the deployment key by deployment key ID.
+func (service *Service) DeploymentKey(ID portainer.DeploymentKeyID) (*portainer.DeploymentKey, error) {
+	var deploymentkey portainer.DeploymentKey
+	identifier := internal.Itob(int(ID))
+
+	err := internal.GetObject(service.db, BucketName, identifier, &deploymentkey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deploymentkey, nil
+}
+
+// DeploymentKeyByName returns a deploymentkey by name.
+func (service *Service) DeploymentKeyByName(name string) (*portainer.DeploymentKey, error) {
+	var deploymentkey *portainer.DeploymentKey
+
+	err := service.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			var t portainer.DeploymentKey
+			err := internal.UnmarshalObject(v, &t)
+			if err != nil {
+				return err
+			}
+
+			if t.Name == name {
+				deploymentkey = &t
+				break
+			}
+		}
+
+		if deploymentkey == nil {
+			return portainer.ErrObjectNotFound
+		}
+
+		return nil
+	})
+
+	return deploymentkey, err
+}
+
+// DeleteDeploymentKey deletes a deployment key.
+func (service *Service) DeleteDeploymentKey(ID portainer.DeploymentKeyID) error {
+	identifier := internal.Itob(int(ID))
+	return internal.DeleteObject(service.db, BucketName, identifier)
+}
+
+// CreateDeploymentKey creates a deployment key.
+func (service *Service) CreateDeploymentKey(deploymentkey *portainer.DeploymentKey) error {
+	return service.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+
+		id, _ := bucket.NextSequence()
+		deploymentkey.ID = portainer.DeploymentKeyID(id)
+
+		data, err := internal.MarshalObject(deploymentkey)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(internal.Itob(int(deploymentkey.ID)), data)
+	})
+}

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -674,6 +674,7 @@ func main() {
 		ResourceControlService: store.ResourceControlService,
 		SettingsService:        store.SettingsService,
 		RegistryService:        store.RegistryService,
+		DeploymentKeyService:   store.DeploymentKeyService,
 		DockerHubService:       store.DockerHubService,
 		StackService:           store.StackService,
 		ScheduleService:        store.ScheduleService,

--- a/api/errors.go
+++ b/api/errors.go
@@ -115,3 +115,8 @@ const (
 	ErrWebhookAlreadyExists   = Error("A webhook for this resource already exists")
 	ErrUnsupportedWebhookType = Error("Webhooks for this resource are not currently supported")
 )
+
+// Deploymentkey errors
+const (
+	ErrDeploymentkeyAlreadyExists = Error("A deployment key for this resource already exists")
+)

--- a/api/git/git.go
+++ b/api/git/git.go
@@ -61,6 +61,7 @@ func (service *Service) ClonePrivateRepositoryWithDeploymentKey(repositoryURL, r
 	}
 
 	repositoryURL = strings.Replace(repositoryURL, "https://", "git@", 1)
+	repositoryURL = strings.Replace(repositoryURL, "github.com/", "github.com:", 1)
 	repositoryURL += ".git"
 
 	options := &git.CloneOptions{

--- a/api/git/git.go
+++ b/api/git/git.go
@@ -47,10 +47,6 @@ func cloneRepository(repositoryURL, referenceName string, destination string) er
 }
 
 func (service *Service) ClonePrivateRepositoryWithDeploymentKey(repositoryURL, referenceName string, destination string, privateKeyPem []byte) error {
-	// url := "git@github.com:ssbkang/personal-development.git"
-	// directory := "personal-development"
-	// https://github.com/portainer/portainer-compose
-
 	signer, _ := ssh.ParsePrivateKey(privateKeyPem)
 	auth := &gitSsh.PublicKeys{
 		User:   "git",

--- a/api/git/git.go
+++ b/api/git/git.go
@@ -46,6 +46,8 @@ func cloneRepository(repositoryURL, referenceName string, destination string) er
 	return err
 }
 
+// ClonePrivateRepositoryWithDeploymentKey clones a private git repository using the specified URL in the specified
+// destination folder. It will use the specified deployment key for SSH based authentication
 func (service *Service) ClonePrivateRepositoryWithDeploymentKey(repositoryURL, referenceName string, destination string, privateKeyPem []byte) error {
 	signer, _ := ssh.ParsePrivateKey(privateKeyPem)
 	auth := &gitSsh.PublicKeys{

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -36,8 +36,6 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusConflict, "A deploymentkey for this resource already exists", portainer.ErrDeploymentkeyAlreadyExists}
 	}
 
-	// Add a function to call and create public key and private key
-
 	private, public, err := handler.SignatureService.GenerateDeploymentKeyPair()
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create private and public key pairs", err}

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -54,7 +54,7 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist the deployment key inside the database", err}
 	}
 
-	// hideFields(deploymentkey)
+	hideFields(deploymentkey)
 
 	return response.JSON(w, deploymentkey)
 }

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -38,10 +38,15 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 
 	// Add a function to call and create public key and private key
 
+	private, public, err := handler.SignatureService.GenerateDeploymentKeyPair()
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create private and public key pairs", err}
+	}
+
 	deploymentkey = &portainer.DeploymentKey{
 		Name:       payload.Name,
-		PublicKey:  "SHA256:hellotherepublic",
-		PrivateKey: "SHA256:hellothereprivate",
+		PublicKey:  public,
+		PrivateKey: private,
 	}
 
 	err = handler.DeploymentKeyService.CreateDeploymentKey(deploymentkey)
@@ -49,7 +54,7 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist the deployment key inside the database", err}
 	}
 
-	hideFields(deploymentkey)
+	// hideFields(deploymentkey)
 
 	return response.JSON(w, deploymentkey)
 }

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -49,5 +49,7 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist the deployment key inside the database", err}
 	}
 
+	hideFields(deploymentkey)
+
 	return response.JSON(w, deploymentkey)
 }

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -29,10 +29,11 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 	}
 
 	deploymentkey, err := handler.DeploymentKeyService.DeploymentKeyByName(payload.Name)
-	if err == portainer.ErrObjectNotFound {
-		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a deployment key with the specified identifier inside the database", err}
-	} else if err != nil {
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a deployment key with the specified identifier inside the database", err}
+	if err != nil && err != portainer.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusInternalServerError, "An error occurred retrieving deploymentkey from the database", err}
+	}
+	if deploymentkey != nil {
+		return &httperror.HandlerError{http.StatusConflict, "A deploymentkey for this resource already exists", portainer.ErrDeploymentkeyAlreadyExists}
 	}
 
 	// Add a function to call and create public key and private key

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -33,7 +33,7 @@ func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a deployment key with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a deployment key with the specified identifier inside the database", err}
-	}	
+	}
 
 	// Add a function to call and create public key and private key
 

--- a/api/http/handler/deploymentkeys/deploymentkey_create.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_create.go
@@ -1,0 +1,52 @@
+package deploymentkeys
+
+import (
+	"net/http"
+
+	"github.com/asaskevich/govalidator"
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	"github.com/portainer/portainer/api"
+)
+
+type deploymentKeyCreatePayload struct {
+	Name string
+}
+
+func (payload *deploymentKeyCreatePayload) Validate(r *http.Request) error {
+	if govalidator.IsNull(payload.Name) {
+		return portainer.Error("Invalid deploymentkey name")
+	}
+	return nil
+}
+
+func (handler *Handler) deploymentkeyCreate(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	var payload deploymentKeyCreatePayload
+	err := request.DecodeAndValidateJSONPayload(r, &payload)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid request payload", err}
+	}
+
+	deploymentkey, err := handler.DeploymentKeyService.DeploymentKeyByName(payload.Name)
+	if err == portainer.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a deployment key with the specified identifier inside the database", err}
+	} else if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a deployment key with the specified identifier inside the database", err}
+	}	
+
+	// Add a function to call and create public key and private key
+
+	deploymentkey = &portainer.DeploymentKey{
+		Name:       payload.Name,
+		PublicKey:  "SHA256:hellotherepublic",
+		PrivateKey: "SHA256:hellothereprivate",
+	}
+
+	err = handler.DeploymentKeyService.CreateDeploymentKey(deploymentkey)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist the deployment key inside the database", err}
+	}
+
+	return response.JSON(w, deploymentkey)
+}

--- a/api/http/handler/deploymentkeys/deploymentkey_delete.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_delete.go
@@ -1,0 +1,25 @@
+package deploymentkeys
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	"github.com/portainer/portainer/api"
+)
+
+// DELETE request on /api/webhook/:serviceID
+func (handler *Handler) deploymentkeyDelete(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	id, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid deployment key id", err}
+	}
+
+	err = handler.DeploymentKeyService.DeleteDeploymentKey(portainer.DeploymentKeyID(id))
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove the deployment key from the database", err}
+	}
+
+	return response.Empty(w)
+}

--- a/api/http/handler/deploymentkeys/deploymentkey_inspect.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_inspect.go
@@ -1,0 +1,27 @@
+package deploymentkeys
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	"github.com/portainer/portainer/api"
+)
+
+// GET request on /api/deployment_keys/:id
+func (handler *Handler) deploymentkeyInspect(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	deploymentkeyID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid deploymentkey identifier route variable", err}
+	}
+
+	deploymentkey, err := handler.DeploymentKeyService.DeploymentKey(portainer.DeploymentKeyID(deploymentkeyID))
+	if err == portainer.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a deployment key with the specified identifier inside the database", err}
+	} else if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a deployment key with the specified identifier inside the database", err}
+	}
+
+	return response.JSON(w, deploymentkey)
+}

--- a/api/http/handler/deploymentkeys/deploymentkey_inspect.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_inspect.go
@@ -23,5 +23,7 @@ func (handler *Handler) deploymentkeyInspect(w http.ResponseWriter, r *http.Requ
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a deployment key with the specified identifier inside the database", err}
 	}
 
+	hideFields(deploymentkey)
+
 	return response.JSON(w, deploymentkey)
 }

--- a/api/http/handler/deploymentkeys/deploymentkey_list.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_list.go
@@ -14,5 +14,9 @@ func (handler *Handler) deploymentkeyList(w http.ResponseWriter, r *http.Request
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve deploymentkeys from the database", err}
 	}
 
+	for idx := range deploymentkeys {
+		hideFields(&deploymentkeys[idx])
+	}
+
 	return response.JSON(w, deploymentkeys)
 }

--- a/api/http/handler/deploymentkeys/deploymentkey_list.go
+++ b/api/http/handler/deploymentkeys/deploymentkey_list.go
@@ -1,0 +1,18 @@
+package deploymentkeys
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/response"
+)
+
+// GET request on /api/deployment_keys
+func (handler *Handler) deploymentkeyList(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	deploymentkeys, err := handler.DeploymentKeyService.DeploymentKeys()
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve deploymentkeys from the database", err}
+	}
+
+	return response.JSON(w, deploymentkeys)
+}

--- a/api/http/handler/deploymentkeys/handler.go
+++ b/api/http/handler/deploymentkeys/handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/portainer/portainer/api/http/security"
 )
 
-// Handler is the HTTP handler used to handle webhook operations.
+// Handler is the HTTP handler used to handle deploymentkey operations.
 type Handler struct {
 	*mux.Router
 	DeploymentKeyService portainer.DeploymentKeyService

--- a/api/http/handler/deploymentkeys/handler.go
+++ b/api/http/handler/deploymentkeys/handler.go
@@ -15,6 +15,10 @@ type Handler struct {
 	DeploymentKeyService portainer.DeploymentKeyService
 }
 
+func hideFields(deploymentkey *portainer.DeploymentKey) {
+	deploymentkey.PrivateKey = ""
+}
+
 // NewHandler creates a handler to manage settings operations.
 func NewHandler(bouncer *security.RequestBouncer) *Handler {
 	h := &Handler{

--- a/api/http/handler/deploymentkeys/handler.go
+++ b/api/http/handler/deploymentkeys/handler.go
@@ -13,10 +13,11 @@ import (
 type Handler struct {
 	*mux.Router
 	DeploymentKeyService portainer.DeploymentKeyService
+	SignatureService     portainer.DigitalSignatureService
 }
 
 func hideFields(deploymentkey *portainer.DeploymentKey) {
-	deploymentkey.PrivateKey = ""
+	deploymentkey.PrivateKey = nil
 }
 
 // NewHandler creates a handler to manage settings operations.

--- a/api/http/handler/deploymentkeys/handler.go
+++ b/api/http/handler/deploymentkeys/handler.go
@@ -1,0 +1,36 @@
+package deploymentkeys
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	httperror "github.com/portainer/libhttp/error"
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+// Handler is the HTTP handler used to handle webhook operations.
+type Handler struct {
+	*mux.Router
+	DeploymentKeyService portainer.DeploymentKeyService
+}
+
+// NewHandler creates a handler to manage settings operations.
+func NewHandler(bouncer *security.RequestBouncer) *Handler {
+	h := &Handler{
+		Router: mux.NewRouter(),
+	}
+	h.Handle("/deployment_keys",
+		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyCreate))).Methods(http.MethodPost)
+		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyCreate))).Methods(http.MethodPost)
+	h.Handle("/deployment_keys",
+		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
+		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
+	h.Handle("/deployment_keys/{id}",
+		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
+		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyInspect))).Methods(http.MethodGet)
+	h.Handle("/deployment_keys/{id}",
+		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyDelete))).Methods(http.MethodDelete)
+		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyDelete))).Methods(http.MethodDelete)
+	return h
+}

--- a/api/http/handler/deploymentkeys/handler.go
+++ b/api/http/handler/deploymentkeys/handler.go
@@ -26,16 +26,12 @@ func NewHandler(bouncer *security.RequestBouncer) *Handler {
 		Router: mux.NewRouter(),
 	}
 	h.Handle("/deployment_keys",
-		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyCreate))).Methods(http.MethodPost)
-		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyCreate))).Methods(http.MethodPost)
+		bouncer.AuthorizedAccess(httperror.LoggerHandler(h.deploymentkeyCreate))).Methods(http.MethodPost)
 	h.Handle("/deployment_keys",
-		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
-		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
+		bouncer.AuthorizedAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
 	h.Handle("/deployment_keys/{id}",
-		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyList))).Methods(http.MethodGet)
-		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyInspect))).Methods(http.MethodGet)
+		bouncer.AuthorizedAccess(httperror.LoggerHandler(h.deploymentkeyInspect))).Methods(http.MethodGet)
 	h.Handle("/deployment_keys/{id}",
-		// bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.deploymentkeyDelete))).Methods(http.MethodDelete)
-		bouncer.PublicAccess(httperror.LoggerHandler(h.deploymentkeyDelete))).Methods(http.MethodDelete)
+		bouncer.AuthorizedAccess(httperror.LoggerHandler(h.deploymentkeyDelete))).Methods(http.MethodDelete)
 	return h
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/roles"
 
 	"github.com/portainer/portainer/api/http/handler/auth"
+	"github.com/portainer/portainer/api/http/handler/deploymentkeys"
 	"github.com/portainer/portainer/api/http/handler/dockerhub"
 	"github.com/portainer/portainer/api/http/handler/endpointgroups"
 	"github.com/portainer/portainer/api/http/handler/endpointproxy"
@@ -34,6 +35,7 @@ import (
 // Handler is a collection of all the service handlers.
 type Handler struct {
 	AuthHandler            *auth.Handler
+	DeploymentKeyHandler   *deploymentkeys.Handler
 	DockerHubHandler       *dockerhub.Handler
 	EndpointGroupHandler   *endpointgroups.Handler
 	EndpointHandler        *endpoints.Handler
@@ -63,6 +65,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(r.URL.Path, "/api/auth"):
 		http.StripPrefix("/api", h.AuthHandler).ServeHTTP(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/deployment_keys"):
+		http.StripPrefix("/api", h.DeploymentKeyHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/dockerhub"):
 		http.StripPrefix("/api", h.DockerHubHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/endpoint_groups"):

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -87,11 +87,13 @@ func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter,
 	return response.JSON(w, stack)
 }
 
+// Update struc to cater for deployment key
 type composeStackFromGitRepositoryPayload struct {
 	Name                        string
 	RepositoryURL               string
 	RepositoryReferenceName     string
 	RepositoryAuthentication    bool
+	RepositoryDeploymentKey     string
 	RepositoryUsername          string
 	RepositoryPassword          string
 	ComposeFilePathInRepository string
@@ -145,11 +147,13 @@ func (handler *Handler) createComposeStackFromGitRepository(w http.ResponseWrite
 	projectPath := handler.FileService.GetStackProjectPath(strconv.Itoa(int(stack.ID)))
 	stack.ProjectPath = projectPath
 
+	// Add Deployment Key
 	gitCloneParams := &cloneRepositoryParameters{
 		url:            payload.RepositoryURL,
 		referenceName:  payload.RepositoryReferenceName,
 		path:           projectPath,
 		authentication: payload.RepositoryAuthentication,
+		deploymentKey:  payload.RepositoryDeploymentKey,
 		username:       payload.RepositoryUsername,
 		password:       payload.RepositoryPassword,
 	}

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -113,17 +113,17 @@ func (payload *swarmStackFromGitRepositoryPayload) Validate(r *http.Request) err
 		return portainer.Error("Invalid Swarm ID")
 	}
 
-	// Need to improve validators for SSH based URL and deployment key type
-
-	/*
 	if govalidator.IsNull(payload.RepositoryURL) || !govalidator.IsURL(payload.RepositoryURL) {
 		return portainer.Error("Invalid repository URL. Must correspond to a valid URL format")
 	}
 
+	// Need to improve validators for SSH based URL and deployment key type
+	/*
 	if payload.RepositoryAuthentication && (govalidator.IsNull(payload.RepositoryDeploymentKey)) || (govalidator.IsNull(payload.RepositoryUsername) || govalidator.IsNull(payload.RepositoryPassword)) {
 		return portainer.Error("Invalid repository credentials or deploymenet key. Either Username & password or a deployment key must be specified when authentication is enabled")
 	}
 	*/
+
 	if govalidator.IsNull(payload.ComposeFilePathInRepository) {
 		payload.ComposeFilePathInRepository = filesystem.ComposeFileDefaultName
 	}

--- a/api/http/handler/stacks/git.go
+++ b/api/http/handler/stacks/git.go
@@ -5,13 +5,18 @@ type cloneRepositoryParameters struct {
 	referenceName  string
 	path           string
 	authentication bool
+	deploymentKey  string
 	username       string
 	password       string
 }
 
 func (handler *Handler) cloneGitRepository(parameters *cloneRepositoryParameters) error {
-	if parameters.authentication {
+	if parameters.authentication && parameters.username != "" && parameters.password != "" {
 		return handler.GitService.ClonePrivateRepositoryWithBasicAuth(parameters.url, parameters.referenceName, parameters.path, parameters.username, parameters.password)
+	}
+	if parameters.authentication && parameters.deploymentKey != "" {
+		deploymentKey, _ := handler.DeploymentKeyService.DeploymentKeyByName(parameters.deploymentKey)
+		return handler.GitService.ClonePrivateRepositoryWithDeploymentKey(parameters.url, parameters.referenceName, parameters.path, deploymentKey.PrivateKey)
 	}
 	return handler.GitService.ClonePublicRepository(parameters.url, parameters.referenceName, parameters.path)
 }

--- a/api/http/handler/stacks/git.go
+++ b/api/http/handler/stacks/git.go
@@ -1,22 +1,21 @@
 package stacks
 
 type cloneRepositoryParameters struct {
-	url            string
-	referenceName  string
-	path           string
-	authentication bool
-	deploymentKey  string
-	username       string
-	password       string
+	url                string
+	referenceName      string
+	path               string
+	authenticationType string
+	deploymentKey      []byte
+	username           string
+	password           string
 }
 
 func (handler *Handler) cloneGitRepository(parameters *cloneRepositoryParameters) error {
-	if parameters.authentication && parameters.username != "" && parameters.password != "" {
+	if parameters.authenticationType != "" && parameters.username != "" && parameters.password != "" {
 		return handler.GitService.ClonePrivateRepositoryWithBasicAuth(parameters.url, parameters.referenceName, parameters.path, parameters.username, parameters.password)
 	}
-	if parameters.authentication && parameters.deploymentKey != "" {
-		deploymentKey, _ := handler.DeploymentKeyService.DeploymentKeyByName(parameters.deploymentKey)
-		return handler.GitService.ClonePrivateRepositoryWithDeploymentKey(parameters.url, parameters.referenceName, parameters.path, deploymentKey.PrivateKey)
+	if parameters.authenticationType != "" && parameters.deploymentKey != nil {
+		return handler.GitService.ClonePrivateRepositoryWithDeploymentKey(parameters.url, parameters.referenceName, parameters.path, parameters.deploymentKey)
 	}
 	return handler.GitService.ClonePublicRepository(parameters.url, parameters.referenceName, parameters.path)
 }

--- a/api/http/handler/stacks/handler.go
+++ b/api/http/handler/stacks/handler.go
@@ -16,6 +16,7 @@ type Handler struct {
 	stackDeletionMutex *sync.Mutex
 	requestBouncer     *security.RequestBouncer
 	*mux.Router
+	DeploymentKeyService   portainer.DeploymentKeyService
 	FileService            portainer.FileService
 	GitService             portainer.GitService
 	StackService           portainer.StackService

--- a/api/http/proxy/factory_local_windows.go
+++ b/api/http/proxy/factory_local_windows.go
@@ -3,10 +3,10 @@
 package proxy
 
 import (
+	"github.com/Microsoft/go-winio"
 	"net"
 	"net/http"
-	"github.com/Microsoft/go-winio"
-	
+
 	portainer "github.com/portainer/portainer/api"
 )
 

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/portainer/api/docker"
 	"github.com/portainer/portainer/api/http/handler"
 	"github.com/portainer/portainer/api/http/handler/auth"
+	"github.com/portainer/portainer/api/http/handler/deploymentkeys"
 	"github.com/portainer/portainer/api/http/handler/dockerhub"
 	"github.com/portainer/portainer/api/http/handler/endpointgroups"
 	"github.com/portainer/portainer/api/http/handler/endpointproxy"
@@ -51,6 +52,7 @@ type Server struct {
 	JobScheduler           portainer.JobScheduler
 	Snapshotter            portainer.Snapshotter
 	RoleService            portainer.RoleService
+	DeploymentKeyService   portainer.DeploymentKeyService
 	DockerHubService       portainer.DockerHubService
 	EndpointService        portainer.EndpointService
 	EndpointGroupService   portainer.EndpointGroupService
@@ -222,9 +224,13 @@ func (server *Server) Start() error {
 	webhookHandler.EndpointService = server.EndpointService
 	webhookHandler.DockerClientFactory = server.DockerClientFactory
 
+	var deploymentKeyHandler = deploymentkeys.NewHandler(requestBouncer)
+	deploymentKeyHandler.DeploymentKeyService = server.DeploymentKeyService
+
 	server.Handler = &handler.Handler{
 		RoleHandler:            roleHandler,
 		AuthHandler:            authHandler,
+		DeploymentKeyHandler:   deploymentKeyHandler,
 		DockerHubHandler:       dockerHubHandler,
 		EndpointGroupHandler:   endpointGroupHandler,
 		EndpointHandler:        endpointHandler,

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -226,6 +226,7 @@ func (server *Server) Start() error {
 
 	var deploymentKeyHandler = deploymentkeys.NewHandler(requestBouncer)
 	deploymentKeyHandler.DeploymentKeyService = server.DeploymentKeyService
+	deploymentKeyHandler.SignatureService = server.SignatureService
 
 	server.Handler = &handler.Handler{
 		RoleHandler:            roleHandler,

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -182,6 +182,7 @@ func (server *Server) Start() error {
 	stackHandler.FileService = server.FileService
 	stackHandler.StackService = server.StackService
 	stackHandler.EndpointService = server.EndpointService
+	stackHandler.DeploymentKeyService = server.DeploymentKeyService
 	stackHandler.ResourceControlService = server.ResourceControlService
 	stackHandler.SwarmStackManager = server.SwarmStackManager
 	stackHandler.ComposeStackManager = server.ComposeStackManager

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -817,6 +817,7 @@ type (
 	GitService interface {
 		ClonePublicRepository(repositoryURL, referenceName string, destination string) error
 		ClonePrivateRepositoryWithBasicAuth(repositoryURL, referenceName string, destination, username, password string) error
+		ClonePrivateRepositoryWithDeploymentKey(repositoryURL, referenceName string, destination string, privateKeyPem []byte) error
 	}
 
 	// JobScheduler represents a service to run jobs on a periodic basis

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -216,6 +216,18 @@ type (
 		TLSConfig      TLSConfiguration `json:"TLSConfig"`
 	}
 
+	// DeploymentKeyID represents
+	DeploymentKeyID int
+
+	// DeploymentKey represents the SSH key details that will be used to
+	// connect to GitHub for deployments based on private key clone
+	DeploymentKey struct {
+		ID         DeploymentKeyID `json:"Id`
+		Name       string          `json:"Name"`
+		PublicKey  string          `json:"PublicKey"`
+		PrivateKey string          `json:"PrivateKey"`
+	}
+
 	// DockerHub represents all the required information to connect and use the
 	// Docker Hub
 	DockerHub struct {
@@ -674,6 +686,15 @@ type (
 		GetNextIdentifier() int
 	}
 
+	// DeploymentKeyService represents a service for managing the DeploymentKey object
+	DeploymentKeyService interface {
+		DeploymentKey(ID DeploymentKeyID) (*DeploymentKey, error)
+		DeploymentKeyByName(name string) (*DeploymentKey, error)
+		DeploymentKeys() ([]DeploymentKey, error)
+		DeleteDeploymentKey(ID DeploymentKeyID) error
+		CreateDeploymentKey(deploymentkey *DeploymentKey) error
+	}
+
 	// DockerHubService represents a service for managing the DockerHub object
 	DockerHubService interface {
 		DockerHub() (*DockerHub, error)
@@ -876,7 +897,7 @@ const (
 	PortainerAgentSignatureMessage = "Portainer-App"
 	// SupportedDockerAPIVersion is the minimum Docker API version supported by Portainer
 	SupportedDockerAPIVersion = "1.24"
-	// ExtensionServer represents the server used by Portainer to communicate with extensions 
+	// ExtensionServer represents the server used by Portainer to communicate with extensions
 	ExtensionServer = "localhost"
 )
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -225,7 +225,7 @@ type (
 		ID         DeploymentKeyID `json:"Id`
 		Name       string          `json:"Name"`
 		PublicKey  string          `json:"PublicKey"`
-		PrivateKey string          `json:"PrivateKey"`
+		PrivateKey []byte          `json:"PrivateKey"`
 	}
 
 	// DockerHub represents all the required information to connect and use the
@@ -778,6 +778,7 @@ type (
 	DigitalSignatureService interface {
 		ParseKeyPair(private, public []byte) error
 		GenerateKeyPair() ([]byte, []byte, error)
+		GenerateDeploymentKeyPair() ([]byte, string, error)
 		EncodedPublicKey() string
 		PEMHeaders() (string, string)
 		CreateSignature(message string) (string, error)

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -222,7 +222,7 @@ type (
 	// DeploymentKey represents the SSH key details that will be used to
 	// connect to GitHub for deployments based on private key clone
 	DeploymentKey struct {
-		ID         DeploymentKeyID `json:"Id`
+		ID         DeploymentKeyID `json:"Id"`
 		Name       string          `json:"Name"`
 		PublicKey  string          `json:"PublicKey"`
 		PrivateKey []byte          `json:"PrivateKey"`


### PR DESCRIPTION
**Short Description**
This is to introduce a feature called `Deployment Keys`, which will generate ECDSA based private and public keys. 
The public key then can be leveraged in GitHub for enabling SSH key based Git clone for Stack deployments from a private GitHub repo. This will eliminate the limitation of users not being able to use Basic Authentication while 2FA is enabled.

**Issues to Fix**
This will fix #1752, #1753 and potentially #2448.

**Future Improvements**
Allow the `Create Stack` API to update with the new compose or stack `.yml` file if Swarm Stack exists.

