### PR TITLE
limit only on request failure

### DIFF
--- a/api/http/security/rate_limiter.go
+++ b/api/http/security/rate_limiter.go
@@ -7,8 +7,27 @@ import (
 
 	"github.com/g07cha/defender"
 	httperror "github.com/portainer/libhttp/error"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 )
+
+// CatchStatusCodeResponseWriter implement ResponseWriter interface but also expose HTTP status code
+type CatchStatusCodeResponseWriter struct {
+	http.ResponseWriter
+	StatusCode int
+}
+
+// NewCatchStatusCodeResponseWriter initialize a CatchStatusCodeResponseWriter from a ResponseWriter
+func NewCatchStatusCodeResponseWriter(w http.ResponseWriter) *CatchStatusCodeResponseWriter {
+	// WriteHeader(int) is not called if our response implicitly returns 200 OK, so
+	// we default to that status code.
+	return &CatchStatusCodeResponseWriter{w, http.StatusOK}
+}
+
+// WriteHeader overload ResponseWriter method in order to store the status code
+func (rrw *CatchStatusCodeResponseWriter) WriteHeader(code int) {
+	rrw.StatusCode = code
+	rrw.ResponseWriter.WriteHeader(code)
+}
 
 // RateLimiter represents an entity that manages request rate limiting
 type RateLimiter struct {
@@ -25,15 +44,28 @@ func NewRateLimiter(maxRequests int, duration time.Duration, banDuration time.Du
 	}
 }
 
+// IsBanned return true if given IP is banned
+func (limiter *RateLimiter) IsBanned(ip interface{}) bool {
+	c, ok := limiter.Client(ip)
+	if ok {
+		return c.Banned()
+	}
+	return false
+}
+
 // LimitAccess wraps current request with check if remote address does not goes above the defined limits
 func (limiter *RateLimiter) LimitAccess(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := StripAddrPort(r.RemoteAddr)
-		if banned := limiter.Inc(ip); banned == true {
+		if limiter.IsBanned(ip) {
 			httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrResourceAccessDenied)
 			return
 		}
-		next.ServeHTTP(w, r)
+		rw := NewCatchStatusCodeResponseWriter(w)
+		next.ServeHTTP(rw, r)
+		if rw.StatusCode >= 400 {
+			limiter.Inc(ip)
+		}
 	})
 }
 


### PR DESCRIPTION
fix #3092 

With this PR the `RateLimiter` increment only on request failure (>= 400 status code). Maybe it should be renamed according to this, something like `FailureRateLimiter`.

Let me know your thoughts.