### PR TITLE
fix #3144: convert localhost to 127.0.0.1

### DIFF
--- a/api/chisel/service.go
+++ b/api/chisel/service.go
@@ -179,7 +179,7 @@ func (service *Service) snapshotEnvironment(endpointID portainer.EndpointID, tun
 	}
 
 	endpointURL := endpoint.URL
-	endpoint.URL = fmt.Sprintf("tcp://localhost:%d", tunnelPort)
+	endpoint.URL = fmt.Sprintf("tcp://127.0.0.1:%d", tunnelPort)
 	snapshot, err := service.snapshotter.CreateSnapshot(endpoint)
 	if err != nil {
 		return err

--- a/api/docker/client.go
+++ b/api/docker/client.go
@@ -81,7 +81,7 @@ func createEdgeClient(endpoint *portainer.Endpoint, reverseTunnelService portain
 	}
 
 	tunnel := reverseTunnelService.GetTunnelDetails(endpoint.ID)
-	endpointURL := fmt.Sprintf("http://localhost:%d", tunnel.Port)
+	endpointURL := fmt.Sprintf("http://127.0.0.1:%d", tunnel.Port)
 
 	return client.NewClientWithOpts(
 		client.WithHost(endpointURL),

--- a/api/exec/swarm_stack.go
+++ b/api/exec/swarm_stack.go
@@ -123,7 +123,7 @@ func (manager *SwarmStackManager) prepareDockerCommandAndArgs(binaryPath, dataPa
 	endpointURL := endpoint.URL
 	if endpoint.Type == portainer.EdgeAgentEnvironment {
 		tunnel := manager.reverseTunnelService.GetTunnelDetails(endpoint.ID)
-		endpointURL = fmt.Sprintf("tcp://localhost:%d", tunnel.Port)
+		endpointURL = fmt.Sprintf("tcp://127.0.0.1:%d", tunnel.Port)
 	}
 
 	args = append(args, "-H", endpointURL)

--- a/api/http/handler/websocket/proxy.go
+++ b/api/http/handler/websocket/proxy.go
@@ -14,7 +14,7 @@ import (
 func (handler *Handler) proxyEdgeAgentWebsocketRequest(w http.ResponseWriter, r *http.Request, params *webSocketRequestParams) error {
 	tunnel := handler.ReverseTunnelService.GetTunnelDetails(params.endpoint.ID)
 
-	endpointURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", tunnel.Port))
+	endpointURL, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", tunnel.Port))
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker.go
+++ b/api/http/proxy/factory/docker.go
@@ -34,7 +34,7 @@ func (factory *ProxyFactory) newDockerLocalProxy(endpoint *portainer.Endpoint) (
 func (factory *ProxyFactory) newDockerHTTPProxy(endpoint *portainer.Endpoint) (http.Handler, error) {
 	if endpoint.Type == portainer.EdgeAgentEnvironment {
 		tunnel := factory.reverseTunnelService.GetTunnelDetails(endpoint.ID)
-		endpoint.URL = fmt.Sprintf("http://localhost:%d", tunnel.Port)
+		endpoint.URL = fmt.Sprintf("http://127.0.0.1:%d", tunnel.Port)
 	}
 
 	endpointURL, err := url.Parse(endpoint.URL)

--- a/api/libcompose/compose_stack.go
+++ b/api/libcompose/compose_stack.go
@@ -39,7 +39,7 @@ func (manager *ComposeStackManager) createClient(endpoint *portainer.Endpoint) (
 	endpointURL := endpoint.URL
 	if endpoint.Type == portainer.EdgeAgentEnvironment {
 		tunnel := manager.reverseTunnelService.GetTunnelDetails(endpoint.ID)
-		endpointURL = fmt.Sprintf("tcp://localhost:%d", tunnel.Port)
+		endpointURL = fmt.Sprintf("tcp://127.0.0.1:%d", tunnel.Port)
 	}
 
 	clientOpts := client.Options{

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -941,7 +941,7 @@ const (
 	// to be used when communicating with an agent
 	PortainerAgentSignatureMessage = "Portainer-App"
 	// ExtensionServer represents the server used by Portainer to communicate with extensions
-	ExtensionServer = "localhost"
+	ExtensionServer = "127.0.0.1"
 	// DefaultEdgeAgentCheckinIntervalInSeconds represents the default interval (in seconds) used by Edge agents to checkin with the Portainer instance
 	DefaultEdgeAgentCheckinIntervalInSeconds = 5
 	// LocalExtensionManifestFile represents the name of the local manifest file for extensions


### PR DESCRIPTION
This commit changes all instances of "localhost" in Go code to fix #3144.

Should fully resolve the issue until the IETF localhost draft becomes adopted. 