### PR TITLE
Enable Pull Dog for the repository

### DIFF
--- a/docker-compose.pull-dog.yml
+++ b/docker-compose.pull-dog.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   portainer:
-    image: portainerci/portainer:develop
+    image: portainerci/portainer:$PORTAINER_TAG
     command: -H unix:///var/run/docker.sock
     restart: always
     ports:

--- a/docker-compose.pull-dog.yml
+++ b/docker-compose.pull-dog.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  portainer:
+    image: portainerci/portainer:develop
+    command: -H unix:///var/run/docker.sock
+    restart: always
+    ports:
+      - 9000:9000
+      - 8000:8000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+
+volumes:
+  portainer_data:

--- a/pull-dog.json
+++ b/pull-dog.json
@@ -1,0 +1,3 @@
+{
+  "dockerComposeYmlFilePaths": ["docker-compose.pull-dog.yml"]
+}

--- a/pull-dog.json
+++ b/pull-dog.json
@@ -1,3 +1,4 @@
 {
-  "dockerComposeYmlFilePaths": ["docker-compose.pull-dog.yml"]
+  "dockerComposeYmlFilePaths": ["docker-compose.pull-dog.yml"],
+  "isLazy": true
 }


### PR DESCRIPTION
I sent you an e-mail about this @deviantony, along with a video that demonstrates the whole thing. This pull request assumes you've watched the video first.

**It's important that you install the GitHub app before merging this.** If you don't, Pull Dog will not detect that the repo has been set up.

As per the video (and as you can see in `pull-dog.json`), lazy mode has been enabled, meaning that a POST request from the build server will be needed before Pull Dog starts.

The POST request that has to be made is of the following form:

```
POST https://dogger.io/api/pull-dog/provision
{
	"repositoryHandle": "59239347",
	"apiKey": "<your API key from the dashboard, as seen in the video>",
	"commitReference": "<GIT commit ID>",
	"configuration": {
		"buildArguments": {
			"PORTAINER_TAG": "develop"
		}
	}
}
```

The GIT commit ID can be fetched from the build server using `git rev-parse --short HEAD`.

The PR that was used in the video is here (apparently the video got really blurry): https://github.com/pull-dog-user/portainer/pull/1

You have been invited to my fork, in case you want to play around with it there instead.