### PR TITLE
Feat3520 sort env vars

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -406,7 +406,8 @@ function ($q, $scope, $async, $state, $timeout, $transition$, $filter, Container
         envArr.push({'name': arr[0], 'value': arr[1]});
       }
     }
-    $scope.config.Env = envArr;
+    // Sort ENV VARs to improve readability.
+    $scope.config.Env = _.sortBy(envArr, ['name']);
   }
 
   function loadFromContainerLabels() {

--- a/app/docker/views/containers/edit/containerController.js
+++ b/app/docker/views/containers/edit/containerController.js
@@ -1,3 +1,4 @@
+import _ from 'lodash-es';
 import moment from 'moment';
 import { PorImageRegistryModel } from 'Docker/models/porImageRegistry';
 
@@ -32,6 +33,8 @@ function ($q, $scope, $state, $transition$, $filter, $async, ExtensionService, C
       $scope.container = container;
       $scope.container.edit = false;
       $scope.container.newContainerName = $filter('trimcontainername')(container.Name);
+      // Sort ENV VARs (here, "key=value") to improve readability.
+      $scope.container.Config.Env = _.sortBy(container.Config.Env);
 
       if (container.State.Running) {
         $scope.activityTime = moment.duration(moment(container.State.StartedAt).utc().diff(moment().utc())).humanize();

--- a/app/docker/views/images/edit/imageController.js
+++ b/app/docker/views/images/edit/imageController.js
@@ -139,6 +139,8 @@ function ($q, $scope, $transition$, $state, $timeout, ImageService, ImageHelper,
 			history: endpointProvider !== 'VMWARE_VIC' ? ImageService.history($transition$.params().id) : []
 		})
 		.then(function success(data) {
+			// Sort ENV VARs (here, "key=value") to improve readability.
+			data.image.Env = _.sortBy(data.image.Env);
 			$scope.image = data.image;
 			$scope.history = data.history;
 		})

--- a/app/extensions/registry-management/views/repositories/tag/registryRepositoryTagController.js
+++ b/app/extensions/registry-management/views/repositories/tag/registryRepositoryTagController.js
@@ -44,6 +44,8 @@ class RegistryRepositoryTagController {
       this.history = _.map(this.tag.History, (layer, idx) => new RegistryImageLayerViewModel(length - idx, layer));
       _.forEach(this.history, (item) => item.CreatedBy = this.imagelayercommandFilter(item.CreatedBy))
       this.details = new RegistryImageDetailsViewModel(this.tag.History[0]);
+      // Sort ENV VARs (here, "key=value") to improve readability.
+      this.details.Env = _.sortBy(this.details.Env);
     } catch (error) {
       this.Notifications.error('Failure', error, 'Unable to retrieve tag')
     }

--- a/app/portainer/views/stacks/edit/stackController.js
+++ b/app/portainer/views/stacks/edit/stackController.js
@@ -1,3 +1,5 @@
+import _ from 'lodash-es';
+
 angular.module('portainer.app')
 .controller('StackController', ['$q', '$scope', '$state', '$transition$', 'StackService', 'NodeService', 'ServiceService', 'TaskService', 'ContainerService', 'ServiceHelper', 'TaskHelper', 'Notifications', 'FormHelper', 'EndpointProvider', 'EndpointService', 'GroupService', 'ModalService',
 function ($q, $scope, $state, $transition$, StackService, NodeService, ServiceService, TaskService, ContainerService, ServiceHelper, TaskHelper, Notifications, FormHelper, EndpointProvider, EndpointService, GroupService, ModalService) {
@@ -172,6 +174,8 @@ function ($q, $scope, $state, $transition$, StackService, NodeService, ServiceSe
     })
     .then(function success(data) {
       var stack = data.stack;
+      // Sort ENV VARs to improve readability.
+      stack.Env = _.sortBy(stack.Env, ['name']);
       $scope.groups = data.groups;
       $scope.stack = stack;
 

--- a/app/portainer/views/templates/edit/templateController.js
+++ b/app/portainer/views/templates/edit/templateController.js
@@ -41,6 +41,8 @@ function ($q, $scope, $state, $transition$, TemplateService, TemplateHelper, Net
     })
     .then(function success(data) {
       var template = data.template;
+      // Sort ENV VARs to improve readability.
+      template.Env = _.sortBy(template.Env, ['name']);
       if (template.Network) {
         template.Network = _.find(data.networks, function(o) { return o.Name === template.Network; });
       } else {


### PR DESCRIPTION
These commits address #3520 feature as a whole: each commit addresses the feature in a single scope.

Sorting in each scope has been done in the controller and not directly in the view to preserve the UX when adding new empty ENV VARs, at the end of the list.

I'm available to change/rebase what required.

HTH,
Matteo