### PR TITLE
fix(auth): autofocus on login field

### DIFF
--- a/app/portainer/views/auth/auth.html
+++ b/app/portainer/views/auth/auth.html
@@ -9,7 +9,7 @@
       </div>
       <!-- !login box logo -->
       <!-- login panel -->
-      <div class="panel panel-default" ng-show="!ctrl.state.loginInProgress">
+      <div class="panel panel-default" ng-if="!ctrl.state.loginInProgress">
         <div class="panel-body">
           <!-- login form -->
           <form class="simple-box-form form-horizontal">


### PR DESCRIPTION
Close #3953 .

As a note `auto-focus` directive doesn't work when used inside a `ng-show`'d block. It's only working inside blocks that are always displayed, or `ng-if`'d blocks.