### PR TITLE
refactor(errors): reorganize errors

### DIFF
--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -1,6 +1,7 @@
 package bolt
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"log"
 	"path"
 	"time"
@@ -121,7 +122,7 @@ func (store *Store) MigrateData() error {
 	}
 
 	version, err := store.VersionService.DBVersion()
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		version = 0
 	} else if err != nil {
 		return err

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -1,7 +1,6 @@
 package bolt
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"log"
 	"path"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/portainer/portainer/api/bolt/endpoint"
 	"github.com/portainer/portainer/api/bolt/endpointgroup"
 	"github.com/portainer/portainer/api/bolt/endpointrelation"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/extension"
 	"github.com/portainer/portainer/api/bolt/migrator"
 	"github.com/portainer/portainer/api/bolt/registry"

--- a/api/bolt/errors/errors.go
+++ b/api/bolt/errors/errors.go
@@ -1,0 +1,7 @@
+package errors
+
+import "errors"
+
+var (
+	ErrObjectNotFound = errors.New("Object not found inside the database")
+)

--- a/api/bolt/init.go
+++ b/api/bolt/init.go
@@ -2,13 +2,14 @@ package bolt
 
 import (
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/authorization"
 )
 
 // Init creates the default data set.
 func (store *Store) Init() error {
 	_, err := store.SettingsService.Settings()
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		defaultSettings := &portainer.Settings{
 			AuthenticationMethod: portainer.AuthenticationInternal,
 			BlackListedLabels:    make([]portainer.Pair, 0),
@@ -42,7 +43,7 @@ func (store *Store) Init() error {
 	}
 
 	_, err = store.DockerHubService.DockerHub()
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		defaultDockerHub := &portainer.DockerHub{
 			Authentication: false,
 			Username:       "",

--- a/api/bolt/internal/db.go
+++ b/api/bolt/internal/db.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/boltdb/bolt"
-	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // Itob returns an 8-byte big endian representation of v.
@@ -36,7 +36,7 @@ func GetObject(db *bolt.DB, bucketName string, key []byte, object interface{}) e
 
 		value := bucket.Get(key)
 		if value == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		data = make([]byte, len(value))

--- a/api/bolt/migrator/migrate_dbversion0.go
+++ b/api/bolt/migrator/migrate_dbversion0.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"github.com/boltdb/bolt"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/user"
 )
 
@@ -22,7 +23,7 @@ func (m *Migrator) updateAdminUserToDBVersion1() error {
 		if err != nil {
 			return err
 		}
-	} else if err != nil && err != portainer.ErrObjectNotFound {
+	} else if err != nil && err != errors.ErrObjectNotFound {
 		return err
 	}
 	return nil

--- a/api/bolt/stack/stack.go
+++ b/api/bolt/stack/stack.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 
 	"github.com/boltdb/bolt"
@@ -64,7 +65,7 @@ func (service *Service) StackByName(name string) (*portainer.Stack, error) {
 		}
 
 		if stack == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		return nil

--- a/api/bolt/team/team.go
+++ b/api/bolt/team/team.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 
 	"github.com/boltdb/bolt"
@@ -64,7 +65,7 @@ func (service *Service) TeamByName(name string) (*portainer.Team, error) {
 		}
 
 		if team == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		return nil

--- a/api/bolt/user/user.go
+++ b/api/bolt/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 
 	"github.com/boltdb/bolt"
@@ -64,7 +65,7 @@ func (service *Service) UserByUsername(username string) (*portainer.User, error)
 		}
 
 		if user == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 		return nil
 	})

--- a/api/bolt/version/version.go
+++ b/api/bolt/version/version.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	"github.com/boltdb/bolt"
-	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 )
 
@@ -40,7 +40,7 @@ func (service *Service) DBVersion() (int, error) {
 
 		value := bucket.Get([]byte(versionKey))
 		if value == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		data = make([]byte, len(value))

--- a/api/bolt/webhook/webhook.go
+++ b/api/bolt/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 
 	"github.com/boltdb/bolt"
@@ -87,7 +88,7 @@ func (service *Service) WebhookByResourceID(ID string) (*portainer.Webhook, erro
 		}
 
 		if webhook == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		return nil
@@ -118,7 +119,7 @@ func (service *Service) WebhookByToken(token string) (*portainer.Webhook, error)
 		}
 
 		if webhook == nil {
-			return portainer.ErrObjectNotFound
+			return errors.ErrObjectNotFound
 		}
 
 		return nil

--- a/api/chisel/service.go
+++ b/api/chisel/service.go
@@ -2,6 +2,7 @@ package chisel
 
 import (
 	"fmt"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"log"
 	"strconv"
 	"time"
@@ -11,7 +12,7 @@ import (
 	cmap "github.com/orcaman/concurrent-map"
 
 	chserver "github.com/jpillora/chisel/server"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
 )
 
 const (
@@ -88,7 +89,7 @@ func (service *Service) retrievePrivateKeySeed() (string, error) {
 	var serverInfo *portainer.TunnelServerInfo
 
 	serverInfo, err := service.dataStore.TunnelServer().Info()
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		keySeed := uniuri.NewLen(16)
 
 		serverInfo = &portainer.TunnelServerInfo{

--- a/api/chisel/service.go
+++ b/api/chisel/service.go
@@ -2,17 +2,15 @@ package chisel
 
 import (
 	"fmt"
-	"github.com/portainer/portainer/api/bolt/errors"
 	"log"
 	"strconv"
 	"time"
 
 	"github.com/dchest/uniuri"
-
-	cmap "github.com/orcaman/concurrent-map"
-
 	chserver "github.com/jpillora/chisel/server"
+	cmap "github.com/orcaman/concurrent-map"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 const (

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"time"
 
 	"github.com/portainer/portainer/api"
@@ -15,11 +16,11 @@ import (
 // Service implements the CLIService interface
 type Service struct{}
 
-const (
-	errInvalidEndpointProtocol       = portainer.Error("Invalid endpoint protocol: Portainer only supports unix://, npipe:// or tcp://")
-	errSocketOrNamedPipeNotFound     = portainer.Error("Unable to locate Unix socket or named pipe")
-	errInvalidSnapshotInterval       = portainer.Error("Invalid snapshot interval")
-	errAdminPassExcludeAdminPassFile = portainer.Error("Cannot use --admin-password with --admin-password-file")
+var (
+	errInvalidEndpointProtocol       = errors.New("Invalid endpoint protocol: Portainer only supports unix://, npipe:// or tcp://")
+	errSocketOrNamedPipeNotFound     = errors.New("Unable to locate Unix socket or named pipe")
+	errInvalidSnapshotInterval       = errors.New("Invalid snapshot interval")
+	errAdminPassExcludeAdminPassFile = errors.New("Cannot use --admin-password with --admin-password-file")
 )
 
 // ParseFlags parse the CLI flags and return a portainer.Flags struct

--- a/api/docker/client.go
+++ b/api/docker/client.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,8 +12,9 @@ import (
 	"github.com/portainer/portainer/api/crypto"
 )
 
+var errUnsupportedEnvironmentType = errors.New("Environment not supported")
+
 const (
-	unsupportedEnvironmentType  = portainer.Error("Environment not supported")
 	defaultDockerRequestTimeout = 60
 	dockerClientVersion         = "1.37"
 )
@@ -36,7 +38,7 @@ func NewClientFactory(signatureService portainer.DigitalSignatureService, revers
 // with an agent enabled endpoint to target a specific node in an agent cluster.
 func (factory *ClientFactory) CreateClient(endpoint *portainer.Endpoint, nodeName string) (*client.Client, error) {
 	if endpoint.Type == portainer.AzureEnvironment {
-		return nil, unsupportedEnvironmentType
+		return nil, errUnsupportedEnvironmentType
 	} else if endpoint.Type == portainer.AgentOnDockerEnvironment {
 		return createAgentClient(endpoint, factory.signatureService, nodeName)
 	} else if endpoint.Type == portainer.EdgeAgentOnDockerEnvironment {

--- a/api/docker/errors.go
+++ b/api/docker/errors.go
@@ -1,0 +1,8 @@
+package docker
+
+import "errors"
+
+// Docker errors
+var (
+	ErrUnableToPingEndpoint = errors.New("Unable to communicate with the endpoint")
+)

--- a/api/errors.go
+++ b/api/errors.go
@@ -2,7 +2,6 @@ package portainer
 
 // General errors.
 const (
-	ErrResourceAccessDenied   = Error("Access denied to resource")
 	ErrAuthorizationRequired  = Error("Authorization required for this operation")
 	ErrMissingSecurityContext = Error("Unable to find security details in request context")
 )

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,72 +1,13 @@
 package portainer
 
-// Team errors.
-const (
-	ErrTeamAlreadyExists = Error("Team already exists")
-)
-
-// TeamMembership errors.
-const (
-	ErrTeamMembershipAlreadyExists = Error("Team membership already exists for this user and team")
-)
-
-// ResourceControl errors.
-const (
-	ErrResourceControlAlreadyExists = Error("A resource control is already applied on this resource")
-	ErrInvalidResourceControlType   = Error("Unsupported resource control type")
-)
-
 // Endpoint errors.
 const (
 	ErrEndpointAccessDenied = Error("Access denied to endpoint")
 )
 
-// Azure environment errors
-const (
-	ErrAzureInvalidCredentials = Error("Invalid Azure credentials")
-)
-
-// Endpoint group errors.
-const (
-	ErrCannotRemoveDefaultGroup = Error("Cannot remove the default endpoint group")
-)
-
-// Registry errors.
-const (
-	ErrRegistryAlreadyExists = Error("A registry is already defined for this URL")
-)
-
-// Stack errors
-const (
-	ErrStackAlreadyExists              = Error("A stack already exists with this name")
-	ErrComposeFileNotFoundInRepository = Error("Unable to find a Compose file in the repository")
-	ErrStackNotExternal                = Error("Not an external stack")
-)
-
-// Tag errors
-const (
-	ErrTagAlreadyExists = Error("A tag already exists with this name")
-)
-
-// Endpoint extensions error
-const (
-	ErrEndpointExtensionNotSupported = Error("This extension is not supported")
-)
-
-// JWT errors.
-const (
-	ErrSecretGeneration = Error("Unable to generate secret key")
-	ErrInvalidJWTToken  = Error("Invalid JWT token")
-)
-
 // File errors.
 const (
 	ErrUndefinedTLSFileType = Error("Undefined TLS file type")
-)
-
-// Extension errors.
-const (
-	ErrExtensionAlreadyEnabled = Error("This extension is already enabled")
 )
 
 // Docker errors.
@@ -84,9 +25,3 @@ type Error string
 
 // Error returns the error message.
 func (e Error) Error() string { return string(e) }
-
-// Webhook errors
-const (
-	ErrWebhookAlreadyExists   = Error("A webhook for this resource already exists")
-	ErrUnsupportedWebhookType = Error("Webhooks for this resource are not currently supported")
-)

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,14 +1,5 @@
 package portainer
 
-// User errors.
-const (
-	ErrUserAlreadyExists          = Error("User already exists")
-	ErrInvalidUsername            = Error("Invalid username. White spaces are not allowed")
-	ErrAdminAlreadyInitialized    = Error("An administrator user already exists")
-	ErrAdminCannotRemoveSelf      = Error("Cannot remove your own user account. Contact another administrator")
-	ErrCannotRemoveLastLocalAdmin = Error("Cannot remove the last local administrator account")
-)
-
 // Team errors.
 const (
 	ErrTeamAlreadyExists = Error("Team already exists")
@@ -59,13 +50,7 @@ const (
 
 // Endpoint extensions error
 const (
-	ErrEndpointExtensionNotSupported      = Error("This extension is not supported")
-	ErrEndpointExtensionAlreadyAssociated = Error("This extension is already associated to the endpoint")
-)
-
-// Crypto errors.
-const (
-	ErrCryptoHashFailure = Error("Unable to hash data")
+	ErrEndpointExtensionNotSupported = Error("This extension is not supported")
 )
 
 // JWT errors.

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,11 +1,5 @@
 package portainer
 
-// General errors.
-const (
-	ErrAuthorizationRequired  = Error("Authorization required for this operation")
-	ErrMissingSecurityContext = Error("Unable to find security details in request context")
-)
-
 // User errors.
 const (
 	ErrUserAlreadyExists          = Error("User already exists")
@@ -76,9 +70,8 @@ const (
 
 // JWT errors.
 const (
-	ErrSecretGeneration   = Error("Unable to generate secret key")
-	ErrInvalidJWTToken    = Error("Invalid JWT token")
-	ErrMissingContextData = Error("Unable to find JWT data in request context")
+	ErrSecretGeneration = Error("Unable to generate secret key")
+	ErrInvalidJWTToken  = Error("Invalid JWT token")
 )
 
 // File errors.

--- a/api/errors.go
+++ b/api/errors.go
@@ -5,7 +5,6 @@ const (
 	ErrUnauthorized           = Error("Unauthorized")
 	ErrResourceAccessDenied   = Error("Access denied to resource")
 	ErrAuthorizationRequired  = Error("Authorization required for this operation")
-	ErrObjectNotFound         = Error("Object not found inside the database")
 	ErrMissingSecurityContext = Error("Unable to find security details in request context")
 )
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -2,7 +2,6 @@ package portainer
 
 // General errors.
 const (
-	ErrUnauthorized           = Error("Unauthorized")
 	ErrResourceAccessDenied   = Error("Access denied to resource")
 	ErrAuthorizationRequired  = Error("Authorization required for this operation")
 	ErrMissingSecurityContext = Error("Unable to find security details in request context")

--- a/api/errors.go
+++ b/api/errors.go
@@ -5,11 +5,6 @@ const (
 	ErrUndefinedTLSFileType = Error("Undefined TLS file type")
 )
 
-// Docker errors.
-const (
-	ErrUnableToPingEndpoint = Error("Unable to communicate with the endpoint")
-)
-
 // Error represents an application error.
 type Error string
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,10 +1,5 @@
 package portainer
 
-// Endpoint errors.
-const (
-	ErrEndpointAccessDenied = Error("Access denied to endpoint")
-)
-
 // File errors.
 const (
 	ErrUndefinedTLSFileType = Error("Undefined TLS file type")

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,10 +1,5 @@
 package portainer
 
-// File errors.
-const (
-	ErrUndefinedTLSFileType = Error("Undefined TLS file type")
-)
-
 // Error represents an application error.
 type Error string
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -15,11 +15,6 @@ const (
 	ErrUnableToPingEndpoint = Error("Unable to communicate with the endpoint")
 )
 
-// Schedule errors.
-const (
-	ErrHostManagementFeaturesDisabled = Error("Host management features are disabled")
-)
-
 // Error represents an application error.
 type Error string
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,7 +1,0 @@
-package portainer
-
-// Error represents an application error.
-type Error string
-
-// Error returns the error message.
-func (e Error) Error() string { return string(e) }

--- a/api/exec/swarm_stack.go
+++ b/api/exec/swarm_stack.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -103,7 +104,7 @@ func runCommandAndCaptureStdErr(command string, args []string, env []string, wor
 
 	err := cmd.Run()
 	if err != nil {
-		return portainer.Error(stderr.String())
+		return errors.New(stderr.String())
 	}
 
 	return nil

--- a/api/filesystem/filesystem.go
+++ b/api/filesystem/filesystem.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -44,6 +45,9 @@ const (
 	// registry management extension are stored.
 	ExtensionRegistryManagementStorePath = "extensions"
 )
+
+// ErrUndefinedTLSFileType represents an error returned on undefined TLS file type
+var ErrUndefinedTLSFileType = errors.New("Undefined TLS file type")
 
 // Service represents a service for managing files and directories.
 type Service struct {
@@ -189,7 +193,7 @@ func (service *Service) StoreTLSFileFromBytes(folder string, fileType portainer.
 	case portainer.TLSFileKey:
 		fileName = TLSKeyFile
 	default:
-		return "", portainer.ErrUndefinedTLSFileType
+		return "", ErrUndefinedTLSFileType
 	}
 
 	tlsFilePath := path.Join(storePath, fileName)
@@ -212,7 +216,7 @@ func (service *Service) GetPathForTLSFile(folder string, fileType portainer.TLSF
 	case portainer.TLSFileKey:
 		fileName = TLSKeyFile
 	default:
-		return "", portainer.ErrUndefinedTLSFileType
+		return "", ErrUndefinedTLSFileType
 	}
 	return path.Join(service.fileStorePath, TLSStorePath, folder, fileName), nil
 }
@@ -238,7 +242,7 @@ func (service *Service) DeleteTLSFile(folder string, fileType portainer.TLSFileT
 	case portainer.TLSFileKey:
 		fileName = TLSKeyFile
 	default:
-		return portainer.ErrUndefinedTLSFileType
+		return ErrUndefinedTLSFileType
 	}
 
 	filePath := path.Join(service.fileStorePath, TLSStorePath, folder, fileName)

--- a/api/http/client/client.go
+++ b/api/http/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -56,7 +57,7 @@ func (client *HTTPClient) ExecuteAzureAuthenticationRequest(credentials *portain
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, portainer.ErrAzureInvalidCredentials
+		return nil, errors.New("Invalid Azure credentials")
 	}
 
 	var token AzureAuthenticationResponse

--- a/api/http/client/client.go
+++ b/api/http/client/client.go
@@ -15,9 +15,10 @@ import (
 	"github.com/portainer/portainer/api"
 )
 
+var errInvalidResponseStatus = errors.New("Invalid response status (expecting 200)")
+
 const (
-	errInvalidResponseStatus = portainer.Error("Invalid response status (expecting 200)")
-	defaultHTTPTimeout       = 5
+	defaultHTTPTimeout = 5
 )
 
 // HTTPClient represents a client to send HTTP requests.

--- a/api/http/errors/errors.go
+++ b/api/http/errors/errors.go
@@ -1,0 +1,8 @@
+package errors
+
+import "errors"
+
+// General errors.
+var (
+	ErrUnauthorized = errors.New("Unauthorized")
+)

--- a/api/http/errors/errors.go
+++ b/api/http/errors/errors.go
@@ -4,5 +4,6 @@ import "errors"
 
 // General errors.
 var (
-	ErrUnauthorized = errors.New("Unauthorized")
+	ErrUnauthorized         = errors.New("Unauthorized")
+	ErrResourceAccessDenied = errors.New("Access denied to resource")
 )

--- a/api/http/errors/errors.go
+++ b/api/http/errors/errors.go
@@ -2,8 +2,11 @@ package errors
 
 import "errors"
 
-// General errors.
 var (
-	ErrUnauthorized         = errors.New("Unauthorized")
+	// ErrEndpointAccessDenied Access denied to endpoint error
+	ErrEndpointAccessDenied = errors.New("Access denied to endpoint")
+	// ErrUnauthorized Unauthorized error
+	ErrUnauthorized = errors.New("Unauthorized")
+	// ErrResourceAccessDenied Access denied to resource error
 	ErrResourceAccessDenied = errors.New("Access denied to resource")
 )

--- a/api/http/handler/auth/authenticate.go
+++ b/api/http/handler/auth/authenticate.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"log"
 	"net/http"
 	"strings"
@@ -45,11 +46,11 @@ func (handler *Handler) authenticate(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	u, err := handler.DataStore.User().UserByUsername(payload.Username)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve a user with the specified username from the database", err}
 	}
 
-	if err == portainer.ErrObjectNotFound && (settings.AuthenticationMethod == portainer.AuthenticationInternal || settings.AuthenticationMethod == portainer.AuthenticationOAuth) {
+	if err == errors.ErrObjectNotFound && (settings.AuthenticationMethod == portainer.AuthenticationInternal || settings.AuthenticationMethod == portainer.AuthenticationOAuth) {
 		return &httperror.HandlerError{http.StatusUnprocessableEntity, "Invalid credentials", portainer.ErrUnauthorized}
 	}
 

--- a/api/http/handler/auth/authenticate_oauth.go
+++ b/api/http/handler/auth/authenticate_oauth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/authorization"
 	"io/ioutil"
 	"log"
@@ -89,7 +90,7 @@ func (handler *Handler) validateOAuth(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.OAuthAuthenticationExtension)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Oauth authentication extension is not enabled", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}
@@ -102,7 +103,7 @@ func (handler *Handler) validateOAuth(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	user, err := handler.DataStore.User().UserByUsername(username)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve a user with the specified username from the database", err}
 	}
 

--- a/api/http/handler/dockerhub/dockerhub_update.go
+++ b/api/http/handler/dockerhub/dockerhub_update.go
@@ -1,6 +1,7 @@
 package dockerhub
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -18,7 +19,7 @@ type dockerhubUpdatePayload struct {
 
 func (payload *dockerhubUpdatePayload) Validate(r *http.Request) error {
 	if payload.Authentication && (govalidator.IsNull(payload.Username) || govalidator.IsNull(payload.Password)) {
-		return portainer.Error("Invalid credentials. Username and password must be specified when authentication is enabled")
+		return errors.New("Invalid credentials. Username and password must be specified when authentication is enabled")
 	}
 	return nil
 }

--- a/api/http/handler/edgegroups/edgegroup_create.go
+++ b/api/http/handler/edgegroups/edgegroup_create.go
@@ -1,6 +1,7 @@
 package edgegroups
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -20,13 +21,13 @@ type edgeGroupCreatePayload struct {
 
 func (payload *edgeGroupCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid Edge group name")
+		return errors.New("Invalid Edge group name")
 	}
 	if payload.Dynamic && (payload.TagIDs == nil || len(payload.TagIDs) == 0) {
-		return portainer.Error("TagIDs is mandatory for a dynamic Edge group")
+		return errors.New("TagIDs is mandatory for a dynamic Edge group")
 	}
 	if !payload.Dynamic && (payload.Endpoints == nil || len(payload.Endpoints) == 0) {
-		return portainer.Error("Endpoints is mandatory for a static Edge group")
+		return errors.New("Endpoints is mandatory for a static Edge group")
 	}
 	return nil
 }
@@ -45,7 +46,7 @@ func (handler *Handler) edgeGroupCreate(w http.ResponseWriter, r *http.Request) 
 
 	for _, edgeGroup := range edgeGroups {
 		if edgeGroup.Name == payload.Name {
-			return &httperror.HandlerError{http.StatusBadRequest, "Edge group name must be unique", portainer.Error("Edge group name must be unique")}
+			return &httperror.HandlerError{http.StatusBadRequest, "Edge group name must be unique", errors.New("Edge group name must be unique")}
 		}
 	}
 

--- a/api/http/handler/edgegroups/edgegroup_delete.go
+++ b/api/http/handler/edgegroups/edgegroup_delete.go
@@ -1,6 +1,7 @@
 package edgegroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -16,7 +17,7 @@ func (handler *Handler) edgeGroupDelete(w http.ResponseWriter, r *http.Request) 
 	}
 
 	_, err = handler.DataStore.EdgeGroup().EdgeGroup(portainer.EdgeGroupID(edgeGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge group with the specified identifier inside the database", err}

--- a/api/http/handler/edgegroups/edgegroup_delete.go
+++ b/api/http/handler/edgegroups/edgegroup_delete.go
@@ -1,13 +1,14 @@
 package edgegroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 func (handler *Handler) edgeGroupDelete(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
@@ -17,7 +18,7 @@ func (handler *Handler) edgeGroupDelete(w http.ResponseWriter, r *http.Request) 
 	}
 
 	_, err = handler.DataStore.EdgeGroup().EdgeGroup(portainer.EdgeGroupID(edgeGroupID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge group with the specified identifier inside the database", err}
@@ -31,7 +32,7 @@ func (handler *Handler) edgeGroupDelete(w http.ResponseWriter, r *http.Request) 
 	for _, edgeStack := range edgeStacks {
 		for _, groupID := range edgeStack.EdgeGroups {
 			if groupID == portainer.EdgeGroupID(edgeGroupID) {
-				return &httperror.HandlerError{http.StatusForbidden, "Edge group is used by an Edge stack", portainer.Error("Edge group is used by an Edge stack")}
+				return &httperror.HandlerError{http.StatusForbidden, "Edge group is used by an Edge stack", errors.New("Edge group is used by an Edge stack")}
 			}
 		}
 	}

--- a/api/http/handler/edgegroups/edgegroup_inspect.go
+++ b/api/http/handler/edgegroups/edgegroup_inspect.go
@@ -1,6 +1,7 @@
 package edgegroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -16,7 +17,7 @@ func (handler *Handler) edgeGroupInspect(w http.ResponseWriter, r *http.Request)
 	}
 
 	edgeGroup, err := handler.DataStore.EdgeGroup().EdgeGroup(portainer.EdgeGroupID(edgeGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge group with the specified identifier inside the database", err}

--- a/api/http/handler/edgegroups/edgegroup_inspect.go
+++ b/api/http/handler/edgegroups/edgegroup_inspect.go
@@ -1,13 +1,13 @@
 package edgegroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 func (handler *Handler) edgeGroupInspect(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {

--- a/api/http/handler/edgegroups/edgegroup_update.go
+++ b/api/http/handler/edgegroups/edgegroup_update.go
@@ -1,6 +1,7 @@
 package edgegroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -45,7 +46,7 @@ func (handler *Handler) edgeGroupUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	edgeGroup, err := handler.DataStore.EdgeGroup().EdgeGroup(portainer.EdgeGroupID(edgeGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge group with the specified identifier inside the database", err}

--- a/api/http/handler/edgegroups/edgegroup_update.go
+++ b/api/http/handler/edgegroups/edgegroup_update.go
@@ -1,7 +1,7 @@
 package edgegroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/edge"
 )
 
@@ -22,13 +23,13 @@ type edgeGroupUpdatePayload struct {
 
 func (payload *edgeGroupUpdatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid Edge group name")
+		return errors.New("Invalid Edge group name")
 	}
 	if payload.Dynamic && (payload.TagIDs == nil || len(payload.TagIDs) == 0) {
-		return portainer.Error("TagIDs is mandatory for a dynamic Edge group")
+		return errors.New("TagIDs is mandatory for a dynamic Edge group")
 	}
 	if !payload.Dynamic && (payload.Endpoints == nil || len(payload.Endpoints) == 0) {
-		return portainer.Error("Endpoints is mandatory for a static Edge group")
+		return errors.New("Endpoints is mandatory for a static Edge group")
 	}
 	return nil
 }
@@ -46,7 +47,7 @@ func (handler *Handler) edgeGroupUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	edgeGroup, err := handler.DataStore.EdgeGroup().EdgeGroup(portainer.EdgeGroupID(edgeGroupID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge group with the specified identifier inside the database", err}
@@ -59,7 +60,7 @@ func (handler *Handler) edgeGroupUpdate(w http.ResponseWriter, r *http.Request) 
 		}
 		for _, edgeGroup := range edgeGroups {
 			if edgeGroup.Name == payload.Name && edgeGroup.ID != portainer.EdgeGroupID(edgeGroupID) {
-				return &httperror.HandlerError{http.StatusBadRequest, "Edge group name must be unique", portainer.Error("Edge group name must be unique")}
+				return &httperror.HandlerError{http.StatusBadRequest, "Edge group name must be unique", errors.New("Edge group name must be unique")}
 			}
 		}
 

--- a/api/http/handler/edgejobs/edgejob_create.go
+++ b/api/http/handler/edgejobs/edgejob_create.go
@@ -41,7 +41,7 @@ type edgeJobCreateFromFileContentPayload struct {
 
 func (payload *edgeJobCreateFromFileContentPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid Edge job name")
+		return errors.New("Invalid Edge job name")
 	}
 
 	if !govalidator.Matches(payload.Name, `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`) {
@@ -49,15 +49,15 @@ func (payload *edgeJobCreateFromFileContentPayload) Validate(r *http.Request) er
 	}
 
 	if govalidator.IsNull(payload.CronExpression) {
-		return portainer.Error("Invalid cron expression")
+		return errors.New("Invalid cron expression")
 	}
 
 	if payload.Endpoints == nil || len(payload.Endpoints) == 0 {
-		return portainer.Error("Invalid endpoints payload")
+		return errors.New("Invalid endpoints payload")
 	}
 
 	if govalidator.IsNull(payload.FileContent) {
-		return portainer.Error("Invalid script file content")
+		return errors.New("Invalid script file content")
 	}
 
 	return nil
@@ -114,7 +114,7 @@ func (payload *edgeJobCreateFromFilePayload) Validate(r *http.Request) error {
 
 	file, _, err := request.RetrieveMultiPartFormFile(r, "file")
 	if err != nil {
-		return portainer.Error("Invalid script file. Ensure that the file is uploaded correctly")
+		return errors.New("Invalid script file. Ensure that the file is uploaded correctly")
 	}
 	payload.File = file
 

--- a/api/http/handler/edgejobs/edgejob_delete.go
+++ b/api/http/handler/edgejobs/edgejob_delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 func (handler *Handler) edgeJobDelete(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
@@ -17,7 +18,7 @@ func (handler *Handler) edgeJobDelete(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_file.go
+++ b/api/http/handler/edgejobs/edgejob_file.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type edgeJobFileResponse struct {
@@ -21,7 +22,7 @@ func (handler *Handler) edgeJobFile(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_inspect.go
+++ b/api/http/handler/edgejobs/edgejob_inspect.go
@@ -3,11 +3,11 @@ package edgejobs
 import (
 	"net/http"
 
-	"github.com/portainer/libhttp/response"
-	"github.com/portainer/portainer/api"
-
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type edgeJobInspectResponse struct {
@@ -22,7 +22,7 @@ func (handler *Handler) edgeJobInspect(w http.ResponseWriter, r *http.Request) *
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_tasklogs_clear.go
+++ b/api/http/handler/edgejobs/edgejob_tasklogs_clear.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/edge_jobs/:id/tasks/:taskID/logs
@@ -23,7 +24,7 @@ func (handler *Handler) edgeJobTasksClear(w http.ResponseWriter, r *http.Request
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_tasklogs_collect.go
+++ b/api/http/handler/edgejobs/edgejob_tasklogs_collect.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 // POST request on /api/edge_jobs/:id/tasks/:taskID/logs
@@ -22,7 +23,7 @@ func (handler *Handler) edgeJobTasksCollect(w http.ResponseWriter, r *http.Reque
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_tasks_list.go
+++ b/api/http/handler/edgejobs/edgejob_tasks_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type taskContainer struct {
@@ -33,7 +34,7 @@ func (handler *Handler) edgeJobTasksList(w http.ResponseWriter, r *http.Request)
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_tasks_list.go
+++ b/api/http/handler/edgejobs/edgejob_tasks_list.go
@@ -19,15 +19,6 @@ type taskContainer struct {
 
 // GET request on /api/edge_jobs/:id/tasks
 func (handler *Handler) edgeJobTasksList(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
-	settings, err := handler.DataStore.Settings().Settings()
-	if err != nil {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Unable to retrieve settings", err}
-	}
-
-	if !settings.EnableEdgeComputeFeatures {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Edge compute features are disabled", portainer.ErrHostManagementFeaturesDisabled}
-	}
-
 	edgeJobID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid Edge job identifier route variable", err}

--- a/api/http/handler/edgejobs/edgejob_update.go
+++ b/api/http/handler/edgejobs/edgejob_update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type edgeJobUpdatePayload struct {
@@ -49,7 +50,7 @@ func (handler *Handler) edgeJobUpdate(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an Edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an Edge job with the specified identifier inside the database", err}

--- a/api/http/handler/edgejobs/edgejob_update.go
+++ b/api/http/handler/edgejobs/edgejob_update.go
@@ -29,15 +29,6 @@ func (payload *edgeJobUpdatePayload) Validate(r *http.Request) error {
 }
 
 func (handler *Handler) edgeJobUpdate(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
-	settings, err := handler.DataStore.Settings().Settings()
-	if err != nil {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Unable to retrieve settings", err}
-	}
-
-	if !settings.EnableEdgeComputeFeatures {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Edge compute features are disabled", portainer.ErrHostManagementFeaturesDisabled}
-	}
-
 	edgeJobID, err := request.RetrieveNumericRouteVariableValue(r, "id")
 	if err != nil {
 		return &httperror.HandlerError{http.StatusBadRequest, "Invalid Edge job identifier route variable", err}

--- a/api/http/handler/edgestacks/edgestack_create.go
+++ b/api/http/handler/edgestacks/edgestack_create.go
@@ -82,13 +82,13 @@ type swarmStackFromFileContentPayload struct {
 
 func (payload *swarmStackFromFileContentPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	if payload.EdgeGroups == nil || len(payload.EdgeGroups) == 0 {
-		return portainer.Error("Edge Groups are mandatory for an Edge stack")
+		return errors.New("Edge Groups are mandatory for an Edge stack")
 	}
 	return nil
 }
@@ -144,19 +144,19 @@ type swarmStackFromGitRepositoryPayload struct {
 
 func (payload *swarmStackFromGitRepositoryPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	if govalidator.IsNull(payload.RepositoryURL) || !govalidator.IsURL(payload.RepositoryURL) {
-		return portainer.Error("Invalid repository URL. Must correspond to a valid URL format")
+		return errors.New("Invalid repository URL. Must correspond to a valid URL format")
 	}
 	if payload.RepositoryAuthentication && (govalidator.IsNull(payload.RepositoryUsername) || govalidator.IsNull(payload.RepositoryPassword)) {
-		return portainer.Error("Invalid repository credentials. Username and password must be specified when authentication is enabled")
+		return errors.New("Invalid repository credentials. Username and password must be specified when authentication is enabled")
 	}
 	if govalidator.IsNull(payload.ComposeFilePathInRepository) {
 		payload.ComposeFilePathInRepository = filesystem.ComposeFileDefaultName
 	}
 	if payload.EdgeGroups == nil || len(payload.EdgeGroups) == 0 {
-		return portainer.Error("Edge Groups are mandatory for an Edge stack")
+		return errors.New("Edge Groups are mandatory for an Edge stack")
 	}
 	return nil
 }
@@ -218,20 +218,20 @@ type swarmStackFromFileUploadPayload struct {
 func (payload *swarmStackFromFileUploadPayload) Validate(r *http.Request) error {
 	name, err := request.RetrieveMultiPartFormValue(r, "Name", false)
 	if err != nil {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	payload.Name = name
 
 	composeFileContent, _, err := request.RetrieveMultiPartFormFile(r, "file")
 	if err != nil {
-		return portainer.Error("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
+		return errors.New("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
 	}
 	payload.StackFileContent = composeFileContent
 
 	var edgeGroups []portainer.EdgeGroupID
 	err = request.RetrieveMultiPartFormJSONValue(r, "EdgeGroups", &edgeGroups, false)
 	if err != nil || len(edgeGroups) == 0 {
-		return portainer.Error("Edge Groups are mandatory for an Edge stack")
+		return errors.New("Edge Groups are mandatory for an Edge stack")
 	}
 	payload.EdgeGroups = edgeGroups
 	return nil
@@ -283,7 +283,7 @@ func (handler *Handler) validateUniqueName(name string) error {
 
 	for _, stack := range edgeStacks {
 		if strings.EqualFold(stack.Name, name) {
-			return portainer.Error("Edge stack name must be unique")
+			return errors.New("Edge stack name must be unique")
 		}
 	}
 	return nil

--- a/api/http/handler/edgestacks/edgestack_delete.go
+++ b/api/http/handler/edgestacks/edgestack_delete.go
@@ -1,6 +1,7 @@
 package edgestacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) edgeStackDelete(w http.ResponseWriter, r *http.Request) 
 	}
 
 	edgeStack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(edgeStackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an edge stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an edge stack with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_delete.go
+++ b/api/http/handler/edgestacks/edgestack_delete.go
@@ -1,13 +1,13 @@
 package edgestacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/edge"
 )
 

--- a/api/http/handler/edgestacks/edgestack_file.go
+++ b/api/http/handler/edgestacks/edgestack_file.go
@@ -1,6 +1,7 @@
 package edgestacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -22,7 +23,7 @@ func (handler *Handler) edgeStackFile(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	stack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an edge stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an edge stack with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_file.go
+++ b/api/http/handler/edgestacks/edgestack_file.go
@@ -1,7 +1,6 @@
 package edgestacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 type stackFileResponse struct {

--- a/api/http/handler/edgestacks/edgestack_inspect.go
+++ b/api/http/handler/edgestacks/edgestack_inspect.go
@@ -1,6 +1,7 @@
 package edgestacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -16,7 +17,7 @@ func (handler *Handler) edgeStackInspect(w http.ResponseWriter, r *http.Request)
 	}
 
 	edgeStack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(edgeStackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an edge stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an edge stack with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_inspect.go
+++ b/api/http/handler/edgestacks/edgestack_inspect.go
@@ -1,13 +1,13 @@
 package edgestacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 func (handler *Handler) edgeStackInspect(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {

--- a/api/http/handler/edgestacks/edgestack_status_update.go
+++ b/api/http/handler/edgestacks/edgestack_status_update.go
@@ -1,6 +1,7 @@
 package edgestacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -36,7 +37,7 @@ func (handler *Handler) edgeStackStatusUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	stack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -49,7 +50,7 @@ func (handler *Handler) edgeStackStatusUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(*payload.EndpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_status_update.go
+++ b/api/http/handler/edgestacks/edgestack_status_update.go
@@ -1,7 +1,7 @@
 package edgestacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type updateStatusPayload struct {
@@ -19,13 +20,13 @@ type updateStatusPayload struct {
 
 func (payload *updateStatusPayload) Validate(r *http.Request) error {
 	if payload.Status == nil {
-		return portainer.Error("Invalid status")
+		return errors.New("Invalid status")
 	}
 	if payload.EndpointID == nil {
-		return portainer.Error("Invalid EndpointID")
+		return errors.New("Invalid EndpointID")
 	}
 	if *payload.Status == portainer.StatusError && govalidator.IsNull(payload.Error) {
-		return portainer.Error("Error message is mandatory when status is error")
+		return errors.New("Error message is mandatory when status is error")
 	}
 	return nil
 }
@@ -37,7 +38,7 @@ func (handler *Handler) edgeStackStatusUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	stack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -50,7 +51,7 @@ func (handler *Handler) edgeStackStatusUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(*payload.EndpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_update.go
+++ b/api/http/handler/edgestacks/edgestack_update.go
@@ -1,6 +1,7 @@
 package edgestacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -36,7 +37,7 @@ func (handler *Handler) edgeStackUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	stack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}

--- a/api/http/handler/edgestacks/edgestack_update.go
+++ b/api/http/handler/edgestacks/edgestack_update.go
@@ -1,7 +1,7 @@
 package edgestacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -10,6 +10,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/edge"
 )
 
@@ -22,10 +23,10 @@ type updateEdgeStackPayload struct {
 
 func (payload *updateEdgeStackPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	if payload.EdgeGroups != nil && len(payload.EdgeGroups) == 0 {
-		return portainer.Error("Edge Groups are mandatory for an Edge stack")
+		return errors.New("Edge Groups are mandatory for an Edge stack")
 	}
 	return nil
 }
@@ -37,7 +38,7 @@ func (handler *Handler) edgeStackUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	stack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}

--- a/api/http/handler/endpointedge/endpoint_edgejob_logs.go
+++ b/api/http/handler/endpointedge/endpoint_edgejob_logs.go
@@ -7,7 +7,8 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type logsPayload struct {
@@ -26,7 +27,7 @@ func (handler *Handler) endpointEdgeJobsLogs(w http.ResponseWriter, r *http.Requ
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -49,7 +50,7 @@ func (handler *Handler) endpointEdgeJobsLogs(w http.ResponseWriter, r *http.Requ
 	}
 
 	edgeJob, err := handler.DataStore.EdgeJob().EdgeJob(portainer.EdgeJobID(edgeJobID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an edge job with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an edge job with the specified identifier inside the database", err}

--- a/api/http/handler/endpointedge/endpoint_edgestack_inspect.go
+++ b/api/http/handler/endpointedge/endpoint_edgestack_inspect.go
@@ -1,6 +1,7 @@
 package endpointedge
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -24,7 +25,7 @@ func (handler *Handler) endpointEdgeStackInspect(w http.ResponseWriter, r *http.
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -41,7 +42,7 @@ func (handler *Handler) endpointEdgeStackInspect(w http.ResponseWriter, r *http.
 	}
 
 	edgeStack, err := handler.DataStore.EdgeStack().EdgeStack(portainer.EdgeStackID(edgeStackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an edge stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an edge stack with the specified identifier inside the database", err}

--- a/api/http/handler/endpointedge/endpoint_edgestack_inspect.go
+++ b/api/http/handler/endpointedge/endpoint_edgestack_inspect.go
@@ -1,7 +1,6 @@
 package endpointedge
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 type configResponse struct {

--- a/api/http/handler/endpointgroups/endpointgroup_create.go
+++ b/api/http/handler/endpointgroups/endpointgroup_create.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -19,7 +20,7 @@ type endpointGroupCreatePayload struct {
 
 func (payload *endpointGroupCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid endpoint group name")
+		return errors.New("Invalid endpoint group name")
 	}
 	if payload.TagIDs == nil {
 		payload.TagIDs = []portainer.TagID{}

--- a/api/http/handler/endpointgroups/endpointgroup_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_delete.go
@@ -1,13 +1,14 @@
 package endpointgroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/endpoint_groups/:id
@@ -18,11 +19,11 @@ func (handler *Handler) endpointGroupDelete(w http.ResponseWriter, r *http.Reque
 	}
 
 	if endpointGroupID == 1 {
-		return &httperror.HandlerError{http.StatusForbidden, "Unable to remove the default 'Unassigned' group", portainer.ErrCannotRemoveDefaultGroup}
+		return &httperror.HandlerError{http.StatusForbidden, "Unable to remove the default 'Unassigned' group", errors.New("Cannot remove the default endpoint group")}
 	}
 
 	endpointGroup, err := handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_delete.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -21,7 +22,7 @@ func (handler *Handler) endpointGroupDelete(w http.ResponseWriter, r *http.Reque
 	}
 
 	endpointGroup, err := handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -22,14 +23,14 @@ func (handler *Handler) endpointGroupAddEndpoint(w http.ResponseWriter, r *http.
 	}
 
 	endpointGroup, err := handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
@@ -1,13 +1,13 @@
 package endpointgroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // PUT request on /api/endpoint_groups/:id/endpoints/:endpointId

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -22,14 +23,14 @@ func (handler *Handler) endpointGroupDeleteEndpoint(w http.ResponseWriter, r *ht
 	}
 
 	_, err = handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
@@ -1,13 +1,13 @@
 package endpointgroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/endpoint_groups/:id/endpoints/:endpointId

--- a/api/http/handler/endpointgroups/endpointgroup_inspect.go
+++ b/api/http/handler/endpointgroups/endpointgroup_inspect.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) endpointGroupInspect(w http.ResponseWriter, r *http.Requ
 	}
 
 	endpointGroup, err := handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_inspect.go
+++ b/api/http/handler/endpointgroups/endpointgroup_inspect.go
@@ -1,13 +1,13 @@
 package endpointgroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // GET request on /api/endpoint_groups/:id

--- a/api/http/handler/endpointgroups/endpointgroup_update.go
+++ b/api/http/handler/endpointgroups/endpointgroup_update.go
@@ -1,6 +1,7 @@
 package endpointgroups
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"reflect"
 
@@ -37,7 +38,7 @@ func (handler *Handler) endpointGroupUpdate(w http.ResponseWriter, r *http.Reque
 	}
 
 	endpointGroup, err := handler.DataStore.EndpointGroup().EndpointGroup(portainer.EndpointGroupID(endpointGroupID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint group with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint group with the specified identifier inside the database", err}

--- a/api/http/handler/endpointgroups/endpointgroup_update.go
+++ b/api/http/handler/endpointgroups/endpointgroup_update.go
@@ -1,7 +1,6 @@
 package endpointgroups
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"reflect"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/tag"
 )
 

--- a/api/http/handler/endpointproxy/proxy_azure.go
+++ b/api/http/handler/endpointproxy/proxy_azure.go
@@ -1,6 +1,7 @@
 package endpointproxy
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) proxyRequestsToAzureAPI(w http.ResponseWriter, r *http.R
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpointproxy/proxy_azure.go
+++ b/api/http/handler/endpointproxy/proxy_azure.go
@@ -1,12 +1,12 @@
 package endpointproxy
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 
 	"net/http"
 )

--- a/api/http/handler/endpointproxy/proxy_docker.go
+++ b/api/http/handler/endpointproxy/proxy_docker.go
@@ -8,6 +8,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 
 	"net/http"
 )
@@ -19,7 +20,7 @@ func (handler *Handler) proxyRequestsToDockerAPI(w http.ResponseWriter, r *http.
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpointproxy/proxy_kubernetes.go
+++ b/api/http/handler/endpointproxy/proxy_kubernetes.go
@@ -8,6 +8,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 
 	"net/http"
 )
@@ -19,7 +20,7 @@ func (handler *Handler) proxyRequestsToKubernetesAPI(w http.ResponseWriter, r *h
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpointproxy/proxy_storidge.go
+++ b/api/http/handler/endpointproxy/proxy_storidge.go
@@ -3,12 +3,13 @@ package endpointproxy
 // TODO: legacy extension management
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 
 	"net/http"
 )
@@ -20,7 +21,7 @@ func (handler *Handler) proxyRequestsToStoridgeAPI(w http.ResponseWriter, r *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -39,7 +40,7 @@ func (handler *Handler) proxyRequestsToStoridgeAPI(w http.ResponseWriter, r *htt
 	}
 
 	if storidgeExtension == nil {
-		return &httperror.HandlerError{http.StatusServiceUnavailable, "Storidge extension not supported on this endpoint", portainer.ErrEndpointExtensionNotSupported}
+		return &httperror.HandlerError{http.StatusServiceUnavailable, "Storidge extension not supported on this endpoint", errors.New("This extension is not supported")}
 	}
 
 	proxyExtensionKey := strconv.Itoa(endpointID) + "_" + strconv.Itoa(int(portainer.StoridgeEndpointExtension)) + "_" + storidgeExtension.URL

--- a/api/http/handler/endpointproxy/proxy_storidge.go
+++ b/api/http/handler/endpointproxy/proxy_storidge.go
@@ -3,6 +3,7 @@ package endpointproxy
 // TODO: legacy extension management
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -19,7 +20,7 @@ func (handler *Handler) proxyRequestsToStoridgeAPI(w http.ResponseWriter, r *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -39,13 +39,13 @@ type endpointCreatePayload struct {
 func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 	name, err := request.RetrieveMultiPartFormValue(r, "Name", false)
 	if err != nil {
-		return portainer.Error("Invalid endpoint name")
+		return errors.New("Invalid endpoint name")
 	}
 	payload.Name = name
 
 	endpointType, err := request.RetrieveNumericMultiPartFormValue(r, "EndpointType", false)
 	if err != nil || endpointType == 0 {
-		return portainer.Error("Invalid endpoint type value. Value must be one of: 1 (Docker environment), 2 (Agent environment), 3 (Azure environment) or 4 (Edge Agent environment)")
+		return errors.New("Invalid endpoint type value. Value must be one of: 1 (Docker environment), 2 (Agent environment), 3 (Azure environment) or 4 (Edge Agent environment)")
 	}
 	payload.EndpointType = endpointType
 
@@ -58,7 +58,7 @@ func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 	var tagIDs []portainer.TagID
 	err = request.RetrieveMultiPartFormJSONValue(r, "TagIds", &tagIDs, true)
 	if err != nil {
-		return portainer.Error("Invalid TagIds parameter")
+		return errors.New("Invalid TagIds parameter")
 	}
 	payload.TagIDs = tagIDs
 	if payload.TagIDs == nil {
@@ -77,7 +77,7 @@ func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 		if !payload.TLSSkipVerify {
 			caCert, _, err := request.RetrieveMultiPartFormFile(r, "TLSCACertFile")
 			if err != nil {
-				return portainer.Error("Invalid CA certificate file. Ensure that the file is uploaded correctly")
+				return errors.New("Invalid CA certificate file. Ensure that the file is uploaded correctly")
 			}
 			payload.TLSCACertFile = caCert
 		}
@@ -85,13 +85,13 @@ func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 		if !payload.TLSSkipClientVerify {
 			cert, _, err := request.RetrieveMultiPartFormFile(r, "TLSCertFile")
 			if err != nil {
-				return portainer.Error("Invalid certificate file. Ensure that the file is uploaded correctly")
+				return errors.New("Invalid certificate file. Ensure that the file is uploaded correctly")
 			}
 			payload.TLSCertFile = cert
 
 			key, _, err := request.RetrieveMultiPartFormFile(r, "TLSKeyFile")
 			if err != nil {
-				return portainer.Error("Invalid key file. Ensure that the file is uploaded correctly")
+				return errors.New("Invalid key file. Ensure that the file is uploaded correctly")
 			}
 			payload.TLSKeyFile = key
 		}
@@ -101,25 +101,25 @@ func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 	case portainer.AzureEnvironment:
 		azureApplicationID, err := request.RetrieveMultiPartFormValue(r, "AzureApplicationID", false)
 		if err != nil {
-			return portainer.Error("Invalid Azure application ID")
+			return errors.New("Invalid Azure application ID")
 		}
 		payload.AzureApplicationID = azureApplicationID
 
 		azureTenantID, err := request.RetrieveMultiPartFormValue(r, "AzureTenantID", false)
 		if err != nil {
-			return portainer.Error("Invalid Azure tenant ID")
+			return errors.New("Invalid Azure tenant ID")
 		}
 		payload.AzureTenantID = azureTenantID
 
 		azureAuthenticationKey, err := request.RetrieveMultiPartFormValue(r, "AzureAuthenticationKey", false)
 		if err != nil {
-			return portainer.Error("Invalid Azure authentication key")
+			return errors.New("Invalid Azure authentication key")
 		}
 		payload.AzureAuthenticationKey = azureAuthenticationKey
 	default:
 		endpointURL, err := request.RetrieveMultiPartFormValue(r, "URL", true)
 		if err != nil {
-			return portainer.Error("Invalid endpoint URL")
+			return errors.New("Invalid endpoint URL")
 		}
 		payload.URL = endpointURL
 

--- a/api/http/handler/endpoints/endpoint_delete.go
+++ b/api/http/handler/endpoints/endpoint_delete.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -18,7 +19,7 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_delete.go
+++ b/api/http/handler/endpoints/endpoint_delete.go
@@ -1,7 +1,6 @@
 package endpoints
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/endpoints/:id

--- a/api/http/handler/endpoints/endpoint_extension_add.go
+++ b/api/http/handler/endpoints/endpoint_extension_add.go
@@ -3,6 +3,7 @@ package endpoints
 // TODO: legacy extension management
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -35,7 +36,7 @@ func (handler *Handler) endpointExtensionAdd(w http.ResponseWriter, r *http.Requ
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_extension_add.go
+++ b/api/http/handler/endpoints/endpoint_extension_add.go
@@ -3,7 +3,7 @@ package endpoints
 // TODO: legacy extension management
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -11,6 +11,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type endpointExtensionAddPayload struct {
@@ -20,10 +21,10 @@ type endpointExtensionAddPayload struct {
 
 func (payload *endpointExtensionAddPayload) Validate(r *http.Request) error {
 	if payload.Type != 1 {
-		return portainer.Error("Invalid type value. Value must be one of: 1 (Storidge)")
+		return errors.New("Invalid type value. Value must be one of: 1 (Storidge)")
 	}
 	if payload.Type == 1 && govalidator.IsNull(payload.URL) {
-		return portainer.Error("Invalid extension URL")
+		return errors.New("Invalid extension URL")
 	}
 	return nil
 }
@@ -36,7 +37,7 @@ func (handler *Handler) endpointExtensionAdd(w http.ResponseWriter, r *http.Requ
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_extension_remove.go
+++ b/api/http/handler/endpoints/endpoint_extension_remove.go
@@ -3,6 +3,7 @@ package endpoints
 // TODO: legacy extension management
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -19,7 +20,7 @@ func (handler *Handler) endpointExtensionRemove(w http.ResponseWriter, r *http.R
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_extension_remove.go
+++ b/api/http/handler/endpoints/endpoint_extension_remove.go
@@ -3,13 +3,13 @@ package endpoints
 // TODO: legacy extension management
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/endpoints/:id/extensions/:extensionType

--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) endpointInspect(w http.ResponseWriter, r *http.Request) 
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -1,13 +1,13 @@
 package endpoints
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // GET request on /api/endpoints/:id

--- a/api/http/handler/endpoints/endpoint_snapshot.go
+++ b/api/http/handler/endpoints/endpoint_snapshot.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -18,7 +19,7 @@ func (handler *Handler) endpointSnapshot(w http.ResponseWriter, r *http.Request)
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_snapshot.go
+++ b/api/http/handler/endpoints/endpoint_snapshot.go
@@ -1,13 +1,13 @@
 package endpoints
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/snapshot"
 )
 

--- a/api/http/handler/endpoints/endpoint_status_inspect.go
+++ b/api/http/handler/endpoints/endpoint_status_inspect.go
@@ -7,7 +7,8 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 type stackStatusResponse struct {
@@ -40,7 +41,7 @@ func (handler *Handler) endpointStatusInspect(w http.ResponseWriter, r *http.Req
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -1,7 +1,6 @@
 package endpoints
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -10,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/client"
 	"github.com/portainer/portainer/api/internal/edge"
 	"github.com/portainer/portainer/api/internal/tag"

--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -51,7 +52,7 @@ func (handler *Handler) endpointUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/extensions/extension_create.go
+++ b/api/http/handler/extensions/extension_create.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -43,7 +44,7 @@ func (handler *Handler) extensionCreate(w http.ResponseWriter, r *http.Request) 
 
 	for _, existingExtension := range extensions {
 		if existingExtension.ID == extensionID && existingExtension.Enabled {
-			return &httperror.HandlerError{http.StatusConflict, "Unable to enable extension", portainer.ErrExtensionAlreadyEnabled}
+			return &httperror.HandlerError{http.StatusConflict, "Unable to enable extension", errors.New("This extension is already enabled")}
 		}
 	}
 

--- a/api/http/handler/extensions/extension_create.go
+++ b/api/http/handler/extensions/extension_create.go
@@ -18,7 +18,7 @@ type extensionCreatePayload struct {
 
 func (payload *extensionCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.License) {
-		return portainer.Error("Invalid license")
+		return errors.New("Invalid license")
 	}
 
 	return nil

--- a/api/http/handler/extensions/extension_delete.go
+++ b/api/http/handler/extensions/extension_delete.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -18,7 +19,7 @@ func (handler *Handler) extensionDelete(w http.ResponseWriter, r *http.Request) 
 	extensionID := portainer.ExtensionID(extensionIdentifier)
 
 	extension, err := handler.DataStore.Extension().Extension(extensionID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a extension with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/extensions/extension_delete.go
+++ b/api/http/handler/extensions/extension_delete.go
@@ -1,13 +1,13 @@
 package extensions
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/extensions/:id

--- a/api/http/handler/extensions/extension_inspect.go
+++ b/api/http/handler/extensions/extension_inspect.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/portainer/portainer/api/http/client"
@@ -26,7 +27,7 @@ func (handler *Handler) extensionInspect(w http.ResponseWriter, r *http.Request)
 	}
 
 	localExtension, err := handler.DataStore.Extension().Extension(extensionID)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve extension information from the database", err}
 	}
 

--- a/api/http/handler/extensions/extension_inspect.go
+++ b/api/http/handler/extensions/extension_inspect.go
@@ -1,15 +1,14 @@
 package extensions
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
-
-	"github.com/portainer/portainer/api/http/client"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/client"
 )
 
 // GET request on /api/extensions/:id

--- a/api/http/handler/extensions/extension_update.go
+++ b/api/http/handler/extensions/extension_update.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -36,7 +37,7 @@ func (handler *Handler) extensionUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(extensionID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a extension with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/extensions/extension_update.go
+++ b/api/http/handler/extensions/extension_update.go
@@ -1,7 +1,7 @@
 package extensions
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type extensionUpdatePayload struct {
@@ -17,7 +18,7 @@ type extensionUpdatePayload struct {
 
 func (payload *extensionUpdatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Version) {
-		return portainer.Error("Invalid extension version")
+		return errors.New("Invalid extension version")
 	}
 
 	return nil
@@ -37,7 +38,7 @@ func (handler *Handler) extensionUpdate(w http.ResponseWriter, r *http.Request) 
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(extensionID)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a extension with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/extensions/extension_upload.go
+++ b/api/http/handler/extensions/extension_upload.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -19,13 +20,13 @@ type extensionUploadPayload struct {
 func (payload *extensionUploadPayload) Validate(r *http.Request) error {
 	license, err := request.RetrieveMultiPartFormValue(r, "License", false)
 	if err != nil {
-		return portainer.Error("Invalid license")
+		return errors.New("Invalid license")
 	}
 	payload.License = license
 
 	fileData, fileName, err := request.RetrieveMultiPartFormFile(r, "file")
 	if err != nil {
-		return portainer.Error("Invalid extension archive file. Ensure that the file is uploaded correctly")
+		return errors.New("Invalid extension archive file. Ensure that the file is uploaded correctly")
 	}
 	payload.ExtensionArchive = fileData
 	payload.ArchiveFileName = fileName

--- a/api/http/handler/registries/proxy.go
+++ b/api/http/handler/registries/proxy.go
@@ -2,6 +2,7 @@ package registries
 
 import (
 	"encoding/json"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -18,7 +19,7 @@ func (handler *Handler) proxyRequestsToRegistryAPI(w http.ResponseWriter, r *htt
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -30,7 +31,7 @@ func (handler *Handler) proxyRequestsToRegistryAPI(w http.ResponseWriter, r *htt
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RegistryManagementExtension)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Registry management extension is not enabled", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/registries/proxy.go
+++ b/api/http/handler/registries/proxy.go
@@ -2,13 +2,14 @@ package registries
 
 import (
 	"encoding/json"
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 )
 
 // request on /api/registries/:id/v2
@@ -19,7 +20,7 @@ func (handler *Handler) proxyRequestsToRegistryAPI(w http.ResponseWriter, r *htt
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -27,11 +28,11 @@ func (handler *Handler) proxyRequestsToRegistryAPI(w http.ResponseWriter, r *htt
 
 	err = handler.requestBouncer.RegistryAccess(r, registry)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", portainer.ErrEndpointAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", errors.ErrEndpointAccessDenied}
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RegistryManagementExtension)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Registry management extension is not enabled", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/registries/proxy_management_gitlab.go
+++ b/api/http/handler/registries/proxy_management_gitlab.go
@@ -2,6 +2,7 @@ package registries
 
 import (
 	"encoding/json"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -18,7 +19,7 @@ func (handler *Handler) proxyRequestsToGitlabAPIWithRegistry(w http.ResponseWrit
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -30,7 +31,7 @@ func (handler *Handler) proxyRequestsToGitlabAPIWithRegistry(w http.ResponseWrit
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RegistryManagementExtension)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Registry management extension is not enabled", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/registries/proxy_management_gitlab.go
+++ b/api/http/handler/registries/proxy_management_gitlab.go
@@ -2,13 +2,14 @@ package registries
 
 import (
 	"encoding/json"
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 )
 
 // request on /api/registries/{id}/proxies/gitlab
@@ -19,7 +20,7 @@ func (handler *Handler) proxyRequestsToGitlabAPIWithRegistry(w http.ResponseWrit
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -27,11 +28,11 @@ func (handler *Handler) proxyRequestsToGitlabAPIWithRegistry(w http.ResponseWrit
 
 	err = handler.requestBouncer.RegistryAccess(r, registry)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", portainer.ErrEndpointAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", errors.ErrEndpointAccessDenied}
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RegistryManagementExtension)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Registry management extension is not enabled", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a extension with the specified identifier inside the database", err}

--- a/api/http/handler/registries/registry_configure.go
+++ b/api/http/handler/registries/registry_configure.go
@@ -1,6 +1,7 @@
 package registries
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -79,7 +80,7 @@ func (handler *Handler) registryConfigure(w http.ResponseWriter, r *http.Request
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}

--- a/api/http/handler/registries/registry_configure.go
+++ b/api/http/handler/registries/registry_configure.go
@@ -1,7 +1,7 @@
 package registries
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type registryConfigurePayload struct {
@@ -29,7 +30,7 @@ func (payload *registryConfigurePayload) Validate(r *http.Request) error {
 	if useAuthentication {
 		username, err := request.RetrieveMultiPartFormValue(r, "Username", false)
 		if err != nil {
-			return portainer.Error("Invalid username")
+			return errors.New("Invalid username")
 		}
 		payload.Username = username
 
@@ -46,19 +47,19 @@ func (payload *registryConfigurePayload) Validate(r *http.Request) error {
 	if useTLS && !skipTLSVerify {
 		cert, _, err := request.RetrieveMultiPartFormFile(r, "TLSCertFile")
 		if err != nil {
-			return portainer.Error("Invalid certificate file. Ensure that the file is uploaded correctly")
+			return errors.New("Invalid certificate file. Ensure that the file is uploaded correctly")
 		}
 		payload.TLSCertFile = cert
 
 		key, _, err := request.RetrieveMultiPartFormFile(r, "TLSKeyFile")
 		if err != nil {
-			return portainer.Error("Invalid key file. Ensure that the file is uploaded correctly")
+			return errors.New("Invalid key file. Ensure that the file is uploaded correctly")
 		}
 		payload.TLSKeyFile = key
 
 		ca, _, err := request.RetrieveMultiPartFormFile(r, "TLSCACertFile")
 		if err != nil {
-			return portainer.Error("Invalid CA certificate file. Ensure that the file is uploaded correctly")
+			return errors.New("Invalid CA certificate file. Ensure that the file is uploaded correctly")
 		}
 		payload.TLSCACertFile = ca
 	}
@@ -80,7 +81,7 @@ func (handler *Handler) registryConfigure(w http.ResponseWriter, r *http.Request
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}

--- a/api/http/handler/registries/registry_create.go
+++ b/api/http/handler/registries/registry_create.go
@@ -1,6 +1,7 @@
 package registries
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -22,16 +23,16 @@ type registryCreatePayload struct {
 
 func (payload *registryCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid registry name")
+		return errors.New("Invalid registry name")
 	}
 	if govalidator.IsNull(payload.URL) {
-		return portainer.Error("Invalid registry URL")
+		return errors.New("Invalid registry URL")
 	}
 	if payload.Authentication && (govalidator.IsNull(payload.Username) || govalidator.IsNull(payload.Password)) {
-		return portainer.Error("Invalid credentials. Username and password must be specified when authentication is enabled")
+		return errors.New("Invalid credentials. Username and password must be specified when authentication is enabled")
 	}
 	if payload.Type != portainer.QuayRegistry && payload.Type != portainer.AzureRegistry && payload.Type != portainer.CustomRegistry && payload.Type != portainer.GitlabRegistry {
-		return portainer.Error("Invalid registry type. Valid values are: 1 (Quay.io), 2 (Azure container registry), 3 (custom registry) or 4 (Gitlab registry)")
+		return errors.New("Invalid registry type. Valid values are: 1 (Quay.io), 2 (Azure container registry), 3 (custom registry) or 4 (Gitlab registry)")
 	}
 	return nil
 }

--- a/api/http/handler/registries/registry_delete.go
+++ b/api/http/handler/registries/registry_delete.go
@@ -1,6 +1,7 @@
 package registries
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) registryDelete(w http.ResponseWriter, r *http.Request) *
 	}
 
 	_, err = handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}

--- a/api/http/handler/registries/registry_delete.go
+++ b/api/http/handler/registries/registry_delete.go
@@ -1,13 +1,13 @@
 package registries
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/registries/:id

--- a/api/http/handler/registries/registry_inspect.go
+++ b/api/http/handler/registries/registry_inspect.go
@@ -1,6 +1,7 @@
 package registries
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) registryInspect(w http.ResponseWriter, r *http.Request) 
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}

--- a/api/http/handler/registries/registry_inspect.go
+++ b/api/http/handler/registries/registry_inspect.go
@@ -1,8 +1,10 @@
 package registries
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
+
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
@@ -18,7 +20,7 @@ func (handler *Handler) registryInspect(w http.ResponseWriter, r *http.Request) 
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -26,7 +28,7 @@ func (handler *Handler) registryInspect(w http.ResponseWriter, r *http.Request) 
 
 	err = handler.requestBouncer.RegistryAccess(r, registry)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", portainer.ErrEndpointAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access registry", errors.ErrEndpointAccessDenied}
 	}
 
 	hideFields(registry)

--- a/api/http/handler/registries/registry_update.go
+++ b/api/http/handler/registries/registry_update.go
@@ -1,13 +1,14 @@
 package registries
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type registryUpdatePayload struct {
@@ -38,7 +39,7 @@ func (handler *Handler) registryUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}
@@ -55,7 +56,7 @@ func (handler *Handler) registryUpdate(w http.ResponseWriter, r *http.Request) *
 		}
 		for _, r := range registries {
 			if r.ID != registry.ID && hasSameURL(&r, registry) {
-				return &httperror.HandlerError{http.StatusConflict, "Another registry with the same URL already exists", portainer.ErrRegistryAlreadyExists}
+				return &httperror.HandlerError{http.StatusConflict, "Another registry with the same URL already exists", errors.New("A registry is already defined for this URL")}
 			}
 		}
 

--- a/api/http/handler/registries/registry_update.go
+++ b/api/http/handler/registries/registry_update.go
@@ -1,6 +1,7 @@
 package registries
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -37,7 +38,7 @@ func (handler *Handler) registryUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	registry, err := handler.DataStore.Registry().Registry(portainer.RegistryID(registryID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a registry with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a registry with the specified identifier inside the database", err}

--- a/api/http/handler/resourcecontrols/resourcecontrol_delete.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_delete.go
@@ -1,6 +1,7 @@
 package resourcecontrols
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) resourceControlDelete(w http.ResponseWriter, r *http.Req
 	}
 
 	_, err = handler.DataStore.ResourceControl().ResourceControl(portainer.ResourceControlID(resourceControlID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a resource control with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a resource control with with the specified identifier inside the database", err}

--- a/api/http/handler/resourcecontrols/resourcecontrol_delete.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_delete.go
@@ -1,13 +1,13 @@
 package resourcecontrols
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/resource_controls/:id

--- a/api/http/handler/resourcecontrols/resourcecontrol_update.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -43,7 +44,7 @@ func (handler *Handler) resourceControlUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	resourceControl, err := handler.DataStore.ResourceControl().ResourceControl(portainer.ResourceControlID(resourceControlID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a resource control with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a resource control with with the specified identifier inside the database", err}

--- a/api/http/handler/resourcecontrols/resourcecontrol_update.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -56,7 +57,7 @@ func (handler *Handler) resourceControlUpdate(w http.ResponseWriter, r *http.Req
 	}
 
 	if !security.AuthorizedResourceControlAccess(resourceControl, securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access the resource control", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access the resource control", httperrors.ErrResourceAccessDenied}
 	}
 
 	resourceControl.Public = payload.Public
@@ -83,7 +84,7 @@ func (handler *Handler) resourceControlUpdate(w http.ResponseWriter, r *http.Req
 	resourceControl.TeamAccesses = teamAccesses
 
 	if !security.AuthorizedResourceControlUpdate(resourceControl, securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the resource control", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the resource control", httperrors.ErrResourceAccessDenied}
 	}
 
 	err = handler.DataStore.ResourceControl().UpdateResourceControl(resourceControl.ID, resourceControl)

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"time"
 
@@ -169,7 +170,7 @@ func (handler *Handler) updateVolumeBrowserSetting(settings *portainer.Settings)
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return err
 	}
 

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -1,7 +1,7 @@
 package settings
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 	"time"
 
@@ -10,6 +10,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/filesystem"
 )
 
@@ -32,18 +33,18 @@ type settingsUpdatePayload struct {
 
 func (payload *settingsUpdatePayload) Validate(r *http.Request) error {
 	if *payload.AuthenticationMethod != 1 && *payload.AuthenticationMethod != 2 && *payload.AuthenticationMethod != 3 {
-		return portainer.Error("Invalid authentication method value. Value must be one of: 1 (internal), 2 (LDAP/AD) or 3 (OAuth)")
+		return errors.New("Invalid authentication method value. Value must be one of: 1 (internal), 2 (LDAP/AD) or 3 (OAuth)")
 	}
 	if payload.LogoURL != nil && *payload.LogoURL != "" && !govalidator.IsURL(*payload.LogoURL) {
-		return portainer.Error("Invalid logo URL. Must correspond to a valid URL format")
+		return errors.New("Invalid logo URL. Must correspond to a valid URL format")
 	}
 	if payload.TemplatesURL != nil && *payload.TemplatesURL != "" && !govalidator.IsURL(*payload.TemplatesURL) {
-		return portainer.Error("Invalid external templates URL. Must correspond to a valid URL format")
+		return errors.New("Invalid external templates URL. Must correspond to a valid URL format")
 	}
 	if payload.UserSessionTimeout != nil {
 		_, err := time.ParseDuration(*payload.UserSessionTimeout)
 		if err != nil {
-			return portainer.Error("Invalid user session timeout")
+			return errors.New("Invalid user session timeout")
 		}
 	}
 
@@ -170,7 +171,7 @@ func (handler *Handler) updateVolumeBrowserSetting(settings *portainer.Settings)
 	}
 
 	extension, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return err
 	}
 

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -54,7 +54,7 @@ func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter,
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 
@@ -139,7 +139,7 @@ func (handler *Handler) createComposeStackFromGitRepository(w http.ResponseWrite
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 
@@ -234,7 +234,7 @@ func (handler *Handler) createComposeStackFromFileUpload(w http.ResponseWriter, 
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -31,11 +31,11 @@ type composeStackFromFileContentPayload struct {
 
 func (payload *composeStackFromFileContentPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	payload.Name = normalizeStackName(payload.Name)
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	return nil
 }
@@ -110,14 +110,14 @@ type composeStackFromGitRepositoryPayload struct {
 
 func (payload *composeStackFromGitRepositoryPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	payload.Name = normalizeStackName(payload.Name)
 	if govalidator.IsNull(payload.RepositoryURL) || !govalidator.IsURL(payload.RepositoryURL) {
-		return portainer.Error("Invalid repository URL. Must correspond to a valid URL format")
+		return errors.New("Invalid repository URL. Must correspond to a valid URL format")
 	}
 	if payload.RepositoryAuthentication && (govalidator.IsNull(payload.RepositoryUsername) || govalidator.IsNull(payload.RepositoryPassword)) {
-		return portainer.Error("Invalid repository credentials. Username and password must be specified when authentication is enabled")
+		return errors.New("Invalid repository credentials. Username and password must be specified when authentication is enabled")
 	}
 	if govalidator.IsNull(payload.ComposeFilePathInRepository) {
 		payload.ComposeFilePathInRepository = filesystem.ComposeFileDefaultName
@@ -201,20 +201,20 @@ type composeStackFromFileUploadPayload struct {
 func (payload *composeStackFromFileUploadPayload) Validate(r *http.Request) error {
 	name, err := request.RetrieveMultiPartFormValue(r, "Name", false)
 	if err != nil {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	payload.Name = normalizeStackName(name)
 
 	composeFileContent, _, err := request.RetrieveMultiPartFormFile(r, "file")
 	if err != nil {
-		return portainer.Error("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
+		return errors.New("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
 	}
 	payload.StackFileContent = composeFileContent
 
 	var env []portainer.Pair
 	err = request.RetrieveMultiPartFormJSONValue(r, "Env", &env, true)
 	if err != nil {
-		return portainer.Error("Invalid Env parameter")
+		return errors.New("Invalid Env parameter")
 	}
 	payload.Env = env
 	return nil

--- a/api/http/handler/stacks/create_kubernetes_stack.go
+++ b/api/http/handler/stacks/create_kubernetes_stack.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -19,10 +20,10 @@ type kubernetesStackPayload struct {
 
 func (payload *kubernetesStackPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	if govalidator.IsNull(payload.Namespace) {
-		return portainer.Error("Invalid namespace")
+		return errors.New("Invalid namespace")
 	}
 	return nil
 }

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -49,7 +49,7 @@ func (handler *Handler) createSwarmStackFromFileContent(w http.ResponseWriter, r
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 
@@ -138,7 +138,7 @@ func (handler *Handler) createSwarmStackFromGitRepository(w http.ResponseWriter,
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 
@@ -241,7 +241,7 @@ func (handler *Handler) createSwarmStackFromFileUpload(w http.ResponseWriter, r 
 
 	for _, stack := range stacks {
 		if strings.EqualFold(stack.Name, payload.Name) {
-			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", portainer.ErrStackAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "A stack with this name already exists", errStackAlreadyExists}
 		}
 	}
 

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -24,13 +24,13 @@ type swarmStackFromFileContentPayload struct {
 
 func (payload *swarmStackFromFileContentPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	if govalidator.IsNull(payload.SwarmID) {
-		return portainer.Error("Invalid Swarm ID")
+		return errors.New("Invalid Swarm ID")
 	}
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	return nil
 }
@@ -107,16 +107,16 @@ type swarmStackFromGitRepositoryPayload struct {
 
 func (payload *swarmStackFromGitRepositoryPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	if govalidator.IsNull(payload.SwarmID) {
-		return portainer.Error("Invalid Swarm ID")
+		return errors.New("Invalid Swarm ID")
 	}
 	if govalidator.IsNull(payload.RepositoryURL) || !govalidator.IsURL(payload.RepositoryURL) {
-		return portainer.Error("Invalid repository URL. Must correspond to a valid URL format")
+		return errors.New("Invalid repository URL. Must correspond to a valid URL format")
 	}
 	if payload.RepositoryAuthentication && (govalidator.IsNull(payload.RepositoryUsername) || govalidator.IsNull(payload.RepositoryPassword)) {
-		return portainer.Error("Invalid repository credentials. Username and password must be specified when authentication is enabled")
+		return errors.New("Invalid repository credentials. Username and password must be specified when authentication is enabled")
 	}
 	if govalidator.IsNull(payload.ComposeFilePathInRepository) {
 		payload.ComposeFilePathInRepository = filesystem.ComposeFileDefaultName
@@ -202,26 +202,26 @@ type swarmStackFromFileUploadPayload struct {
 func (payload *swarmStackFromFileUploadPayload) Validate(r *http.Request) error {
 	name, err := request.RetrieveMultiPartFormValue(r, "Name", false)
 	if err != nil {
-		return portainer.Error("Invalid stack name")
+		return errors.New("Invalid stack name")
 	}
 	payload.Name = name
 
 	swarmID, err := request.RetrieveMultiPartFormValue(r, "SwarmID", false)
 	if err != nil {
-		return portainer.Error("Invalid Swarm ID")
+		return errors.New("Invalid Swarm ID")
 	}
 	payload.SwarmID = swarmID
 
 	composeFileContent, _, err := request.RetrieveMultiPartFormFile(r, "file")
 	if err != nil {
-		return portainer.Error("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
+		return errors.New("Invalid Compose file. Ensure that the Compose file is uploaded correctly")
 	}
 	payload.StackFileContent = composeFileContent
 
 	var env []portainer.Pair
 	err = request.RetrieveMultiPartFormJSONValue(r, "Env", &env, true)
 	if err != nil {
-		return portainer.Error("Invalid Env parameter")
+		return errors.New("Invalid Env parameter")
 	}
 	payload.Env = env
 	return nil

--- a/api/http/handler/stacks/handler.go
+++ b/api/http/handler/stacks/handler.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"sync"
 
@@ -65,9 +66,9 @@ func (handler *Handler) userCanAccessStack(securityContext *security.RestrictedR
 	}
 
 	_, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return false, nil
-	} else if err != nil && err != portainer.ErrObjectNotFound {
+	} else if err != nil && err != errors.ErrObjectNotFound {
 		return false, err
 	}
 

--- a/api/http/handler/stacks/handler.go
+++ b/api/http/handler/stacks/handler.go
@@ -1,15 +1,21 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 	"sync"
 
 	"github.com/gorilla/mux"
 	httperror "github.com/portainer/libhttp/error"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
+)
+
+var (
+	errStackAlreadyExists = errors.New("A stack already exists with this name")
+	errStackNotExternal   = errors.New("Not an external stack")
 )
 
 // Handler is the HTTP handler used to handle stack operations.
@@ -66,9 +72,9 @@ func (handler *Handler) userCanAccessStack(securityContext *security.RestrictedR
 	}
 
 	_, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return false, nil
-	} else if err != nil && err != errors.ErrObjectNotFound {
+	} else if err != nil && err != bolterrors.ErrObjectNotFound {
 		return false, err
 	}
 

--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
 )
@@ -45,7 +46,7 @@ func (handler *Handler) stackCreate(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
 )
@@ -69,7 +70,7 @@ func (handler *Handler) stackCreate(w http.ResponseWriter, r *http.Request) *htt
 		return handler.createComposeStack(w, r, method, endpoint, tokenData.ID)
 	case portainer.KubernetesStack:
 		if tokenData.Role != portainer.AdministratorRole {
-			return &httperror.HandlerError{http.StatusForbidden, "Access denied", portainer.ErrUnauthorized}
+			return &httperror.HandlerError{http.StatusForbidden, "Access denied", httperrors.ErrUnauthorized}
 		}
 
 		return handler.createKubernetesStack(w, r, endpoint)

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -79,7 +80,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", httperrors.ErrResourceAccessDenied}
 	}
 
 	err = handler.deleteStack(stack, endpoint)
@@ -131,11 +132,11 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 
 	if rbacExtension != nil {
 		if !securityContext.IsAdmin && !endpointResourceAccess {
-			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", errors.ErrUnauthorized}
+			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", httperrors.ErrUnauthorized}
 		}
 	} else {
 		if !securityContext.IsAdmin {
-			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", errors.ErrUnauthorized}
+			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", httperrors.ErrUnauthorized}
 		}
 	}
 
@@ -144,7 +145,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check for stack existence inside the database", err}
 	}
 	if stack != nil {
-		return &httperror.HandlerError{http.StatusBadRequest, "A stack with this name exists inside the database. Cannot use external delete method", portainer.ErrStackNotExternal}
+		return &httperror.HandlerError{http.StatusBadRequest, "A stack with this name exists inside the database. Cannot use external delete method", errors.New("A tag already exists with this name")}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -37,7 +38,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(id))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -57,7 +58,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(endpointIdentifier)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}
@@ -118,7 +119,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 	}
 
 	rbacExtension, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify if RBAC extension is loaded", err}
 	}
 
@@ -139,7 +140,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 	}
 
 	stack, err := handler.DataStore.Stack().StackByName(stackName)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check for stack existence inside the database", err}
 	}
 	if stack != nil {
@@ -147,7 +148,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -1,16 +1,16 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
-
-	"github.com/portainer/portainer/api/http/security"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
 )
 
 // DELETE request on /api/stacks/:id?external=<external>&endpointId=<endpointId>
@@ -38,7 +38,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(id))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -58,7 +58,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(endpointIdentifier)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}
@@ -119,7 +119,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 	}
 
 	rbacExtension, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify if RBAC extension is loaded", err}
 	}
 
@@ -131,16 +131,16 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 
 	if rbacExtension != nil {
 		if !securityContext.IsAdmin && !endpointResourceAccess {
-			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", portainer.ErrUnauthorized}
+			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", errors.ErrUnauthorized}
 		}
 	} else {
 		if !securityContext.IsAdmin {
-			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", portainer.ErrUnauthorized}
+			return &httperror.HandlerError{http.StatusUnauthorized, "Permission denied to delete the stack", errors.ErrUnauthorized}
 		}
 	}
 
 	stack, err := handler.DataStore.Stack().StackByName(stackName)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check for stack existence inside the database", err}
 	}
 	if stack != nil {
@@ -148,7 +148,7 @@ func (handler *Handler) deleteExternalStack(r *http.Request, w http.ResponseWrit
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -79,7 +79,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
 	}
 
 	err = handler.deleteStack(stack, endpoint)

--- a/api/http/handler/stacks/stack_file.go
+++ b/api/http/handler/stacks/stack_file.go
@@ -1,7 +1,6 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -9,6 +8,8 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -24,14 +25,14 @@ func (handler *Handler) stackFile(w http.ResponseWriter, r *http.Request) *httpe
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -57,7 +58,7 @@ func (handler *Handler) stackFile(w http.ResponseWriter, r *http.Request) *httpe
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
 	}
 
 	stackFileContent, err := handler.FileService.GetFileContent(path.Join(stack.ProjectPath, stack.EntryPoint))

--- a/api/http/handler/stacks/stack_file.go
+++ b/api/http/handler/stacks/stack_file.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"path"
 
@@ -23,14 +24,14 @@ func (handler *Handler) stackFile(w http.ResponseWriter, r *http.Request) *httpe
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/stacks/stack_inspect.go
+++ b/api/http/handler/stacks/stack_inspect.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -18,14 +19,14 @@ func (handler *Handler) stackInspect(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/stacks/stack_inspect.go
+++ b/api/http/handler/stacks/stack_inspect.go
@@ -1,13 +1,14 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -19,14 +20,14 @@ func (handler *Handler) stackInspect(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -52,7 +53,7 @@ func (handler *Handler) stackInspect(w http.ResponseWriter, r *http.Request) *ht
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
 	}
 
 	if resourceControl != nil {

--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -45,9 +46,9 @@ func (handler *Handler) stackList(w http.ResponseWriter, r *http.Request) *httpe
 	if !securityContext.IsAdmin {
 		rbacExtensionEnabled := true
 		_, err := handler.DataStore.Extension().Extension(portainer.RBACExtension)
-		if err == portainer.ErrObjectNotFound {
+		if err == errors.ErrObjectNotFound {
 			rbacExtensionEnabled = false
-		} else if err != nil && err != portainer.ErrObjectNotFound {
+		} else if err != nil && err != errors.ErrObjectNotFound {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check if RBAC extension is enabled", err}
 		}
 

--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -1,13 +1,13 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
 )

--- a/api/http/handler/stacks/stack_migrate.go
+++ b/api/http/handler/stacks/stack_migrate.go
@@ -1,13 +1,14 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -38,14 +39,14 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -71,7 +72,7 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
 	}
 
 	// TODO: this is a work-around for stacks created with Portainer version >= 1.17.1
@@ -86,7 +87,7 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	targetEndpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(payload.EndpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/stacks/stack_migrate.go
+++ b/api/http/handler/stacks/stack_migrate.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -37,14 +38,14 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -85,7 +86,7 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 	}
 
 	targetEndpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(payload.EndpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/stacks/stack_migrate.go
+++ b/api/http/handler/stacks/stack_migrate.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -8,7 +9,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -20,7 +21,7 @@ type stackMigratePayload struct {
 
 func (payload *stackMigratePayload) Validate(r *http.Request) error {
 	if payload.EndpointID == 0 {
-		return portainer.Error("Invalid endpoint identifier. Must be a positive number")
+		return errors.New("Invalid endpoint identifier. Must be a positive number")
 	}
 	return nil
 }
@@ -72,7 +73,7 @@ func (handler *Handler) stackMigrate(w http.ResponseWriter, r *http.Request) *ht
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", httperrors.ErrResourceAccessDenied}
 	}
 
 	// TODO: this is a work-around for stacks created with Portainer version >= 1.17.1

--- a/api/http/handler/stacks/stack_update.go
+++ b/api/http/handler/stacks/stack_update.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
 
@@ -46,7 +47,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -64,7 +65,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/handler/stacks/stack_update.go
+++ b/api/http/handler/stacks/stack_update.go
@@ -1,17 +1,17 @@
 package stacks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strconv"
-
-	"github.com/portainer/portainer/api/http/security"
 
 	"github.com/asaskevich/govalidator"
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
 )
 
 type updateComposeStackPayload struct {
@@ -47,7 +47,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	stack, err := handler.DataStore.Stack().Stack(portainer.StackID(stackID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a stack with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a stack with the specified identifier inside the database", err}
@@ -65,7 +65,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}
@@ -91,7 +91,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
 	}
 
 	updateError := handler.updateAndDeployStack(r, stack, endpoint)

--- a/api/http/handler/stacks/stack_update.go
+++ b/api/http/handler/stacks/stack_update.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -21,7 +22,7 @@ type updateComposeStackPayload struct {
 
 func (payload *updateComposeStackPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	return nil
 }
@@ -34,7 +35,7 @@ type updateSwarmStackPayload struct {
 
 func (payload *updateSwarmStackPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.StackFileContent) {
-		return portainer.Error("Invalid stack file content")
+		return errors.New("Invalid stack file content")
 	}
 	return nil
 }
@@ -91,7 +92,7 @@ func (handler *Handler) stackUpdate(w http.ResponseWriter, r *http.Request) *htt
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to verify user authorizations to validate stack access", err}
 	}
 	if !access {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to resource", httperrors.ErrResourceAccessDenied}
 	}
 
 	updateError := handler.updateAndDeployStack(r, stack, endpoint)

--- a/api/http/handler/tags/tag_create.go
+++ b/api/http/handler/tags/tag_create.go
@@ -1,6 +1,7 @@
 package tags
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -36,7 +37,7 @@ func (handler *Handler) tagCreate(w http.ResponseWriter, r *http.Request) *httpe
 
 	for _, tag := range tags {
 		if tag.Name == payload.Name {
-			return &httperror.HandlerError{http.StatusConflict, "This name is already associated to a tag", portainer.ErrTagAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "This name is already associated to a tag", errors.New("A tag already exists with this name")}
 		}
 	}
 

--- a/api/http/handler/tags/tag_create.go
+++ b/api/http/handler/tags/tag_create.go
@@ -17,7 +17,7 @@ type tagCreatePayload struct {
 
 func (payload *tagCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid tag name")
+		return errors.New("Invalid tag name")
 	}
 	return nil
 }

--- a/api/http/handler/tags/tag_delete.go
+++ b/api/http/handler/tags/tag_delete.go
@@ -1,6 +1,7 @@
 package tags
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -19,7 +20,7 @@ func (handler *Handler) tagDelete(w http.ResponseWriter, r *http.Request) *httpe
 	tagID := portainer.TagID(id)
 
 	tag, err := handler.DataStore.Tag().Tag(tagID)
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a tag with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a tag with the specified identifier inside the database", err}

--- a/api/http/handler/tags/tag_delete.go
+++ b/api/http/handler/tags/tag_delete.go
@@ -1,13 +1,13 @@
 package tags
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/internal/edge"
 )
 

--- a/api/http/handler/teammemberships/teammembership_create.go
+++ b/api/http/handler/teammemberships/teammembership_create.go
@@ -1,13 +1,14 @@
 package teammemberships
 
 import (
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -44,7 +45,7 @@ func (handler *Handler) teamMembershipCreate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(payload.TeamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to manage team memberships", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to manage team memberships", httperrors.ErrResourceAccessDenied}
 	}
 
 	memberships, err := handler.DataStore.TeamMembership().TeamMembershipsByUserID(portainer.UserID(payload.UserID))
@@ -55,7 +56,7 @@ func (handler *Handler) teamMembershipCreate(w http.ResponseWriter, r *http.Requ
 	if len(memberships) > 0 {
 		for _, membership := range memberships {
 			if membership.UserID == portainer.UserID(payload.UserID) && membership.TeamID == portainer.TeamID(payload.TeamID) {
-				return &httperror.HandlerError{http.StatusConflict, "Team membership already registered", portainer.ErrTeamMembershipAlreadyExists}
+				return &httperror.HandlerError{http.StatusConflict, "Team membership already registered", errors.New("Team membership already exists for this user and team")}
 			}
 		}
 	}

--- a/api/http/handler/teammemberships/teammembership_create.go
+++ b/api/http/handler/teammemberships/teammembership_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -43,7 +44,7 @@ func (handler *Handler) teamMembershipCreate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(payload.TeamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to manage team memberships", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to manage team memberships", errors.ErrResourceAccessDenied}
 	}
 
 	memberships, err := handler.DataStore.TeamMembership().TeamMembershipsByUserID(portainer.UserID(payload.UserID))

--- a/api/http/handler/teammemberships/teammembership_create.go
+++ b/api/http/handler/teammemberships/teammembership_create.go
@@ -20,13 +20,13 @@ type teamMembershipCreatePayload struct {
 
 func (payload *teamMembershipCreatePayload) Validate(r *http.Request) error {
 	if payload.UserID == 0 {
-		return portainer.Error("Invalid UserID")
+		return errors.New("Invalid UserID")
 	}
 	if payload.TeamID == 0 {
-		return portainer.Error("Invalid TeamID")
+		return errors.New("Invalid TeamID")
 	}
 	if payload.Role != 1 && payload.Role != 2 {
-		return portainer.Error("Invalid role value. Value must be one of: 1 (leader) or 2 (member)")
+		return errors.New("Invalid role value. Value must be one of: 1 (leader) or 2 (member)")
 	}
 	return nil
 }

--- a/api/http/handler/teammemberships/teammembership_delete.go
+++ b/api/http/handler/teammemberships/teammembership_delete.go
@@ -1,13 +1,14 @@
 package teammemberships
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -19,7 +20,7 @@ func (handler *Handler) teamMembershipDelete(w http.ResponseWriter, r *http.Requ
 	}
 
 	membership, err := handler.DataStore.TeamMembership().TeamMembership(portainer.TeamMembershipID(membershipID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team membership with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team membership with the specified identifier inside the database", err}
@@ -31,7 +32,7 @@ func (handler *Handler) teamMembershipDelete(w http.ResponseWriter, r *http.Requ
 	}
 
 	if !security.AuthorizedTeamManagement(membership.TeamID, securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to delete the membership", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to delete the membership", errors.ErrResourceAccessDenied}
 	}
 
 	err = handler.DataStore.TeamMembership().DeleteTeamMembership(portainer.TeamMembershipID(membershipID))

--- a/api/http/handler/teammemberships/teammembership_delete.go
+++ b/api/http/handler/teammemberships/teammembership_delete.go
@@ -1,6 +1,7 @@
 package teammemberships
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -18,7 +19,7 @@ func (handler *Handler) teamMembershipDelete(w http.ResponseWriter, r *http.Requ
 	}
 
 	membership, err := handler.DataStore.TeamMembership().TeamMembership(portainer.TeamMembershipID(membershipID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team membership with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team membership with the specified identifier inside the database", err}

--- a/api/http/handler/teammemberships/teammembership_list.go
+++ b/api/http/handler/teammemberships/teammembership_list.go
@@ -5,7 +5,7 @@ import (
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/response"
-	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -17,7 +17,7 @@ func (handler *Handler) teamMembershipList(w http.ResponseWriter, r *http.Reques
 	}
 
 	if !securityContext.IsAdmin && !securityContext.IsTeamLeader {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to list team memberships", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to list team memberships", errors.ErrResourceAccessDenied}
 	}
 
 	memberships, err := handler.DataStore.TeamMembership().TeamMemberships()

--- a/api/http/handler/teammemberships/teammembership_update.go
+++ b/api/http/handler/teammemberships/teammembership_update.go
@@ -1,6 +1,7 @@
 package teammemberships
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -52,7 +53,7 @@ func (handler *Handler) teamMembershipUpdate(w http.ResponseWriter, r *http.Requ
 	}
 
 	membership, err := handler.DataStore.TeamMembership().TeamMembership(portainer.TeamMembershipID(membershipID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team membership with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team membership with the specified identifier inside the database", err}

--- a/api/http/handler/teammemberships/teammembership_update.go
+++ b/api/http/handler/teammemberships/teammembership_update.go
@@ -1,13 +1,14 @@
 package teammemberships
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -49,18 +50,18 @@ func (handler *Handler) teamMembershipUpdate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(payload.TeamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the membership", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the membership", errors.ErrResourceAccessDenied}
 	}
 
 	membership, err := handler.DataStore.TeamMembership().TeamMembership(portainer.TeamMembershipID(membershipID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team membership with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team membership with the specified identifier inside the database", err}
 	}
 
 	if securityContext.IsTeamLeader && membership.Role != portainer.MembershipRole(payload.Role) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the role of membership", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the role of membership", errors.ErrResourceAccessDenied}
 	}
 
 	membership.UserID = portainer.UserID(payload.UserID)

--- a/api/http/handler/teammemberships/teammembership_update.go
+++ b/api/http/handler/teammemberships/teammembership_update.go
@@ -1,6 +1,7 @@
 package teammemberships
 
 import (
+	"errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -8,7 +9,7 @@ import (
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -20,13 +21,13 @@ type teamMembershipUpdatePayload struct {
 
 func (payload *teamMembershipUpdatePayload) Validate(r *http.Request) error {
 	if payload.UserID == 0 {
-		return portainer.Error("Invalid UserID")
+		return errors.New("Invalid UserID")
 	}
 	if payload.TeamID == 0 {
-		return portainer.Error("Invalid TeamID")
+		return errors.New("Invalid TeamID")
 	}
 	if payload.Role != 1 && payload.Role != 2 {
-		return portainer.Error("Invalid role value. Value must be one of: 1 (leader) or 2 (member)")
+		return errors.New("Invalid role value. Value must be one of: 1 (leader) or 2 (member)")
 	}
 	return nil
 }
@@ -50,7 +51,7 @@ func (handler *Handler) teamMembershipUpdate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(payload.TeamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the membership", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the membership", httperrors.ErrResourceAccessDenied}
 	}
 
 	membership, err := handler.DataStore.TeamMembership().TeamMembership(portainer.TeamMembershipID(membershipID))
@@ -61,7 +62,7 @@ func (handler *Handler) teamMembershipUpdate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if securityContext.IsTeamLeader && membership.Role != portainer.MembershipRole(payload.Role) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the role of membership", errors.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update the role of membership", httperrors.ErrResourceAccessDenied}
 	}
 
 	membership.UserID = portainer.UserID(payload.UserID)

--- a/api/http/handler/teams/team_create.go
+++ b/api/http/handler/teams/team_create.go
@@ -1,7 +1,7 @@
 package teams
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +9,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type teamCreatePayload struct {
@@ -30,11 +31,11 @@ func (handler *Handler) teamCreate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	team, err := handler.DataStore.Team().TeamByName(payload.Name)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve teams from the database", err}
 	}
 	if team != nil {
-		return &httperror.HandlerError{http.StatusConflict, "A team with the same name already exists", portainer.ErrTeamAlreadyExists}
+		return &httperror.HandlerError{http.StatusConflict, "A team with the same name already exists", errors.New("Team already exists")}
 	}
 
 	team = &portainer.Team{

--- a/api/http/handler/teams/team_create.go
+++ b/api/http/handler/teams/team_create.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -29,7 +30,7 @@ func (handler *Handler) teamCreate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	team, err := handler.DataStore.Team().TeamByName(payload.Name)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve teams from the database", err}
 	}
 	if team != nil {

--- a/api/http/handler/teams/team_create.go
+++ b/api/http/handler/teams/team_create.go
@@ -18,7 +18,7 @@ type teamCreatePayload struct {
 
 func (payload *teamCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Name) {
-		return portainer.Error("Invalid team name")
+		return errors.New("Invalid team name")
 	}
 	return nil
 }

--- a/api/http/handler/teams/team_delete.go
+++ b/api/http/handler/teams/team_delete.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -17,7 +18,7 @@ func (handler *Handler) teamDelete(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	_, err = handler.DataStore.Team().Team(portainer.TeamID(teamID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team with the specified identifier inside the database", err}

--- a/api/http/handler/teams/team_delete.go
+++ b/api/http/handler/teams/team_delete.go
@@ -1,13 +1,13 @@
 package teams
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // DELETE request on /api/teams/:id

--- a/api/http/handler/teams/team_inspect.go
+++ b/api/http/handler/teams/team_inspect.go
@@ -1,13 +1,14 @@
 package teams
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -24,11 +25,11 @@ func (handler *Handler) teamInspect(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(teamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to team", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to team", errors.ErrResourceAccessDenied}
 	}
 
 	team, err := handler.DataStore.Team().Team(portainer.TeamID(teamID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team with the specified identifier inside the database", err}

--- a/api/http/handler/teams/team_inspect.go
+++ b/api/http/handler/teams/team_inspect.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -27,7 +28,7 @@ func (handler *Handler) teamInspect(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	team, err := handler.DataStore.Team().Team(portainer.TeamID(teamID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team with the specified identifier inside the database", err}

--- a/api/http/handler/teams/team_memberships.go
+++ b/api/http/handler/teams/team_memberships.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -23,7 +24,7 @@ func (handler *Handler) teamMemberships(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if !security.AuthorizedTeamManagement(portainer.TeamID(teamID), securityContext) {
-		return &httperror.HandlerError{http.StatusForbidden, "Access denied to team", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Access denied to team", errors.ErrResourceAccessDenied}
 	}
 
 	memberships, err := handler.DataStore.TeamMembership().TeamMembershipsByTeamID(portainer.TeamID(teamID))

--- a/api/http/handler/teams/team_update.go
+++ b/api/http/handler/teams/team_update.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
@@ -31,7 +32,7 @@ func (handler *Handler) teamUpdate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	team, err := handler.DataStore.Team().Team(portainer.TeamID(teamID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a team with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a team with the specified identifier inside the database", err}

--- a/api/http/handler/teams/team_update.go
+++ b/api/http/handler/teams/team_update.go
@@ -1,13 +1,13 @@
 package teams
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 type teamUpdatePayload struct {

--- a/api/http/handler/upload/upload_tls.go
+++ b/api/http/handler/upload/upload_tls.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/filesystem"
 )
 
 // POST request on /api/upload/tls/{certificate:(?:ca|cert|key)}?folder=<folder>
@@ -35,7 +36,7 @@ func (handler *Handler) uploadTLS(w http.ResponseWriter, r *http.Request) *httpe
 	case "key":
 		fileType = portainer.TLSFileKey
 	default:
-		return &httperror.HandlerError{http.StatusBadRequest, "Invalid certificate route value. Value must be one of: ca, cert or key", portainer.ErrUndefinedTLSFileType}
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid certificate route value. Value must be one of: ca, cert or key", filesystem.ErrUndefinedTLSFileType}
 	}
 
 	_, err = handler.FileService.StoreTLSFileFromBytes(folder, fileType, file)

--- a/api/http/handler/users/admin_check.go
+++ b/api/http/handler/users/admin_check.go
@@ -6,6 +6,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // GET request on /api/users/admin/check
@@ -16,7 +17,7 @@ func (handler *Handler) adminCheck(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	if len(users) == 0 {
-		return &httperror.HandlerError{http.StatusNotFound, "No administrator account found inside the database", portainer.ErrObjectNotFound}
+		return &httperror.HandlerError{http.StatusNotFound, "No administrator account found inside the database", errors.ErrObjectNotFound}
 	}
 
 	return response.Empty(w)

--- a/api/http/handler/users/admin_init.go
+++ b/api/http/handler/users/admin_init.go
@@ -40,7 +40,7 @@ func (handler *Handler) adminInit(w http.ResponseWriter, r *http.Request) *httpe
 	}
 
 	if len(users) != 0 {
-		return &httperror.HandlerError{http.StatusConflict, "Unable to create administrator user", portainer.ErrAdminAlreadyInitialized}
+		return &httperror.HandlerError{http.StatusConflict, "Unable to create administrator user", errAdminAlreadyInitialized}
 	}
 
 	user := &portainer.User{
@@ -51,7 +51,7 @@ func (handler *Handler) adminInit(w http.ResponseWriter, r *http.Request) *httpe
 
 	user.Password, err = handler.CryptoService.Hash(payload.Password)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", portainer.ErrCryptoHashFailure}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", errCryptoHashFailure}
 	}
 
 	err = handler.DataStore.User().CreateUser(user)

--- a/api/http/handler/users/admin_init.go
+++ b/api/http/handler/users/admin_init.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -18,10 +19,10 @@ type adminInitPayload struct {
 
 func (payload *adminInitPayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Username) || govalidator.Contains(payload.Username, " ") {
-		return portainer.Error("Invalid username. Must not contain any whitespace")
+		return errors.New("Invalid username. Must not contain any whitespace")
 	}
 	if govalidator.IsNull(payload.Password) {
-		return portainer.Error("Invalid password")
+		return errors.New("Invalid password")
 	}
 	return nil
 }

--- a/api/http/handler/users/handler.go
+++ b/api/http/handler/users/handler.go
@@ -1,6 +1,8 @@
 package users
 
 import (
+	"errors"
+
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/http/security"
@@ -9,6 +11,14 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+)
+
+var (
+	errUserAlreadyExists          = errors.New("User already exists")
+	errAdminAlreadyInitialized    = errors.New("An administrator user already exists")
+	errAdminCannotRemoveSelf      = errors.New("Cannot remove your own user account. Contact another administrator")
+	errCannotRemoveLastLocalAdmin = errors.New("Cannot remove the last local administrator account")
+	errCryptoHashFailure          = errors.New("Unable to hash data")
 )
 
 func hideFields(user *portainer.User) {

--- a/api/http/handler/users/user_create.go
+++ b/api/http/handler/users/user_create.go
@@ -1,7 +1,6 @@
 package users
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +8,8 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
 )
@@ -44,15 +45,15 @@ func (handler *Handler) userCreate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	if !securityContext.IsAdmin && !securityContext.IsTeamLeader {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create user", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create user", errors.ErrResourceAccessDenied}
 	}
 
 	if securityContext.IsTeamLeader && payload.Role == 1 {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create administrator user", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create administrator user", errors.ErrResourceAccessDenied}
 	}
 
 	user, err := handler.DataStore.User().UserByUsername(payload.Username)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 	}
 	if user != nil {

--- a/api/http/handler/users/user_create.go
+++ b/api/http/handler/users/user_create.go
@@ -57,7 +57,7 @@ func (handler *Handler) userCreate(w http.ResponseWriter, r *http.Request) *http
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 	}
 	if user != nil {
-		return &httperror.HandlerError{http.StatusConflict, "Another user with the same username already exists", portainer.ErrUserAlreadyExists}
+		return &httperror.HandlerError{http.StatusConflict, "Another user with the same username already exists", errUserAlreadyExists}
 	}
 
 	user = &portainer.User{
@@ -74,7 +74,7 @@ func (handler *Handler) userCreate(w http.ResponseWriter, r *http.Request) *http
 	if settings.AuthenticationMethod == portainer.AuthenticationInternal {
 		user.Password, err = handler.CryptoService.Hash(payload.Password)
 		if err != nil {
-			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", portainer.ErrCryptoHashFailure}
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", errCryptoHashFailure}
 		}
 	}
 

--- a/api/http/handler/users/user_create.go
+++ b/api/http/handler/users/user_create.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -51,7 +52,7 @@ func (handler *Handler) userCreate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	user, err := handler.DataStore.User().UserByUsername(payload.Username)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 	}
 	if user != nil {

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -32,7 +33,7 @@ func (handler *Handler) userDelete(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -29,7 +29,7 @@ func (handler *Handler) userDelete(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	if tokenData.ID == portainer.UserID(userID) {
-		return &httperror.HandlerError{http.StatusForbidden, "Cannot remove your own user account. Contact another administrator", portainer.ErrAdminCannotRemoveSelf}
+		return &httperror.HandlerError{http.StatusForbidden, "Cannot remove your own user account. Contact another administrator", errAdminCannotRemoveSelf}
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
@@ -64,7 +64,7 @@ func (handler *Handler) deleteAdminUser(w http.ResponseWriter, user *portainer.U
 	}
 
 	if localAdminCount < 2 {
-		return &httperror.HandlerError{http.StatusInternalServerError, "Cannot remove local administrator user", portainer.ErrCannotRemoveLastLocalAdmin}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Cannot remove local administrator user", errCannotRemoveLastLocalAdmin}
 	}
 
 	return handler.deleteUser(w, user)

--- a/api/http/handler/users/user_inspect.go
+++ b/api/http/handler/users/user_inspect.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/portainer/portainer/api/http/security"
@@ -28,7 +29,7 @@ func (handler *Handler) userInspect(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}

--- a/api/http/handler/users/user_inspect.go
+++ b/api/http/handler/users/user_inspect.go
@@ -1,15 +1,15 @@
 package users
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
-
-	"github.com/portainer/portainer/api/http/security"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
 )
 
 // GET request on /api/users/:id
@@ -25,11 +25,11 @@ func (handler *Handler) userInspect(w http.ResponseWriter, r *http.Request) *htt
 	}
 
 	if !securityContext.IsAdmin && securityContext.UserID != portainer.UserID(userID) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied inspect user", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied inspect user", errors.ErrResourceAccessDenied}
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}

--- a/api/http/handler/users/user_memberships.go
+++ b/api/http/handler/users/user_memberships.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -23,7 +24,7 @@ func (handler *Handler) userMemberships(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if tokenData.Role != portainer.AdministratorRole && tokenData.ID != portainer.UserID(userID) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user memberships", portainer.ErrUnauthorized}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user memberships", errors.ErrUnauthorized}
 	}
 
 	memberships, err := handler.DataStore.TeamMembership().TeamMembershipsByUserID(portainer.UserID(userID))

--- a/api/http/handler/users/user_update.go
+++ b/api/http/handler/users/user_update.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -55,7 +56,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
@@ -63,7 +64,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 
 	if payload.Username != "" && payload.Username != user.Username {
 		sameNameUser, err := handler.DataStore.User().UserByUsername(payload.Username)
-		if err != nil && err != portainer.ErrObjectNotFound {
+		if err != nil && err != errors.ErrObjectNotFound {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 		}
 		if sameNameUser != nil && sameNameUser.ID != portainer.UserID(userID) {

--- a/api/http/handler/users/user_update.go
+++ b/api/http/handler/users/user_update.go
@@ -53,7 +53,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	if tokenData.Role != portainer.AdministratorRole && payload.Role != 0 {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user to administrator role", portainer.ErrResourceAccessDenied}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user to administrator role", errors.ErrResourceAccessDenied}
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))

--- a/api/http/handler/users/user_update.go
+++ b/api/http/handler/users/user_update.go
@@ -1,7 +1,6 @@
 package users
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +8,8 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -42,7 +43,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	if tokenData.Role != portainer.AdministratorRole && tokenData.ID != portainer.UserID(userID) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user", portainer.ErrUnauthorized}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user", errors.ErrUnauthorized}
 	}
 
 	var payload userUpdatePayload
@@ -56,7 +57,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
@@ -64,7 +65,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 
 	if payload.Username != "" && payload.Username != user.Username {
 		sameNameUser, err := handler.DataStore.User().UserByUsername(payload.Username)
-		if err != nil && err != errors.ErrObjectNotFound {
+		if err != nil && err != bolterrors.ErrObjectNotFound {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 		}
 		if sameNameUser != nil && sameNameUser.ID != portainer.UserID(userID) {

--- a/api/http/handler/users/user_update.go
+++ b/api/http/handler/users/user_update.go
@@ -69,7 +69,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve users from the database", err}
 		}
 		if sameNameUser != nil && sameNameUser.ID != portainer.UserID(userID) {
-			return &httperror.HandlerError{http.StatusConflict, "Another user with the same username already exists", portainer.ErrUserAlreadyExists}
+			return &httperror.HandlerError{http.StatusConflict, "Another user with the same username already exists", errUserAlreadyExists}
 		}
 
 		user.Username = payload.Username
@@ -78,7 +78,7 @@ func (handler *Handler) userUpdate(w http.ResponseWriter, r *http.Request) *http
 	if payload.Password != "" {
 		user.Password, err = handler.CryptoService.Hash(payload.Password)
 		if err != nil {
-			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", portainer.ErrCryptoHashFailure}
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", errCryptoHashFailure}
 		}
 	}
 

--- a/api/http/handler/users/user_update_password.go
+++ b/api/http/handler/users/user_update_password.go
@@ -1,7 +1,6 @@
 package users
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -9,6 +8,8 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
 
@@ -40,7 +41,7 @@ func (handler *Handler) userUpdatePassword(w http.ResponseWriter, r *http.Reques
 	}
 
 	if tokenData.Role != portainer.AdministratorRole && tokenData.ID != portainer.UserID(userID) {
-		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user", portainer.ErrUnauthorized}
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to update user", errors.ErrUnauthorized}
 	}
 
 	var payload userUpdatePasswordPayload
@@ -50,7 +51,7 @@ func (handler *Handler) userUpdatePassword(w http.ResponseWriter, r *http.Reques
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
@@ -58,7 +59,7 @@ func (handler *Handler) userUpdatePassword(w http.ResponseWriter, r *http.Reques
 
 	err = handler.CryptoService.CompareHashAndData(user.Password, payload.Password)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusForbidden, "Specified password do not match actual password", portainer.ErrUnauthorized}
+		return &httperror.HandlerError{http.StatusForbidden, "Specified password do not match actual password", errors.ErrUnauthorized}
 	}
 
 	user.Password, err = handler.CryptoService.Hash(payload.NewPassword)

--- a/api/http/handler/users/user_update_password.go
+++ b/api/http/handler/users/user_update_password.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -49,7 +50,7 @@ func (handler *Handler) userUpdatePassword(w http.ResponseWriter, r *http.Reques
 	}
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}

--- a/api/http/handler/users/user_update_password.go
+++ b/api/http/handler/users/user_update_password.go
@@ -64,7 +64,7 @@ func (handler *Handler) userUpdatePassword(w http.ResponseWriter, r *http.Reques
 
 	user.Password, err = handler.CryptoService.Hash(payload.NewPassword)
 	if err != nil {
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", portainer.ErrCryptoHashFailure}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to hash user password", errCryptoHashFailure}
 	}
 
 	err = handler.DataStore.User().UpdateUser(user.ID, user)

--- a/api/http/handler/webhooks/webhook_create.go
+++ b/api/http/handler/webhooks/webhook_create.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -38,7 +39,7 @@ func (handler *Handler) webhookCreate(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	webhook, err := handler.DataStore.Webhook().WebhookByResourceID(payload.ResourceID)
-	if err != nil && err != portainer.ErrObjectNotFound {
+	if err != nil && err != errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "An error occurred retrieving webhooks from the database", err}
 	}
 	if webhook != nil {

--- a/api/http/handler/webhooks/webhook_create.go
+++ b/api/http/handler/webhooks/webhook_create.go
@@ -1,7 +1,7 @@
 package webhooks
 
 import (
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
@@ -10,6 +10,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type webhookCreatePayload struct {
@@ -39,11 +40,11 @@ func (handler *Handler) webhookCreate(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	webhook, err := handler.DataStore.Webhook().WebhookByResourceID(payload.ResourceID)
-	if err != nil && err != errors.ErrObjectNotFound {
+	if err != nil && err != bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusInternalServerError, "An error occurred retrieving webhooks from the database", err}
 	}
 	if webhook != nil {
-		return &httperror.HandlerError{http.StatusConflict, "A webhook for this resource already exists", portainer.ErrWebhookAlreadyExists}
+		return &httperror.HandlerError{http.StatusConflict, "A webhook for this resource already exists", errors.New("A webhook for this resource already exists")}
 	}
 
 	token, err := uuid.NewV4()

--- a/api/http/handler/webhooks/webhook_create.go
+++ b/api/http/handler/webhooks/webhook_create.go
@@ -21,13 +21,13 @@ type webhookCreatePayload struct {
 
 func (payload *webhookCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.ResourceID) {
-		return portainer.Error("Invalid ResourceID")
+		return errors.New("Invalid ResourceID")
 	}
 	if payload.EndpointID == 0 {
-		return portainer.Error("Invalid EndpointID")
+		return errors.New("Invalid EndpointID")
 	}
 	if payload.WebhookType != 1 {
-		return portainer.Error("Invalid WebhookType")
+		return errors.New("Invalid WebhookType")
 	}
 	return nil
 }

--- a/api/http/handler/webhooks/webhook_execute.go
+++ b/api/http/handler/webhooks/webhook_execute.go
@@ -2,7 +2,7 @@ package webhooks
 
 import (
 	"context"
-	"github.com/portainer/portainer/api/bolt/errors"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -11,6 +11,7 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 // Acts on a passed in token UUID to restart the docker service
@@ -24,7 +25,7 @@ func (handler *Handler) webhookExecute(w http.ResponseWriter, r *http.Request) *
 
 	webhook, err := handler.DataStore.Webhook().WebhookByToken(webhookToken)
 
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a webhook with this token", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve webhook from the database", err}
@@ -35,7 +36,7 @@ func (handler *Handler) webhookExecute(w http.ResponseWriter, r *http.Request) *
 	webhookType := webhook.WebhookType
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == errors.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
@@ -47,7 +48,7 @@ func (handler *Handler) webhookExecute(w http.ResponseWriter, r *http.Request) *
 	case portainer.ServiceWebhook:
 		return handler.executeServiceWebhook(w, endpoint, resourceID, imageTag)
 	default:
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unsupported webhook type", portainer.ErrUnsupportedWebhookType}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unsupported webhook type", errors.New("Webhooks for this resource are not currently supported")}
 	}
 }
 

--- a/api/http/handler/webhooks/webhook_execute.go
+++ b/api/http/handler/webhooks/webhook_execute.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net/http"
 	"strings"
 
@@ -23,7 +24,7 @@ func (handler *Handler) webhookExecute(w http.ResponseWriter, r *http.Request) *
 
 	webhook, err := handler.DataStore.Webhook().WebhookByToken(webhookToken)
 
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find a webhook with this token", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve webhook from the database", err}
@@ -34,7 +35,7 @@ func (handler *Handler) webhookExecute(w http.ResponseWriter, r *http.Request) *
 	webhookType := webhook.WebhookType
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}

--- a/api/http/handler/websocket/attach.go
+++ b/api/http/handler/websocket/attach.go
@@ -11,6 +11,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/errors"
 )
 
 // websocketAttach handles GET requests on /websocket/attach?id=<attachID>&endpointId=<endpointID>&nodeName=<nodeName>&token=<token>
@@ -33,7 +34,7 @@ func (handler *Handler) websocketAttach(w http.ResponseWriter, r *http.Request) 
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/handler/websocket/exec.go
+++ b/api/http/handler/websocket/exec.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/portainer/portainer/api/bolt/errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -40,7 +41,7 @@ func (handler *Handler) websocketExec(w http.ResponseWriter, r *http.Request) *h
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == errors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/handler/websocket/pod.go
+++ b/api/http/handler/websocket/pod.go
@@ -10,6 +10,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 // websocketPodExec handles GET requests on /websocket/pod?token=<token>&endpointId=<endpointID>&namespace=<namespace>&podName=<podName>&containerName=<containerName>&command=<command>
@@ -49,7 +50,7 @@ func (handler *Handler) websocketPodExec(w http.ResponseWriter, r *http.Request)
 	}
 
 	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
 	} else if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}

--- a/api/http/proxy/factory/docker/transport.go
+++ b/api/http/proxy/factory/docker/transport.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/docker"
 	"github.com/portainer/portainer/api/http/proxy/factory/responseutils"
 	"github.com/portainer/portainer/api/http/security"
@@ -409,7 +410,7 @@ func (transport *Transport) restrictedResourceOperation(request *http.Request, r
 
 	if tokenData.Role != portainer.AdministratorRole {
 		rbacExtension, err := transport.dataStore.Extension().Extension(portainer.RBACExtension)
-		if err != nil && err != portainer.ErrObjectNotFound {
+		if err != nil && err != bolterrors.ErrObjectNotFound {
 			return nil, err
 		}
 

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -269,7 +269,7 @@ func (bouncer *RequestBouncer) mwUpgradeToRestrictedRequest(next http.Handler) h
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenData, err := RetrieveTokenData(r)
 		if err != nil {
-			httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrResourceAccessDenied)
+			httperror.WriteError(w, http.StatusForbidden, "Access denied", httperrors.ErrResourceAccessDenied)
 			return
 		}
 

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -2,12 +2,12 @@ package security
 
 import (
 	"errors"
+	"net/http"
+	"strings"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/portainer/api"
-
-	"net/http"
-	"strings"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 )
 
 type (
@@ -152,7 +152,7 @@ func (bouncer *RequestBouncer) checkEndpointOperationAuthorization(r *http.Reque
 	}
 
 	extension, err := bouncer.dataStore.Extension().Extension(portainer.RBACExtension)
-	if err == portainer.ErrObjectNotFound {
+	if err == bolterrors.ErrObjectNotFound {
 		return nil
 	} else if err != nil {
 		return err
@@ -223,7 +223,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 		}
 
 		extension, err := bouncer.dataStore.Extension().Extension(portainer.RBACExtension)
-		if err == portainer.ErrObjectNotFound {
+		if err == bolterrors.ErrObjectNotFound {
 			if administratorOnly {
 				httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrUnauthorized)
 				return
@@ -237,7 +237,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 		}
 
 		user, err := bouncer.dataStore.User().User(tokenData.ID)
-		if err != nil && err == portainer.ErrObjectNotFound {
+		if err != nil && err == bolterrors.ErrObjectNotFound {
 			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", portainer.ErrUnauthorized)
 			return
 		} else if err != nil {
@@ -313,7 +313,7 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 		}
 
 		_, err = bouncer.dataStore.User().User(tokenData.ID)
-		if err != nil && err == portainer.ErrObjectNotFound {
+		if err != nil && err == bolterrors.ErrObjectNotFound {
 			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", portainer.ErrUnauthorized)
 			return
 		} else if err != nil {

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -8,6 +8,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 )
 
 type (
@@ -213,7 +214,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenData, err := RetrieveTokenData(r)
 		if err != nil {
-			httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrUnauthorized)
+			httperror.WriteError(w, http.StatusForbidden, "Access denied", httperrors.ErrUnauthorized)
 			return
 		}
 
@@ -225,7 +226,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 		extension, err := bouncer.dataStore.Extension().Extension(portainer.RBACExtension)
 		if err == bolterrors.ErrObjectNotFound {
 			if administratorOnly {
-				httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrUnauthorized)
+				httperror.WriteError(w, http.StatusForbidden, "Access denied", httperrors.ErrUnauthorized)
 				return
 			}
 
@@ -238,7 +239,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 
 		user, err := bouncer.dataStore.User().User(tokenData.ID)
 		if err != nil && err == bolterrors.ErrObjectNotFound {
-			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", portainer.ErrUnauthorized)
+			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", httperrors.ErrUnauthorized)
 			return
 		} else if err != nil {
 			httperror.WriteError(w, http.StatusInternalServerError, "Unable to retrieve user details from the database", err)
@@ -301,7 +302,7 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 		}
 
 		if token == "" {
-			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", portainer.ErrUnauthorized)
+			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", httperrors.ErrUnauthorized)
 			return
 		}
 
@@ -314,7 +315,7 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 
 		_, err = bouncer.dataStore.User().User(tokenData.ID)
 		if err != nil && err == bolterrors.ErrObjectNotFound {
-			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", portainer.ErrUnauthorized)
+			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", httperrors.ErrUnauthorized)
 			return
 		} else if err != nil {
 			httperror.WriteError(w, http.StatusInternalServerError, "Unable to retrieve user details from the database", err)

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -117,7 +117,7 @@ func (bouncer *RequestBouncer) AuthorizedEndpointOperation(r *http.Request, endp
 	if authorizationCheck {
 		err = bouncer.checkEndpointOperationAuthorization(r, endpoint)
 		if err != nil {
-			return portainer.ErrAuthorizationRequired
+			return ErrAuthorizationRequired
 		}
 	}
 
@@ -255,7 +255,7 @@ func (bouncer *RequestBouncer) mwCheckPortainerAuthorizations(next http.Handler,
 		bouncer.rbacExtensionClient.setLicenseKey(extension.License.LicenseKey)
 		err = bouncer.rbacExtensionClient.checkAuthorization(apiOperation)
 		if err != nil {
-			httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrAuthorizationRequired)
+			httperror.WriteError(w, http.StatusForbidden, "Access denied", ErrAuthorizationRequired)
 			return
 		}
 

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -111,7 +111,7 @@ func (bouncer *RequestBouncer) AuthorizedEndpointOperation(r *http.Request, endp
 	}
 
 	if !authorizedEndpointAccess(endpoint, group, tokenData.ID, memberships) {
-		return portainer.ErrEndpointAccessDenied
+		return httperrors.ErrEndpointAccessDenied
 	}
 
 	if authorizationCheck {
@@ -193,7 +193,7 @@ func (bouncer *RequestBouncer) RegistryAccess(r *http.Request, registry *portain
 	}
 
 	if !AuthorizedRegistryAccess(registry, tokenData.ID, memberships) {
-		return portainer.ErrEndpointAccessDenied
+		return httperrors.ErrEndpointAccessDenied
 	}
 
 	return nil

--- a/api/http/security/context.go
+++ b/api/http/security/context.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/portainer/portainer/api"
@@ -25,7 +26,7 @@ func storeTokenData(request *http.Request, tokenData *portainer.TokenData) conte
 func RetrieveTokenData(request *http.Request) (*portainer.TokenData, error) {
 	contextData := request.Context().Value(contextAuthenticationKey)
 	if contextData == nil {
-		return nil, portainer.ErrMissingContextData
+		return nil, errors.New("Unable to find JWT data in request context")
 	}
 
 	tokenData := contextData.(*portainer.TokenData)
@@ -42,7 +43,7 @@ func storeRestrictedRequestContext(request *http.Request, requestContext *Restri
 func RetrieveRestrictedRequestContext(request *http.Request) (*RestrictedRequestContext, error) {
 	contextData := request.Context().Value(contextRestrictedRequest)
 	if contextData == nil {
-		return nil, portainer.ErrMissingSecurityContext
+		return nil, errors.New("Unable to find security details in request context")
 	}
 
 	requestContext := contextData.(*RestrictedRequestContext)

--- a/api/http/security/errors.go
+++ b/api/http/security/errors.go
@@ -1,0 +1,7 @@
+package security
+
+import "errors"
+
+var (
+	ErrAuthorizationRequired = errors.New("Authorization required for this operation")
+)

--- a/api/http/security/rate_limiter.go
+++ b/api/http/security/rate_limiter.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/g07cha/defender"
 	httperror "github.com/portainer/libhttp/error"
-	"github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/errors"
 )
 
 // RateLimiter represents an entity that manages request rate limiting
@@ -30,7 +30,7 @@ func (limiter *RateLimiter) LimitAccess(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := StripAddrPort(r.RemoteAddr)
 		if banned := limiter.Inc(ip); banned == true {
-			httperror.WriteError(w, http.StatusForbidden, "Access denied", portainer.ErrResourceAccessDenied)
+			httperror.WriteError(w, http.StatusForbidden, "Access denied", errors.ErrResourceAccessDenied)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/api/http/security/rbac.go
+++ b/api/http/security/rbac.go
@@ -52,7 +52,7 @@ func (client *rbacExtensionClient) checkAuthorization(authRequest *portainer.API
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return portainer.ErrAuthorizationRequired
+		return ErrAuthorizationRequired
 	}
 
 	return nil

--- a/api/jwt/jwt.go
+++ b/api/jwt/jwt.go
@@ -1,6 +1,8 @@
 package jwt
 
 import (
+	"errors"
+
 	"github.com/portainer/portainer/api"
 
 	"fmt"
@@ -23,6 +25,11 @@ type claims struct {
 	jwt.StandardClaims
 }
 
+var (
+	errSecretGeneration = errors.New("Unable to generate secret key")
+	errInvalidJWTToken  = errors.New("Invalid JWT token")
+)
+
 // NewService initializes a new service. It will generate a random key that will be used to sign JWT tokens.
 func NewService(userSessionDuration string) (*Service, error) {
 	userSessionTimeout, err := time.ParseDuration(userSessionDuration)
@@ -32,7 +39,7 @@ func NewService(userSessionDuration string) (*Service, error) {
 
 	secret := securecookie.GenerateRandomKey(32)
 	if secret == nil {
-		return nil, portainer.ErrSecretGeneration
+		return nil, errSecretGeneration
 	}
 
 	service := &Service{
@@ -83,7 +90,7 @@ func (service *Service) ParseAndVerifyToken(token string) (*portainer.TokenData,
 		}
 	}
 
-	return nil, portainer.ErrInvalidJWTToken
+	return nil, errInvalidJWTToken
 }
 
 // SetUserSessionDuration sets the user session duration

--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -7,6 +7,7 @@ import (
 	ldap "github.com/go-ldap/ldap/v3"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/crypto"
+	"github.com/portainer/portainer/api/http/errors"
 )
 
 const (
@@ -105,7 +106,7 @@ func (*Service) AuthenticateUser(username, password string, settings *portainer.
 
 	err = connection.Bind(userDN, password)
 	if err != nil {
-		return portainer.ErrUnauthorized
+		return errors.ErrUnauthorized
 	}
 
 	return nil

--- a/api/ldap/ldap.go
+++ b/api/ldap/ldap.go
@@ -1,19 +1,20 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	ldap "github.com/go-ldap/ldap/v3"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/crypto"
-	"github.com/portainer/portainer/api/http/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
 )
 
-const (
-	// ErrUserNotFound defines an error raised when the user is not found via LDAP search
+var (
+	// errUserNotFound defines an error raised when the user is not found via LDAP search
 	// or that too many entries (> 1) are returned.
-	ErrUserNotFound = portainer.Error("User not found or too many entries returned")
+	errUserNotFound = errors.New("User not found or too many entries returned")
 )
 
 // Service represents a service used to authenticate users against a LDAP/AD.
@@ -48,7 +49,7 @@ func searchUser(username string, conn *ldap.Conn, settings []portainer.LDAPSearc
 	}
 
 	if !found {
-		return "", ErrUserNotFound
+		return "", errUserNotFound
 	}
 
 	return userDN, nil
@@ -106,7 +107,7 @@ func (*Service) AuthenticateUser(username, password string, settings *portainer.
 
 	err = connection.Bind(userDN, password)
 	if err != nil {
-		return errors.ErrUnauthorized
+		return httperrors.ErrUnauthorized
 	}
 
 	return nil


### PR DESCRIPTION
this pr is related to #3851 instead of introducing an internal errors package, we removed the errors file and moved the different errors to their specific package. By removing the errors file, the type `portainer.Error` was also removed and replaced everywhere with `errors.New`