### PR TITLE
Support resource constraints in template definition (portainer#2008)

### DIFF
--- a/api/http/handler/templates/template_create.go
+++ b/api/http/handler/templates/template_create.go
@@ -33,20 +33,20 @@ type templateCreatePayload struct {
 	Repository portainer.TemplateRepository
 
 	// Opt container
-	Registry      		string
-	Command       		string
-	Network       		string
-	Volumes       		[]portainer.TemplateVolume
-	Ports         		[]string
-	Labels        		[]portainer.Pair
-	Privileged    		bool
-	Interactive   		bool
-	RestartPolicy 		string
-	Hostname      		string
-	MemoryLimit   		int
-	MemoryReservation 	int
-	CPULimit      		int
-	ImageTags     		[]string
+	Registry          string
+	Command           string
+	Network           string
+	Volumes           []portainer.TemplateVolume
+	Ports             []string
+	Labels            []portainer.Pair
+	Privileged        bool
+	Interactive       bool
+	RestartPolicy     string
+	Hostname          string
+	MemoryLimit       int
+	MemoryReservation int
+	CPULimit          int
+	ImageTags         []string
 }
 
 func (payload *templateCreatePayload) Validate(r *http.Request) error {
@@ -112,7 +112,7 @@ func (handler *Handler) templateCreate(w http.ResponseWriter, r *http.Request) *
 		template.RestartPolicy = payload.RestartPolicy
 		template.Hostname = payload.Hostname
 		template.MemoryLimit = payload.MemoryLimit
-		template.MemoryReservation 	= payload.MemoryReservation
+		template.MemoryReservation = payload.MemoryReservation
 		template.CPULimit = payload.CPULimit
 		template.ImageTags = payload.ImageTags
 	}

--- a/api/http/handler/templates/template_create.go
+++ b/api/http/handler/templates/template_create.go
@@ -33,16 +33,20 @@ type templateCreatePayload struct {
 	Repository portainer.TemplateRepository
 
 	// Opt container
-	Registry      string
-	Command       string
-	Network       string
-	Volumes       []portainer.TemplateVolume
-	Ports         []string
-	Labels        []portainer.Pair
-	Privileged    bool
-	Interactive   bool
-	RestartPolicy string
-	Hostname      string
+	Registry      		string
+	Command       		string
+	Network       		string
+	Volumes       		[]portainer.TemplateVolume
+	Ports         		[]string
+	Labels        		[]portainer.Pair
+	Privileged    		bool
+	Interactive   		bool
+	RestartPolicy 		string
+	Hostname      		string
+	MemoryLimit   		int
+	MemoryReservation 	int
+	CpuLimit      		int
+	ImageTags     		[]string
 }
 
 func (payload *templateCreatePayload) Validate(r *http.Request) error {
@@ -107,6 +111,10 @@ func (handler *Handler) templateCreate(w http.ResponseWriter, r *http.Request) *
 		template.Interactive = payload.Interactive
 		template.RestartPolicy = payload.RestartPolicy
 		template.Hostname = payload.Hostname
+		template.MemoryLimit = payload.MemoryLimit
+		template.MemoryReservation 	= payload.MemoryReservation
+		template.CpuLimit = payload.CpuLimit
+		template.ImageTags = payload.ImageTags
 	}
 
 	if template.Type == portainer.SwarmStackTemplate || template.Type == portainer.ComposeStackTemplate {

--- a/api/http/handler/templates/template_create.go
+++ b/api/http/handler/templates/template_create.go
@@ -45,7 +45,7 @@ type templateCreatePayload struct {
 	Hostname      		string
 	MemoryLimit   		int
 	MemoryReservation 	int
-	CpuLimit      		int
+	CPULimit      		int
 	ImageTags     		[]string
 }
 
@@ -113,7 +113,7 @@ func (handler *Handler) templateCreate(w http.ResponseWriter, r *http.Request) *
 		template.Hostname = payload.Hostname
 		template.MemoryLimit = payload.MemoryLimit
 		template.MemoryReservation 	= payload.MemoryReservation
-		template.CpuLimit = payload.CpuLimit
+		template.CPULimit = payload.CPULimit
 		template.ImageTags = payload.ImageTags
 	}
 

--- a/api/http/handler/templates/template_update.go
+++ b/api/http/handler/templates/template_update.go
@@ -31,6 +31,10 @@ type templateUpdatePayload struct {
 	Interactive       *bool
 	RestartPolicy     *string
 	Hostname          *string
+	MemoryLimit   	  *int
+	MemoryReservation *int
+	CpuLimit      	  *int
+	ImageTags     	  []string
 }
 
 func (payload *templateUpdatePayload) Validate(r *http.Request) error {
@@ -111,6 +115,23 @@ func updateContainerProperties(template *portainer.Template, payload *templateUp
 	if payload.Hostname != nil {
 		template.Hostname = *payload.Hostname
 	}
+
+	if payload.MemoryLimit != nil {
+		template.MemoryLimit = *payload.MemoryLimit
+	}
+
+	if payload.MemoryReservation != nil {
+		template.MemoryReservation = *payload.MemoryReservation
+	}
+
+	if payload.CpuLimit != nil {
+		template.CpuLimit = *payload.CpuLimit
+	}
+
+	if payload.ImageTags != nil {
+		template.ImageTags = payload.ImageTags
+	}
+
 }
 
 func updateStackProperties(template *portainer.Template, payload *templateUpdatePayload) {

--- a/api/http/handler/templates/template_update.go
+++ b/api/http/handler/templates/template_update.go
@@ -31,10 +31,10 @@ type templateUpdatePayload struct {
 	Interactive       *bool
 	RestartPolicy     *string
 	Hostname          *string
-	MemoryLimit   	  *int
+	MemoryLimit       *int
 	MemoryReservation *int
-	CPULimit      	  *int
-	ImageTags     	  []string
+	CPULimit          *int
+	ImageTags         []string
 }
 
 func (payload *templateUpdatePayload) Validate(r *http.Request) error {

--- a/api/http/handler/templates/template_update.go
+++ b/api/http/handler/templates/template_update.go
@@ -33,7 +33,7 @@ type templateUpdatePayload struct {
 	Hostname          *string
 	MemoryLimit   	  *int
 	MemoryReservation *int
-	CpuLimit      	  *int
+	CPULimit      	  *int
 	ImageTags     	  []string
 }
 
@@ -124,8 +124,8 @@ func updateContainerProperties(template *portainer.Template, payload *templateUp
 		template.MemoryReservation = *payload.MemoryReservation
 	}
 
-	if payload.CpuLimit != nil {
-		template.CpuLimit = *payload.CpuLimit
+	if payload.CPULimit != nil {
+		template.CPULimit = *payload.CPULimit
 	}
 
 	if payload.ImageTags != nil {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -520,17 +520,21 @@ type (
 		Categories []string      `json:"categories,omitempty"`
 
 		// Optional container fields
-		Registry      string           `json:"registry,omitempty"`
-		Command       string           `json:"command,omitempty"`
-		Network       string           `json:"network,omitempty"`
-		Volumes       []TemplateVolume `json:"volumes,omitempty"`
-		Ports         []string         `json:"ports,omitempty"`
-		Labels        []Pair           `json:"labels,omitempty"`
-		Privileged    bool             `json:"privileged,omitempty"`
-		Interactive   bool             `json:"interactive,omitempty"`
-		RestartPolicy string           `json:"restart_policy,omitempty"`
-		Hostname      string           `json:"hostname,omitempty"`
-	}
+		Registry      		string           `json:"registry,omitempty"`
+		Command       		string           `json:"command,omitempty"`
+		Network       		string           `json:"network,omitempty"`
+		Volumes       		[]TemplateVolume `json:"volumes,omitempty"`
+		Ports         		[]string         `json:"ports,omitempty"`
+		Labels        		[]Pair           `json:"labels,omitempty"`
+		Privileged    		bool             `json:"privileged,omitempty"`
+		Interactive   		bool             `json:"interactive,omitempty"`
+		RestartPolicy 		string           `json:"restart_policy,omitempty"`
+		Hostname      		string           `json:"hostname,omitempty"`
+		MemoryLimit   		int           	 `json:"memory_limit,omitempty"`
+		MemoryReservation 	int			 	 `json:"memory_reservation,omitempty"`
+		CpuLimit      		int           	 `json:"cpu_limit,omitempty"`
+		ImageTags     		[]string         `json:"image_tags,omitempty"`
+		}
 
 	// TemplateEnv represents a template environment variable configuration
 	TemplateEnv struct {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -532,7 +532,7 @@ type (
 		Hostname      		string           `json:"hostname,omitempty"`
 		MemoryLimit   		int           	 `json:"memory_limit,omitempty"`
 		MemoryReservation 	int			 	 `json:"memory_reservation,omitempty"`
-		CpuLimit      		int           	 `json:"cpu_limit,omitempty"`
+		CPULimit      		int           	 `json:"cpu_limit,omitempty"`
 		ImageTags     		[]string         `json:"image_tags,omitempty"`
 		}
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -520,21 +520,21 @@ type (
 		Categories []string      `json:"categories,omitempty"`
 
 		// Optional container fields
-		Registry      		string           `json:"registry,omitempty"`
-		Command       		string           `json:"command,omitempty"`
-		Network       		string           `json:"network,omitempty"`
-		Volumes       		[]TemplateVolume `json:"volumes,omitempty"`
-		Ports         		[]string         `json:"ports,omitempty"`
-		Labels        		[]Pair           `json:"labels,omitempty"`
-		Privileged    		bool             `json:"privileged,omitempty"`
-		Interactive   		bool             `json:"interactive,omitempty"`
-		RestartPolicy 		string           `json:"restart_policy,omitempty"`
-		Hostname      		string           `json:"hostname,omitempty"`
-		MemoryLimit   		int           	 `json:"memory_limit,omitempty"`
-		MemoryReservation 	int			 	 `json:"memory_reservation,omitempty"`
-		CPULimit      		int           	 `json:"cpu_limit,omitempty"`
-		ImageTags     		[]string         `json:"image_tags,omitempty"`
-		}
+		Registry          string           `json:"registry,omitempty"`
+		Command           string           `json:"command,omitempty"`
+		Network           string           `json:"network,omitempty"`
+		Volumes           []TemplateVolume `json:"volumes,omitempty"`
+		Ports             []string         `json:"ports,omitempty"`
+		Labels            []Pair           `json:"labels,omitempty"`
+		Privileged        bool             `json:"privileged,omitempty"`
+		Interactive       bool             `json:"interactive,omitempty"`
+		RestartPolicy     string           `json:"restart_policy,omitempty"`
+		Hostname          string           `json:"hostname,omitempty"`
+		MemoryLimit       int              `json:"memory_limit,omitempty"`
+		MemoryReservation int              `json:"memory_reservation,omitempty"`
+		CPULimit          int              `json:"cpu_limit,omitempty"`
+		ImageTags         []string         `json:"image_tags,omitempty"`
+	}
 
 	// TemplateEnv represents a template environment variable configuration
 	TemplateEnv struct {

--- a/app/portainer/components/forms/template-form/templateForm.html
+++ b/app/portainer/components/forms/template-form/templateForm.html
@@ -229,6 +229,37 @@
         </div>
       </div>
       <!-- !hostname -->
+      <div class="form-group">
+        <label for="template_memorylimit" class="col-sm-3 col-lg-2 control-label text-left">
+          Memory Limit (mb)
+          <portainer-tooltip position="bottom" message="Set the amount of memory to allocate to the container. Will use Docker default if not specified or set to 0."></portainer-tooltip>
+        </label>
+        <div class="col-sm-9 col-lg-10">
+          <input type="number" class="form-control" name="template_memorylimit" ng-model="$ctrl.model.MemoryLimit" placeholder="Leave blank or 0 for default value">
+        </div>
+      </div>
+      <!-- !MemoryLimit -->
+      <!-- MemoryReservation -->
+      <div class="form-group">
+        <label for="template_memoryreservation" class="col-sm-3 col-lg-2 control-label text-left">
+          Memory Reservation (mb)
+          <portainer-tooltip position="bottom" message="Set amount of memory to reserve for this container. Will use Docker default if not specified or set to 0."></portainer-tooltip>
+        </label>
+        <div class="col-sm-9 col-lg-10">
+          <input type="number" class="form-control" name="template_memoryreservation" ng-model="$ctrl.model.MemoryReservation" placeholder="Leave blank or 0 for default value">
+        </div>
+      </div>
+      <!-- !MemoryReservation -->
+      <!-- CpuLimit -->
+      <div class="form-group">
+        <label for="template_cpulimit" class="col-sm-3 col-lg-2 control-label text-left">
+          CPU Limit
+          <portainer-tooltip position="bottom" message="Set the share of the CPUs (in 1/1000000000 of a CPU share) to allocate to this container. Will use Docker default if not specified or set to 0."></portainer-tooltip>
+        </label>
+        <div class="col-sm-9 col-lg-10">
+          <input type="number" class="form-control" name="template_cpulimit" ng-model="$ctrl.model.CpuLimit" placeholder="Leave blank or 0 for default value">
+        </div>
+      </div>
       <!-- network -->
       <div class="form-group">
         <label for="template_network" class="col-sm-3 col-lg-2 control-label text-left">

--- a/app/portainer/models/template.js
+++ b/app/portainer/models/template.js
@@ -12,6 +12,12 @@ export function TemplateDefaultModel() {
   this.Labels = [];
   this.RestartPolicy = 'always';
   this.RegistryModel = new PorImageRegistryModel();
+  this.Registry = {};
+  this.MemoryReservation = 0;
+  this.MemoryLimit = 0;
+  this.CpuLimit = 0;
+  this.ImageTags = [];
+
 }
 
 export function TemplateCreateRequest(model) {
@@ -35,6 +41,11 @@ export function TemplateCreateRequest(model) {
   this.Repository = model.Repository;
   this.Env = model.Env;
   this.AdministratorOnly = model.AdministratorOnly;
+
+  this.MemoryReservation = model.MemoryReservation;
+  this.MemoryLimit = model.MemoryLimit;
+  this.CpuLimit = model.CpuLimit;
+  this.ImageTags = model.ImageTags;
 
   this.Ports = [];
   for (var i = 0; i < model.Ports.length; i++) {
@@ -79,7 +90,12 @@ export function TemplateViewModel(data) {
   this.Env = templateEnv(data);
   this.Volumes = templateVolumes(data);
   this.Ports = templatePorts(data);
-}
+
+  this.MemoryReservation = data.memory_reservation > 0 ? data.memory_reservation : 0;
+  this.MemoryLimit = data.memory_limit > 0 ? data.memory_limit : 0;
+  this.CpuLimit = data.cpu_limit > 0 ? data.cpu_limit : 0;
+  this.ImageTags = data.image_tags ? data.image_tags : [];
+  }
 
 function templatePorts(data) {
   var ports = [];

--- a/app/portainer/services/api/templateService.js
+++ b/app/portainer/services/api/templateService.js
@@ -94,6 +94,24 @@ function TemplateServiceFactory($q, Templates, TemplateHelper, RegistryService, 
     configuration.OpenStdin = consoleConfiguration.openStdin;
     configuration.Tty = consoleConfiguration.tty;
     configuration.Labels = TemplateHelper.updateContainerConfigurationWithLabels(template.Labels);
+
+    if (template.MemoryLimit > 0) {
+      // Memory Limit - Round to 0.125
+      var memoryLimit = (Math.round(template.MemoryLimit * 8) / 8).toFixed(3);
+      memoryLimit *= 1024 * 1024;
+      configuration.HostConfig.Memory = memoryLimit;
+    }
+    if (template.MemoryReservation > 0) {
+      // Memory Reservation - Round to 0.125
+      var memoryReservation = (Math.round(template.MemoryReservation * 8) / 8).toFixed(3);
+      memoryReservation *= 1024 * 1024;
+      configuration.HostConfig.MemoryReservation = memoryReservation;
+    }
+    if (template.CpuLimit > 0) {
+      // CPU Limit
+      configuration.HostConfig.NanoCpus = template.CpuLimit * 1000000000;
+    }
+
     return configuration;
   }
 

--- a/app/portainer/views/templates/templates.html
+++ b/app/portainer/views/templates/templates.html
@@ -324,6 +324,32 @@
               </div>
             </div>
             <!-- !hostname -->
+            <div class="form-group">
+                <div class="col-sm-12" style="margin-top: 5px;">
+                    <label class="control-label text-left">Resources</label>
+                </div>
+              <div class="col-sm-12" style="margin-top: 5px;">
+              <label for="container_memorylimit" class="col-sm-2 control-label text-left">Memory Limit (mb)</label>
+              <div class="col-sm-10">
+                <input type="number" name="container_memorylimit" class="form-control" ng-model="state.selectedTemplate.MemoryLimit" placeholder="leave empty to use docker default">
+              </div>
+            </div>
+              <div class="col-sm-12" style="margin-top: 5px;">
+              <label for="container_memoryreservation" class="col-sm-2 control-label text-left">Memory Reservation (mb)</label>
+              <div class="col-sm-10">
+                <input type="number" name="container_memoryreservation" class="form-control" ng-model="state.selectedTemplate.MemoryReservation" placeholder="leave empty to use docker default">
+              </div>
+            </div>
+            <div class="col-sm-12" style="margin-top: 5px;">
+            <label for="container_cpulimit" class="col-sm-2 control-label text-left">CPU Limit</label>
+              <div class="col-sm-10">
+                <input type="number" name="container_cpulimit" class="form-control" ng-model="state.selectedTemplate.CpuLimit" placeholder="leave empty to use docker default">
+              </div>
+            </div>
+          </div>
+
+
+
           </div>
           <!-- !advanced-options -->
           <!-- actions -->


### PR DESCRIPTION
This is a copy of pull request [#2009](https://github.com/portainer/portainer/pull/2009).

Commit is a copy of @cohero's commit [40590d8](https://github.com/cohero/portainer/commit/40590d8da66f8ae72abb6cdf7a62387b4c9e180e), which implements feature [#2008](https://github.com/portainer/portainer/issues/2008).

I believe this feature is a must-have for anyone using templates, and hopefully can be included in next version.

Commit was rebased and up-to-date.