### PR TITLE
fix(container-details): table word-break ui (#3430)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -141,7 +141,6 @@ a[ng-click]{
 
 .widget .widget-body table tbody td {
   white-space: normal;
-  word-break: break-word;
 }
 
 .widget .widget-body table.description-table {


### PR DESCRIPTION
Closes #3430 

Table UI looks broken when a container has large env variables.

![tela](https://user-images.githubusercontent.com/20758876/70242263-4b376c00-174f-11ea-8a45-f970fa0d05aa.png)
