### PR TITLE
feat(authentication/ldap): preserve ReaderDN in database if empty in settings payload

### DIFF
--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -69,11 +69,16 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.LDAPSettings != nil {
+		ldapReaderDN := settings.LDAPSettings.ReaderDN
 		ldapPassword := settings.LDAPSettings.Password
+		if payload.LDAPSettings.ReaderDN != "" {
+			ldapReaderDN = payload.LDAPSettings.ReaderDN
+		}
 		if payload.LDAPSettings.Password != "" {
 			ldapPassword = payload.LDAPSettings.Password
 		}
 		settings.LDAPSettings = *payload.LDAPSettings
+		settings.LDAPSettings.ReaderDN = ldapReaderDN
 		settings.LDAPSettings.Password = ldapPassword
 	}
 


### PR DESCRIPTION
* Allows to avoid changing any current value when using LDAP Anonymous Mode

Futher API changes to fix #3443 and to complement #3456

See comment: https://github.com/portainer/portainer/pull/3456#issuecomment-577462777