### PR TITLE
feat(api): trigger user authorization update when required

### DIFF
--- a/api/authorizations.go
+++ b/api/authorizations.go
@@ -27,6 +27,7 @@ func NewAuthorizationService(parameters *AuthorizationServiceParameters) *Author
 	return &AuthorizationService{
 		endpointService:       parameters.EndpointService,
 		endpointGroupService:  parameters.EndpointGroupService,
+		registryService:       parameters.RegistryService,
 		roleService:           parameters.RoleService,
 		teamMembershipService: parameters.TeamMembershipService,
 		userService:           parameters.UserService,

--- a/api/bolt/migrator/migrate_dbversion19.go
+++ b/api/bolt/migrator/migrate_dbversion19.go
@@ -6,6 +6,7 @@ func (m *Migrator) updateUsersToDBVersion20() error {
 	authorizationServiceParameters := &portainer.AuthorizationServiceParameters{
 		EndpointService:       m.endpointService,
 		EndpointGroupService:  m.endpointGroupService,
+		RegistryService:       m.registryService,
 		RoleService:           m.roleService,
 		TeamMembershipService: m.teamMembershipService,
 		UserService:           m.userService,

--- a/api/bolt/migrator/migrate_dbversion19.go
+++ b/api/bolt/migrator/migrate_dbversion19.go
@@ -3,11 +3,6 @@ package migrator
 import portainer "github.com/portainer/portainer/api"
 
 func (m *Migrator) updateUsersToDBVersion20() error {
-	legacyUsers, err := m.userService.Users()
-	if err != nil {
-		return err
-	}
-
 	authorizationServiceParameters := &portainer.AuthorizationServiceParameters{
 		EndpointService:       m.endpointService,
 		EndpointGroupService:  m.endpointGroupService,
@@ -17,13 +12,5 @@ func (m *Migrator) updateUsersToDBVersion20() error {
 	}
 
 	authorizationService := portainer.NewAuthorizationService(authorizationServiceParameters)
-
-	for _, user := range legacyUsers {
-		err := authorizationService.UpdateUserAuthorizations(user.ID)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return authorizationService.UpdateUsersAuthorizations()
 }

--- a/api/http/handler/endpointgroups/endpointgroup_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_delete.go
@@ -37,13 +37,22 @@ func (handler *Handler) endpointGroupDelete(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve endpoints from the database", err}
 	}
 
+	updateAuthorizations := false
 	for _, endpoint := range endpoints {
 		if endpoint.GroupID == portainer.EndpointGroupID(endpointGroupID) {
+			updateAuthorizations = true
 			endpoint.GroupID = portainer.EndpointGroupID(1)
 			err = handler.EndpointService.UpdateEndpoint(endpoint.ID, &endpoint)
 			if err != nil {
 				return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update endpoint", err}
 			}
+		}
+	}
+
+	if updateAuthorizations {
+		err = handler.AuthorizationService.UpdateUsersAuthorizations()
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
 		}
 	}
 

--- a/api/http/handler/endpointgroups/endpointgroup_update.go
+++ b/api/http/handler/endpointgroups/endpointgroup_update.go
@@ -2,6 +2,7 @@ package endpointgroups
 
 import (
 	"net/http"
+	"reflect"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
@@ -54,12 +55,12 @@ func (handler *Handler) endpointGroupUpdate(w http.ResponseWriter, r *http.Reque
 	}
 
 	updateAuthorizations := false
-	if payload.UserAccessPolicies != nil {
+	if payload.UserAccessPolicies != nil && !reflect.DeepEqual(payload.UserAccessPolicies, endpointGroup.UserAccessPolicies) {
 		endpointGroup.UserAccessPolicies = payload.UserAccessPolicies
 		updateAuthorizations = true
 	}
 
-	if payload.TeamAccessPolicies != nil {
+	if payload.TeamAccessPolicies != nil && !reflect.DeepEqual(payload.TeamAccessPolicies, endpointGroup.TeamAccessPolicies) {
 		endpointGroup.TeamAccessPolicies = payload.TeamAccessPolicies
 		updateAuthorizations = true
 	}
@@ -70,7 +71,7 @@ func (handler *Handler) endpointGroupUpdate(w http.ResponseWriter, r *http.Reque
 	}
 
 	if updateAuthorizations {
-		err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&payload.UserAccessPolicies, &payload.TeamAccessPolicies)
+		err = handler.AuthorizationService.UpdateUsersAuthorizations()
 		if err != nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
 		}

--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -192,9 +192,9 @@ func (handler *Handler) createAzureEndpoint(payload *endpointCreatePayload) (*po
 		Snapshots:          []portainer.Snapshot{},
 	}
 
-	err = handler.EndpointService.CreateEndpoint(endpoint)
+	err = handler.saveEndpointAndUpdateAuthorizations(endpoint)
 	if err != nil {
-		return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist endpoint inside the database", err}
+		return nil, &httperror.HandlerError{http.StatusInternalServerError, "An error occured while trying to create the endpoint", err}
 	}
 
 	return endpoint, nil
@@ -238,9 +238,9 @@ func (handler *Handler) createEdgeAgentEndpoint(payload *endpointCreatePayload) 
 		EdgeKey:         edgeKey,
 	}
 
-	err = handler.EndpointService.CreateEndpoint(endpoint)
+	err = handler.saveEndpointAndUpdateAuthorizations(endpoint)
 	if err != nil {
-		return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist endpoint inside the database", err}
+		return nil, &httperror.HandlerError{http.StatusInternalServerError, "An error occured while trying to create the endpoint", err}
 	}
 
 	return endpoint, nil
@@ -354,9 +354,27 @@ func (handler *Handler) snapshotAndPersistEndpoint(endpoint *portainer.Endpoint)
 		endpoint.Snapshots = []portainer.Snapshot{*snapshot}
 	}
 
-	err = handler.EndpointService.CreateEndpoint(endpoint)
+	err = handler.saveEndpointAndUpdateAuthorizations(endpoint)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist endpoint inside the database", err}
+		return &httperror.HandlerError{http.StatusInternalServerError, "An error occured while trying to create the endpoint", err}
+	}
+
+	return nil
+}
+
+func (handler *Handler) saveEndpointAndUpdateAuthorizations(endpoint *portainer.Endpoint) error {
+	err := handler.EndpointService.CreateEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+
+	group, err := handler.EndpointGroupService.EndpointGroup(endpoint.GroupID)
+	if err != nil {
+		return err
+	}
+
+	if len(group.UserAccessPolicies) > 0 || len(group.TeamAccessPolicies) > 0 {
+		return handler.AuthorizationService.UpdateUsersAuthorizations()
 	}
 
 	return nil

--- a/api/http/handler/endpoints/endpoint_delete.go
+++ b/api/http/handler/endpoints/endpoint_delete.go
@@ -43,5 +43,12 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 
 	handler.ProxyManager.DeleteProxy(endpoint)
 
+	if len(endpoint.UserAccessPolicies) > 0 || len(endpoint.TeamAccessPolicies) > 0 {
+		err = handler.AuthorizationService.UpdateUsersAuthorizations()
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
+		}
+	}
+
 	return response.Empty(w)
 }

--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"net/http"
+	"reflect"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -77,12 +78,12 @@ func (handler *Handler) endpointUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	updateAuthorizations := false
-	if payload.UserAccessPolicies != nil {
+	if payload.UserAccessPolicies != nil && !reflect.DeepEqual(payload.UserAccessPolicies, endpoint.UserAccessPolicies) {
 		endpoint.UserAccessPolicies = payload.UserAccessPolicies
 		updateAuthorizations = true
 	}
 
-	if payload.TeamAccessPolicies != nil {
+	if payload.TeamAccessPolicies != nil && !reflect.DeepEqual(payload.TeamAccessPolicies, endpoint.TeamAccessPolicies) {
 		endpoint.TeamAccessPolicies = payload.TeamAccessPolicies
 		updateAuthorizations = true
 	}
@@ -177,7 +178,7 @@ func (handler *Handler) endpointUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if updateAuthorizations {
-		err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&payload.UserAccessPolicies, &payload.TeamAccessPolicies)
+		err = handler.AuthorizationService.UpdateUsersAuthorizations()
 		if err != nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
 		}

--- a/api/http/handler/extensions/upgrade.go
+++ b/api/http/handler/extensions/upgrade.go
@@ -36,10 +36,10 @@ func (handler *Handler) upgradeRBACData() error {
 			return err
 		}
 
-		err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&endpointGroup.UserAccessPolicies, &endpointGroup.TeamAccessPolicies)
-		if err != nil {
-			return err
-		}
+		//err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&endpointGroup.UserAccessPolicies, &endpointGroup.TeamAccessPolicies)
+		//if err != nil {
+		//	return err
+		//}
 	}
 
 	endpoints, err := handler.EndpointService.Endpoints()
@@ -61,10 +61,13 @@ func (handler *Handler) upgradeRBACData() error {
 			return err
 		}
 
-		err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&endpoint.UserAccessPolicies, &endpoint.TeamAccessPolicies)
-		if err != nil {
-			return err
-		}
+		//err = handler.AuthorizationService.UpdateUserAuthorizationsFromPolicies(&endpoint.UserAccessPolicies, &endpoint.TeamAccessPolicies)
+		//if err != nil {
+		//	return err
+		//}
 	}
-	return nil
+
+	return handler.AuthorizationService.UpdateUsersAuthorizations()
+
+	//return nil
 }

--- a/api/http/handler/teammemberships/handler.go
+++ b/api/http/handler/teammemberships/handler.go
@@ -13,8 +13,8 @@ import (
 // Handler is the HTTP handler used to handle team membership operations.
 type Handler struct {
 	*mux.Router
-	TeamMembershipService  portainer.TeamMembershipService
-	ResourceControlService portainer.ResourceControlService
+	TeamMembershipService portainer.TeamMembershipService
+	AuthorizationService  *portainer.AuthorizationService
 }
 
 // NewHandler creates a handler to manage team membership operations.

--- a/api/http/handler/teammemberships/teammembership_create.go
+++ b/api/http/handler/teammemberships/teammembership_create.go
@@ -70,5 +70,10 @@ func (handler *Handler) teamMembershipCreate(w http.ResponseWriter, r *http.Requ
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist team memberships inside the database", err}
 	}
 
+	err = handler.AuthorizationService.UpdateUsersAuthorizations()
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
+	}
+
 	return response.JSON(w, membership)
 }

--- a/api/http/handler/teammemberships/teammembership_delete.go
+++ b/api/http/handler/teammemberships/teammembership_delete.go
@@ -38,5 +38,10 @@ func (handler *Handler) teamMembershipDelete(w http.ResponseWriter, r *http.Requ
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove the team membership from the database", err}
 	}
 
+	err = handler.AuthorizationService.UpdateUsersAuthorizations()
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to update user authorizations", err}
+	}
+
 	return response.Empty(w)
 }

--- a/api/http/handler/teams/handler.go
+++ b/api/http/handler/teams/handler.go
@@ -12,9 +12,9 @@ import (
 // Handler is the HTTP handler used to handle team operations.
 type Handler struct {
 	*mux.Router
-	TeamService            portainer.TeamService
-	TeamMembershipService  portainer.TeamMembershipService
-	ResourceControlService portainer.ResourceControlService
+	TeamService           portainer.TeamService
+	TeamMembershipService portainer.TeamMembershipService
+	AuthorizationService  *portainer.AuthorizationService
 }
 
 // NewHandler creates a handler to manage team operations.

--- a/api/http/handler/teams/team_delete.go
+++ b/api/http/handler/teams/team_delete.go
@@ -33,5 +33,10 @@ func (handler *Handler) teamDelete(w http.ResponseWriter, r *http.Request) *http
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to delete associated team memberships from the database", err}
 	}
 
+	err = handler.AuthorizationService.RemoveTeamAccessPolicies(portainer.TeamID(teamID))
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to clean-up team access policies", err}
+	}
+
 	return response.Empty(w)
 }

--- a/api/http/handler/users/handler.go
+++ b/api/http/handler/users/handler.go
@@ -23,6 +23,7 @@ type Handler struct {
 	ResourceControlService portainer.ResourceControlService
 	CryptoService          portainer.CryptoService
 	SettingsService        portainer.SettingsService
+	AuthorizationService   *portainer.AuthorizationService
 }
 
 // NewHandler creates a handler to manage user operations.

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -75,5 +75,10 @@ func (handler *Handler) deleteUser(w http.ResponseWriter, user *portainer.User) 
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user memberships from the database", err}
 	}
 
+	err = handler.AuthorizationService.RemoveUserAccessPolicies(user.ID)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to clean-up user access policies", err}
+	}
+
 	return response.Empty(w)
 }

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -65,12 +65,12 @@ func (handler *Handler) deleteAdminUser(w http.ResponseWriter, user *portainer.U
 }
 
 func (handler *Handler) deleteUser(w http.ResponseWriter, user *portainer.User) *httperror.HandlerError {
-	err := handler.UserService.DeleteUser(portainer.UserID(user.ID))
+	err := handler.UserService.DeleteUser(user.ID)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user from the database", err}
 	}
 
-	err = handler.TeamMembershipService.DeleteTeamMembershipByUserID(portainer.UserID(user.ID))
+	err = handler.TeamMembershipService.DeleteTeamMembershipByUserID(user.ID)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user memberships from the database", err}
 	}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -97,6 +97,7 @@ func (server *Server) Start() error {
 	authorizationServiceParameters := &portainer.AuthorizationServiceParameters{
 		EndpointService:       server.EndpointService,
 		EndpointGroupService:  server.EndpointGroupService,
+		RegistryService:       server.RegistryService,
 		RoleService:           server.RoleService,
 		TeamMembershipService: server.TeamMembershipService,
 		UserService:           server.UserService,

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -213,9 +213,12 @@ func (server *Server) Start() error {
 	var teamHandler = teams.NewHandler(requestBouncer)
 	teamHandler.TeamService = server.TeamService
 	teamHandler.TeamMembershipService = server.TeamMembershipService
+	teamHandler.AuthorizationService = authorizationService
 
 	var teamMembershipHandler = teammemberships.NewHandler(requestBouncer)
 	teamMembershipHandler.TeamMembershipService = server.TeamMembershipService
+	teamMembershipHandler.AuthorizationService = authorizationService
+
 	var statusHandler = status.NewHandler(requestBouncer, server.Status)
 
 	var templatesHandler = templates.NewHandler(requestBouncer)
@@ -232,6 +235,7 @@ func (server *Server) Start() error {
 	userHandler.CryptoService = server.CryptoService
 	userHandler.ResourceControlService = server.ResourceControlService
 	userHandler.SettingsService = server.SettingsService
+	userHandler.AuthorizationService = authorizationService
 
 	var websocketHandler = websocket.NewHandler(requestBouncer)
 	websocketHandler.EndpointService = server.EndpointService


### PR DESCRIPTION
The user authorizations were not correctly updated introducing some issues reported in https://github.com/portainer/portainer/issues/2960#issuecomment-537311641

User authorizations are now updated when:

* An access policy on a group has changed (created, updated, deleted)
* An access policy on an endpoint has changed (created, updated, deleted)
* An endpoint has been created that is part of a group with existing access policies associated
* An endpoint group is removed, reassigning access policies associated to the Unassigned default endpoint group
* A user is added to a team
* A user is removed from a team

A clean-up of access policies is also triggered when:

* A user is removed
* A team is removed

This will remove existing access policies associated to the user/team for endpoints/endpoint groups/registries.

Closes #2960 