### PR TITLE
feat(settings): add setting to disable device mapping for regular users

### DIFF
--- a/api/bolt/init.go
+++ b/api/bolt/init.go
@@ -29,6 +29,7 @@ func (store *Store) Init() error {
 			AllowPrivilegedModeForRegularUsers: true,
 			AllowVolumeBrowserForRegularUsers:  false,
 			AllowHostNamespaceForRegularUsers:  true,
+			AllowDeviceMappingForRegularUsers:  true,
 			EnableHostManagementFeatures:       false,
 			EdgeAgentCheckinInterval:           portainer.DefaultEdgeAgentCheckinIntervalInSeconds,
 			TemplatesURL:                       portainer.DefaultTemplatesURL,

--- a/api/bolt/migrator/migrate_dbversion23.go
+++ b/api/bolt/migrator/migrate_dbversion23.go
@@ -7,6 +7,7 @@ func (m *Migrator) updateSettingsToDB24() error {
 	}
 
 	legacySettings.AllowHostNamespaceForRegularUsers = true
+	legacySettings.AllowDeviceMappingForRegularUsers = true
 
 	return m.settingsService.UpdateSettings(legacySettings)
 }

--- a/api/http/handler/settings/settings_public.go
+++ b/api/http/handler/settings/settings_public.go
@@ -6,7 +6,7 @@ import (
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/response"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 )
 
 type publicSettingsResponse struct {
@@ -15,10 +15,11 @@ type publicSettingsResponse struct {
 	AllowBindMountsForRegularUsers     bool                           `json:"AllowBindMountsForRegularUsers"`
 	AllowPrivilegedModeForRegularUsers bool                           `json:"AllowPrivilegedModeForRegularUsers"`
 	AllowVolumeBrowserForRegularUsers  bool                           `json:"AllowVolumeBrowserForRegularUsers"`
+	AllowHostNamespaceForRegularUsers  bool                           `json:"AllowHostNamespaceForRegularUsers"`
+	AllowDeviceMappingForRegularUsers  bool                           `json:"AllowDeviceMappingForRegularUsers"`
 	EnableHostManagementFeatures       bool                           `json:"EnableHostManagementFeatures"`
 	EnableEdgeComputeFeatures          bool                           `json:"EnableEdgeComputeFeatures"`
 	OAuthLoginURI                      string                         `json:"OAuthLoginURI"`
-	AllowHostNamespaceForRegularUsers  bool                           `json:"AllowHostNamespaceForRegularUsers"`
 }
 
 // GET request on /api/settings/public
@@ -35,6 +36,7 @@ func (handler *Handler) settingsPublic(w http.ResponseWriter, r *http.Request) *
 		AllowPrivilegedModeForRegularUsers: settings.AllowPrivilegedModeForRegularUsers,
 		AllowVolumeBrowserForRegularUsers:  settings.AllowVolumeBrowserForRegularUsers,
 		AllowHostNamespaceForRegularUsers:  settings.AllowHostNamespaceForRegularUsers,
+		AllowDeviceMappingForRegularUsers:  settings.AllowDeviceMappingForRegularUsers,
 		EnableHostManagementFeatures:       settings.EnableHostManagementFeatures,
 		EnableEdgeComputeFeatures:          settings.EnableEdgeComputeFeatures,
 		OAuthLoginURI: fmt.Sprintf("%s?response_type=code&client_id=%s&redirect_uri=%s&scope=%s&prompt=login",

--- a/api/http/handler/settings/settings_public.go
+++ b/api/http/handler/settings/settings_public.go
@@ -6,7 +6,7 @@ import (
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/response"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
 )
 
 type publicSettingsResponse struct {

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -24,6 +24,7 @@ type settingsUpdatePayload struct {
 	AllowPrivilegedModeForRegularUsers *bool
 	AllowHostNamespaceForRegularUsers  *bool
 	AllowVolumeBrowserForRegularUsers  *bool
+	AllowDeviceMappingForRegularUsers  *bool
 	EnableHostManagementFeatures       *bool
 	SnapshotInterval                   *string
 	TemplatesURL                       *string
@@ -147,6 +148,10 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 		userSessionDuration, _ := time.ParseDuration(*payload.UserSessionTimeout)
 
 		handler.JWTService.SetUserSessionDuration(userSessionDuration)
+	}
+
+	if payload.AllowDeviceMappingForRegularUsers != nil {
+		settings.AllowDeviceMappingForRegularUsers = *payload.AllowDeviceMappingForRegularUsers
 	}
 
 	tlsError := handler.updateTLS(settings)

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -11,7 +11,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/filesystem"
 	"github.com/portainer/portainer/api/http/security"
 )

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -11,7 +11,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/filesystem"
 	"github.com/portainer/portainer/api/http/security"
 )
@@ -338,7 +338,8 @@ func (handler *Handler) deployComposeStack(config *composeStackDeploymentConfig)
 
 	if (!settings.AllowBindMountsForRegularUsers ||
 		!settings.AllowPrivilegedModeForRegularUsers ||
-		!settings.AllowHostNamespaceForRegularUsers) &&
+		!settings.AllowHostNamespaceForRegularUsers ||
+		!settings.AllowDeviceMappingForRegularUsers) &&
 		!isAdminOrEndpointAdmin {
 
 		composeFilePath := path.Join(config.stack.ProjectPath, config.stack.EntryPoint)

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
-	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/filesystem"
 	"github.com/portainer/portainer/api/http/security"
 )

--- a/api/http/handler/stacks/create_swarm_stack.go
+++ b/api/http/handler/stacks/create_swarm_stack.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/filesystem"
 	"github.com/portainer/portainer/api/http/security"
 )

--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -10,7 +10,7 @@ import (
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
@@ -145,6 +145,10 @@ func (handler *Handler) isValidStackFile(stackFileContent []byte, settings *port
 
 		if !settings.AllowHostNamespaceForRegularUsers && service.Pid == "host" {
 			return errors.New("pid host disabled for non administrator users")
+		}
+
+		if !settings.AllowDeviceMappingForRegularUsers && service.Devices != nil && len(service.Devices) > 0 {
+			return errors.New("device mapping disabled for non administrator users")
 		}
 	}
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -518,13 +518,14 @@ type (
 		AllowBindMountsForRegularUsers     bool                 `json:"AllowBindMountsForRegularUsers"`
 		AllowPrivilegedModeForRegularUsers bool                 `json:"AllowPrivilegedModeForRegularUsers"`
 		AllowVolumeBrowserForRegularUsers  bool                 `json:"AllowVolumeBrowserForRegularUsers"`
+		AllowHostNamespaceForRegularUsers  bool                 `json:"AllowHostNamespaceForRegularUsers"`
+		AllowDeviceMappingForRegularUsers  bool                 `json:"AllowDeviceMappingForRegularUsers"`
 		SnapshotInterval                   string               `json:"SnapshotInterval"`
 		TemplatesURL                       string               `json:"TemplatesURL"`
 		EnableHostManagementFeatures       bool                 `json:"EnableHostManagementFeatures"`
 		EdgeAgentCheckinInterval           int                  `json:"EdgeAgentCheckinInterval"`
 		EnableEdgeComputeFeatures          bool                 `json:"EnableEdgeComputeFeatures"`
 		UserSessionTimeout                 string               `json:"UserSessionTimeout"`
-		AllowHostNamespaceForRegularUsers  bool                 `json:"AllowHostNamespaceForRegularUsers"`
 
 		// Deprecated fields
 		DisplayDonationHeader       bool

--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -30,6 +30,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
   'SettingsService',
   'PluginService',
   'HttpRequestHelper',
+  'ExtensionService',
   function (
     $q,
     $scope,
@@ -55,7 +56,8 @@ angular.module('portainer.docker').controller('CreateContainerController', [
     SystemService,
     SettingsService,
     PluginService,
-    HttpRequestHelper
+    HttpRequestHelper,
+    ExtensionService
   ) {
     $scope.create = create;
 
@@ -189,7 +191,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
 
     function preparePortBindings(config) {
       const bindings = ContainerHelper.preparePortBindings(config.HostConfig.PortBindings);
-      config.ExposedPorts={};
+      config.ExposedPorts = {};
       _.forEach(bindings, (_, key) => (config.ExposedPorts[key] = {}));
       config.HostConfig.PortBindings = bindings;
     }
@@ -604,7 +606,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       });
     }
 
-    function initView() {
+    async function initView() {
       var nodeName = $transition$.params().nodeName;
       $scope.formValues.NodeName = nodeName;
       HttpRequestHelper.setPortainerAgentTargetHeader(nodeName);
@@ -683,6 +685,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       });
 
       $scope.isAdmin = Authentication.isAdmin();
+      $scope.showDeviceMapping = await shouldShowDevices();
     }
 
     function validateForm(accessControlData, isAdmin) {
@@ -892,6 +895,19 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       function onSuccess() {
         Notifications.success('Container successfully created');
         $state.go('docker.containers', {}, { reload: true });
+      }
+    }
+
+    async function shouldShowDevices() {
+      const isAdmin = Authentication.isAdmin();
+      const { allowDeviceMappingForRegularUsers } = $scope.applicationState.application;
+
+      if (isAdmin || allowDeviceMappingForRegularUsers) {
+        return true;
+      }
+      const rbacEnabled = await ExtensionService.extensionEnabled(ExtensionService.EXTENSIONS.RBAC);
+      if (rbacEnabled) {
+        return Authentication.hasAuthorizations(['EndpointResourcesAccess']);
       }
     }
 

--- a/app/docker/views/containers/create/createcontainer.html
+++ b/app/docker/views/containers/create/createcontainer.html
@@ -625,7 +625,7 @@
             </form>
             <form class="form-horizontal" style="margin-top: 15px;">
               <!-- devices -->
-              <div class="form-group">
+              <div ng-if="showDeviceMapping" class="form-group">
                 <div class="col-sm-12" style="margin-top: 5px;">
                   <label class="control-label text-left">Devices</label>
                   <span class="label label-default interactive" style="margin-left: 10px;" ng-click="addDevice()">

--- a/app/portainer/models/settings.js
+++ b/app/portainer/models/settings.js
@@ -7,13 +7,14 @@ export function SettingsViewModel(data) {
   this.AllowBindMountsForRegularUsers = data.AllowBindMountsForRegularUsers;
   this.AllowPrivilegedModeForRegularUsers = data.AllowPrivilegedModeForRegularUsers;
   this.AllowVolumeBrowserForRegularUsers = data.AllowVolumeBrowserForRegularUsers;
+  this.AllowHostNamespaceForRegularUsers = data.AllowHostNamespaceForRegularUsers;
+  this.AllowDeviceMappingForRegularUsers = data.AllowDeviceMappingForRegularUsers;
   this.SnapshotInterval = data.SnapshotInterval;
   this.TemplatesURL = data.TemplatesURL;
   this.EnableHostManagementFeatures = data.EnableHostManagementFeatures;
   this.EdgeAgentCheckinInterval = data.EdgeAgentCheckinInterval;
   this.EnableEdgeComputeFeatures = data.EnableEdgeComputeFeatures;
   this.UserSessionTimeout = data.UserSessionTimeout;
-  this.AllowHostNamespaceForRegularUsers = data.AllowHostNamespaceForRegularUsers;
 }
 
 export function PublicSettingsViewModel(settings) {
@@ -25,6 +26,7 @@ export function PublicSettingsViewModel(settings) {
   this.EnableEdgeComputeFeatures = settings.EnableEdgeComputeFeatures;
   this.LogoURL = settings.LogoURL;
   this.OAuthLoginURI = settings.OAuthLoginURI;
+  this.AllowDeviceMappingForRegularUsers = settings.AllowDeviceMappingForRegularUsers;
 }
 
 export function LDAPSettingsViewModel(data) {

--- a/app/portainer/services/stateManager.js
+++ b/app/portainer/services/stateManager.js
@@ -79,6 +79,11 @@ angular.module('portainer.app').factory('StateManager', [
     manager.updateAllowHostNamespaceForRegularUsers = function (allowHostNamespaceForRegularUsers) {
       state.application.allowHostNamespaceForRegularUsers = allowHostNamespaceForRegularUsers;
       LocalStorage.storeApplicationState(state.application);
+    }
+    
+    manager.updateAllowDeviceMappingForRegularUsers = function updateAllowDeviceMappingForRegularUsers(allowDeviceMappingForRegularUsers) {
+      state.application.allowDeviceMappingForRegularUsers = allowDeviceMappingForRegularUsers;
+      LocalStorage.storeApplicationState(state.application);
     };
 
     function assignStateFromStatusAndSettings(status, settings) {
@@ -89,6 +94,7 @@ angular.module('portainer.app').factory('StateManager', [
       state.application.enableHostManagementFeatures = settings.EnableHostManagementFeatures;
       state.application.enableVolumeBrowserForNonAdminUsers = settings.AllowVolumeBrowserForRegularUsers;
       state.application.enableEdgeComputeFeatures = settings.EnableEdgeComputeFeatures;
+      state.application.allowDeviceMappingForRegularUsers = settings.AllowDeviceMappingForRegularUsers;
       state.application.validity = moment().unix();
     }
 

--- a/app/portainer/views/settings/settings.html
+++ b/app/portainer/views/settings/settings.html
@@ -119,6 +119,16 @@
               </label>
             </div>
           </div>
+          <div class="form-group">
+            <div class="col-sm-12">
+              <label for="toggle_disableDeviceMappingForRegularUsers" class="control-label text-left">
+                Disable device mappings for non-administrators
+              </label>
+              <label class="switch" style="margin-left: 20px;">
+                <input type="checkbox" name="toggle_disableDeviceMappingForRegularUsers" ng-model="formValues.disableDeviceMappingForRegularUsers" /><i></i>
+              </label>
+            </div>
+          </div>
           <!-- !security -->
           <!-- edge -->
           <div class="col-sm-12 form-section-title">

--- a/app/portainer/views/settings/settingsController.js
+++ b/app/portainer/views/settings/settingsController.js
@@ -33,6 +33,7 @@ angular.module('portainer.app').controller('SettingsController', [
       enableVolumeBrowser: false,
       enableEdgeComputeFeatures: false,
       restrictHostNamespaceForRegularUsers: false,
+      allowDeviceMappingForRegularUsers: false,
     };
 
     $scope.removeFilteredContainerLabel = function (index) {
@@ -66,6 +67,7 @@ angular.module('portainer.app').controller('SettingsController', [
       settings.EnableHostManagementFeatures = $scope.formValues.enableHostManagementFeatures;
       settings.EnableEdgeComputeFeatures = $scope.formValues.enableEdgeComputeFeatures;
       settings.AllowHostNamespaceForRegularUsers = !$scope.formValues.restrictHostNamespaceForRegularUsers;
+      settings.AllowDeviceMappingForRegularUsers = !$scope.formValues.disableDeviceMappingForRegularUsers;
 
       $scope.state.actionInProgress = true;
       updateSettings(settings);
@@ -81,6 +83,7 @@ angular.module('portainer.app').controller('SettingsController', [
           StateManager.updateEnableVolumeBrowserForNonAdminUsers(settings.AllowVolumeBrowserForRegularUsers);
           StateManager.updateAllowHostNamespaceForRegularUsers(settings.AllowHostNamespaceForRegularUsers);
           StateManager.updateEnableEdgeComputeFeatures(settings.EnableEdgeComputeFeatures);
+          StateManager.updateAllowDeviceMappingForRegularUsers(settings.AllowDeviceMappingForRegularUsers);
           $state.reload();
         })
         .catch(function error(err) {
@@ -106,6 +109,7 @@ angular.module('portainer.app').controller('SettingsController', [
           $scope.formValues.enableHostManagementFeatures = settings.EnableHostManagementFeatures;
           $scope.formValues.enableEdgeComputeFeatures = settings.EnableEdgeComputeFeatures;
           $scope.formValues.restrictHostNamespaceForRegularUsers = !settings.AllowHostNamespaceForRegularUsers;
+          $scope.formValues.disableDeviceMappingForRegularUsers = !settings.AllowDeviceMappingForRegularUsers;
         })
         .catch(function error(err) {
           Notifications.error('Failure', err, 'Unable to retrieve application settings');


### PR DESCRIPTION
fix #4066

* feat(settings): introduce device mapping service

* feat(containers): hide devices field when setting is on

* feat(containers): prevent passing of devices when not allowed

* feat(stacks): prevent non admin from device mapping

* feat(stacks): disallow swarm stack creation for user

* refactor(settings): replace disableDeviceMapping with allow

* fix(stacks): remove check for disable device mappings from swarm

* feat(settings): rename field to disable

* feat(settings): supply default value for disableDeviceMapping

* feat(container): check for endpoint admin