### PR TITLE
refactor(app): move @babel/polyfill to entry

### DIFF
--- a/app/__module.js
+++ b/app/__module.js
@@ -1,4 +1,6 @@
 import './assets/css';
+import '@babel/polyfill';
+
 import angular from 'angular';
 
 import './agent/_module';

--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import '@babel/polyfill';
 
 angular.module('portainer').run([
   '$rootScope',


### PR DESCRIPTION
this fixes an issue where the @babel/polyfill plugins were loaded after the agent module (loading is alphabetically), because they were in another file other than the entrypoint. babel's best practices suggest putting it in the beginning.