### PR TITLE
feat(authentication/ldap): implement anonymous mode for LDAP connection

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -259,6 +259,7 @@ func initSettings(settingsService portainer.SettingsService, flags *portainer.CL
 			LogoURL:              *flags.Logo,
 			AuthenticationMethod: portainer.AuthenticationInternal,
 			LDAPSettings: portainer.LDAPSettings{
+				AnonymousMode: true,
 				AutoCreateUsers: true,
 				TLSConfig:       portainer.TLSConfiguration{},
 				SearchSettings: []portainer.LDAPSearchSettings{

--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -92,9 +92,11 @@ func (*Service) AuthenticateUser(username, password string, settings *portainer.
 	}
 	defer connection.Close()
 
-	err = connection.Bind(settings.ReaderDN, settings.Password)
-	if err != nil {
-		return err
+	if !settings.AnonymousMode {
+		err = connection.Bind(settings.ReaderDN, settings.Password)
+		if err != nil {
+			return err
+		}
 	}
 
 	userDN, err := searchUser(username, connection, settings.SearchSettings)
@@ -118,9 +120,11 @@ func (*Service) GetUserGroups(username string, settings *portainer.LDAPSettings)
 	}
 	defer connection.Close()
 
-	err = connection.Bind(settings.ReaderDN, settings.Password)
-	if err != nil {
-		return nil, err
+	if !settings.AnonymousMode {
+		err = connection.Bind(settings.ReaderDN, settings.Password)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	userDN, err := searchUser(username, connection, settings.SearchSettings)
@@ -174,9 +178,11 @@ func (*Service) TestConnectivity(settings *portainer.LDAPSettings) error {
 	}
 	defer connection.Close()
 
-	err = connection.Bind(settings.ReaderDN, settings.Password)
-	if err != nil {
-		return err
+	if !settings.AnonymousMode {
+		err = connection.Bind(settings.ReaderDN, settings.Password)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -50,6 +50,7 @@ type (
 
 	// LDAPSettings represents the settings used to connect to a LDAP server
 	LDAPSettings struct {
+		AnonymousMode       bool                      `json:"AnonymousMode"`
 		ReaderDN            string                    `json:"ReaderDN"`
 		Password            string                    `json:"Password,omitempty"`
 		URL                 string                    `json:"URL"`

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3296,6 +3296,10 @@ definitions:
   LDAPSettings:
     type: "object"
     properties:
+      AnonymousMode:
+        type: "boolean"
+        example: true
+        description: "Enable this option if the server is configured for Anonymous access. When enabled, ReaderDN and Password will not be used."
       ReaderDN:
         type: "string"
         example: "cn=readonly-account,dc=ldap,dc=domain,dc=tld"


### PR DESCRIPTION
* When enabled, ReaderDN and Password will not be used
* Anonymous mode is set to `true` by default on fresh installations

**Pending:** bolt database migration logic (if any is necessary)

API changes to fix #3443 and to complement #3456
