### PR TITLE
fix(home): refresh the view on endpoint ping failure

### DIFF
--- a/api/http/handler/endpointproxy/proxy_docker.go
+++ b/api/http/handler/endpointproxy/proxy_docker.go
@@ -25,10 +25,6 @@ func (handler *Handler) proxyRequestsToDockerAPI(w http.ResponseWriter, r *http.
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
 	}
 
-	if endpoint.Type != portainer.EdgeAgentEnvironment && endpoint.Status == portainer.EndpointStatusDown {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Unable to query endpoint", errors.New("Endpoint is down")}
-	}
-
 	err = handler.requestBouncer.AuthorizedEndpointOperation(r, endpoint, true)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access endpoint", err}

--- a/app/portainer/views/home/homeController.js
+++ b/app/portainer/views/home/homeController.js
@@ -127,6 +127,7 @@ angular.module('portainer.app')
           })
           .catch(function error(err) {
             Notifications.error('Failure', err, 'Unable to connect to the Docker endpoint');
+            $state.reload();
           })
           .finally(function final() {
             $scope.state.connectingToEdgeEndpoint = false;

--- a/app/portainer/views/home/homeController.js
+++ b/app/portainer/views/home/homeController.js
@@ -18,7 +18,8 @@ angular.module('portainer.app')
         }
 
         checkEndpointStatus(endpoint)
-          .then(function success() {
+          .then(function success(data) {
+            endpoint = data;
             return switchToDockerEndpoint(endpoint);
           }).catch(function error(err) {
             Notifications.error('Failure', err, 'Unable to verify endpoint status');
@@ -59,6 +60,7 @@ angular.module('portainer.app')
 
             EndpointService.updateEndpoint(endpoint.Id, { Status: status })
               .then(function success() {
+                endpoint.Status = status;
                 deferred.resolve(endpoint);
               }).catch(function error(err) {
                 deferred.reject({ msg: 'Unable to update endpoint status', err: err });


### PR DESCRIPTION
Closes #3083 

Note: This implementation is based on https://github.com/portainer/portainer/pull/3160 and should be tested after this one has been validated.