### PR TITLE
feat(container-creation): add support for --init (#2111)

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -111,6 +111,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
         AutoRemove: false,
         NetworkMode: 'bridge',
         Privileged: false,
+        Init: false,
         Runtime: '',
         ExtraHosts: [],
         Devices: [],

--- a/app/docker/views/containers/create/createcontainer.html
+++ b/app/docker/views/containers/create/createcontainer.html
@@ -606,6 +606,16 @@
                 </div>
               </div>
               <!-- !privileged-mode -->
+              <!-- init -->
+              <div class="form-group" ng-if="applicationState.endpoint.apiVersion >= 1.37">
+                <div class="col-sm-12">
+                  <label for="init" class="control-label text-left">
+                    Init
+                  </label>
+                  <label class="switch" style="margin-left: 20px;"> <input type="checkbox" name="init" ng-model="config.HostConfig.Init" /><i></i> </label>
+                </div>
+              </div>
+              <!-- !init -->
               <!-- runtimes -->
               <div class="form-group">
                 <label for="container_runtime" class="col-sm-1 control-label text-left">Runtime</label>


### PR DESCRIPTION
Adds an option for the `--init` option on container creation, per this comment: https://github.com/portainer/portainer/issues/2111#issuecomment-427155043

This is my first PR, so I'm sure I've missed out on something somewhere; feel free to nag at me to fix it.

Closes #2111 