### PR TITLE
fix(container): Cannot set property <port>/tcp of undefined while editing container port mapping

### DIFF
--- a/app/docker/helpers/containerHelper.js
+++ b/app/docker/helpers/containerHelper.js
@@ -89,6 +89,11 @@ angular.module('portainer.docker').factory('ContainerHelper', [
         EndpointsConfig: {},
       };
       config.NetworkingConfig.EndpointsConfig = container.NetworkSettings.Networks;
+
+      if (config.ExposedPorts === undefined) {
+        config.ExposedPorts = {};
+      }
+
       if (mode.indexOf('container:') !== -1) {
         delete config.Hostname;
         delete config.ExposedPorts;


### PR DESCRIPTION
Close #1261 

I suggest that we just ensure that config.ExposedPorts exists in container's config. It seems that works fine with home-assistant and haproxy now.