### PR TITLE
fix(app): config no support unicode character

### DIFF
--- a/app/docker/models/config.js
+++ b/app/docker/models/config.js
@@ -7,7 +7,7 @@ export function ConfigViewModel(data) {
   this.Version = data.Version.Index;
   this.Name = data.Spec.Name;
   this.Labels = data.Spec.Labels;
-  this.Data = atob(data.Spec.Data);
+  this.Data = decodeURIComponent(escape(atob(data.Spec.Data)));
 
   if (data.Portainer && data.Portainer.ResourceControl) {
     this.ResourceControl = new ResourceControlViewModel(data.Portainer.ResourceControl);


### PR DESCRIPTION
window.atob no support unicode character

see:  https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings

Not the best but simple