### PR TITLE
fix(container): Fix bad env in container creation

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -428,7 +428,7 @@ function ($q, $scope, $state, $timeout, $transition$, $filter, Container, Contai
     var envArr = [];
     for (var e in $scope.config.Env) {
       if ({}.hasOwnProperty.call($scope.config.Env, e)) {
-        var arr = $scope.config.Env[e].split(/\=(.+)/);
+        var arr = $scope.config.Env[e].split(/\=(.*)/);
         envArr.push({'name': arr[0], 'value': arr[1]});
       }
     }


### PR DESCRIPTION
Closes: #2112
Currently we are using RegExp `/\=(.+)/` to catch key-value
of environment variables, which could not match empty-value
environment variables such as `KEY=`.

This commit will change the RegExp to `/\=(.*)/`, which
matches the empty values.