### PR TITLE
fix(app): un-needed checkbox in service details view

### DIFF
--- a/app/extensions/rbac/directives/disable-authorization.js
+++ b/app/extensions/rbac/directives/disable-authorization.js
@@ -5,11 +5,9 @@ angular.module('portainer.extensions.rbac')
       try {
         const rbacEnabled = await ExtensionService.extensionEnabled(ExtensionService.EXTENSIONS.RBAC);
         if (!rbacEnabled) {
-          elem.show();
           return;
         }
       } catch (err) {
-        elem.show();
         return;
       }
 


### PR DESCRIPTION
Closes #2979 

`disable-authorization` directive was hiding/showing elements instead of disabling them.