### PR TITLE
feat(volumes): add browse volume button to other related views

### DIFF
--- a/app/docker/views/containers/edit/container.html
+++ b/app/docker/views/containers/edit/container.html
@@ -257,7 +257,14 @@
             <tbody>
               <tr ng-repeat="vol in container.Mounts">
                 <td ng-if="vol.Type === 'bind'">{{ vol.Source }}</td>
-                <td ng-if="vol.Type === 'volume'"><a ui-sref="docker.volumes.volume({ id: vol.Name, nodeName: nodeName })">{{ vol.Name }}</a></td>
+                <td ng-if="vol.Type === 'volume'"><a ui-sref="docker.volumes.volume({ id: vol.Name, nodeName: nodeName })">{{ vol.Name }}</a>
+                  <a authorization="DockerAgentBrowseList"
+                    ui-sref="docker.volumes.volume.browse({ id: vol.Name, nodeName: nodeName })"
+                    class="btn btn-xs btn-primary space-left"
+                    ng-if="showBrowseAction">
+                    <i class="fa fa-search"></i> browse</a>
+                  </a>
+                </td>
                 <td>{{ vol.Destination }}</td>
               </tr>
             </tbody>

--- a/app/docker/views/volumes/edit/volume.html
+++ b/app/docker/views/volumes/edit/volume.html
@@ -16,6 +16,12 @@
               <td>ID</td>
               <td>
                 {{ volume.Id }}
+                <a authorization="DockerAgentBrowseList"
+                  ui-sref="docker.volumes.volume.browse({ id: volume.Id, nodeName: nodeName })"
+                  class="btn btn-xs btn-primary space-left"
+                  ng-if="showBrowseAction">
+                  <i class="fa fa-search"></i> Browse</a>
+                </a>
                 <button authorization="DockerVolumeDelete" class="btn btn-xs btn-danger" ng-click="removeVolume()"><i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove this volume</button>
               </td>
             </tr>


### PR DESCRIPTION
Closes #2265

Added to the following views the same "browse" button used by the `volumesDatatable` component that allows the user to browse files in a volume:

**Volume details view**
![Volume details](https://i.imgur.com/Rp3sFZw.png)

**Container details view**
![Container details](https://i.imgur.com/ljOa6ra.png)

The buttons use the authorization `DockerAgentBrowseList` and are only shown when these both expressions are true:
- `!EndpointProvider.offlineMode()`
- `StateManager.getState().endpoint.mode.agentProxy`
