### PR TITLE
fix(api): remove automatic backend failure for Down endpoints

### DIFF
--- a/api/http/handler/endpointproxy/proxy_docker.go
+++ b/api/http/handler/endpointproxy/proxy_docker.go
@@ -25,10 +25,6 @@ func (handler *Handler) proxyRequestsToDockerAPI(w http.ResponseWriter, r *http.
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
 	}
 
-	if endpoint.Type != portainer.EdgeAgentEnvironment && endpoint.Status == portainer.EndpointStatusDown {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Unable to query endpoint", errors.New("Endpoint is down")}
-	}
-
 	err = handler.requestBouncer.AuthorizedEndpointOperation(r, endpoint, true)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access endpoint", err}

--- a/app/portainer/views/home/homeController.js
+++ b/app/portainer/views/home/homeController.js
@@ -18,7 +18,8 @@ angular.module('portainer.app')
         }
 
         checkEndpointStatus(endpoint)
-          .then(function success() {
+          .then(function success(data) {
+            endpoint = data;
             return switchToDockerEndpoint(endpoint);
           }).catch(function error(err) {
             Notifications.error('Failure', err, 'Unable to verify endpoint status');
@@ -59,6 +60,7 @@ angular.module('portainer.app')
 
             EndpointService.updateEndpoint(endpoint.Id, { Status: status })
               .then(function success() {
+                endpoint.Status = status;
                 deferred.resolve(endpoint);
               }).catch(function error(err) {
                 deferred.reject({ msg: 'Unable to update endpoint status', err: err });


### PR DESCRIPTION
Closes #3088 

It is worth noting that this PR removes the automatic "Endpoint is down" error response returned by the backend each time a request was sent against an endpoint with a status set to Down.

Instead, we let the request go through the remote API (agent/docker) and returns the response from the remote.