### PR TITLE
fix(http): Add semicolon to the end of X-XSS-Protection header to avo…

### DIFF
--- a/api/http/handler/file/handler.go
+++ b/api/http/handler/file/handler.go
@@ -34,7 +34,7 @@ func (handler *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}
 
-	w.Header().Add("X-XSS-Protection", "1; mode=block")
+	w.Header().Add("X-XSS-Protection", "1; mode=block;")
 	w.Header().Add("X-Content-Type-Options", "nosniff")
 	handler.Handler.ServeHTTP(w, r)
 }

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -299,7 +299,7 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 // mwSecureHeaders provides secure headers middleware for handlers.
 func mwSecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
+		w.Header().Add("X-XSS-Protection", "1; mode=block;")
 		w.Header().Add("X-Content-Type-Options", "nosniff")
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Closes #3152
When portainer is hosted behind another Nginx server that defines its own X-XSS-Protection header then those two headers get merged by in the browser (Chrome in my case). Since your version of the header doesnt have semicolon in the end it will cause an error and force Chrome to ignore both headers.

This simple fix adds the semicolons so browsers can correctly parse duplicate headers.
Below is a screen shot of the error this fix is meant to solve
![error-message](https://user-images.githubusercontent.com/10545187/64488104-5eb86100-d24c-11e9-8866-92b1f3ce33d7.PNG)
