### PR TITLE
#2844 fix(cli): remove the logging of the hashed password of the admin user

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -639,7 +639,7 @@ func main() {
 		}
 
 		if len(users) == 0 {
-			log.Printf("Creating admin user with password hash %s", adminPasswordHash)
+			log.Println("Created admin user with the given password.")
 			user := &portainer.User{
 				Username:                "admin",
 				Role:                    portainer.AdministratorRole,


### PR DESCRIPTION
remove the logging of the hashed password on an 
admin user creation as referenced in issue #2844 .

Closes #2844 