### PR TITLE
feat(containers): disable edit container on security setting restricting regular users

### DIFF
--- a/app/docker/views/containers/edit/containerController.js
+++ b/app/docker/views/containers/edit/containerController.js
@@ -21,6 +21,7 @@ angular.module('portainer.docker').controller('ContainerController', [
   'ImageService',
   'HttpRequestHelper',
   'Authentication',
+  'StateManager',
   function (
     $q,
     $scope,
@@ -40,7 +41,8 @@ angular.module('portainer.docker').controller('ContainerController', [
     RegistryService,
     ImageService,
     HttpRequestHelper,
-    Authentication
+    Authentication,
+    StateManager
   ) {
     $scope.activityTime = 0;
     $scope.portBindings = [];
@@ -94,9 +96,24 @@ angular.module('portainer.docker').controller('ContainerController', [
           const inSwarm = $scope.container.Config.Labels['com.docker.swarm.service.id'];
           const autoRemove = $scope.container.HostConfig.AutoRemove;
           const admin = Authentication.isAdmin();
+          const appState = StateManager.getState();
+          const {
+            allowContainerCapabilitiesForRegularUsers,
+            allowHostNamespaceForRegularUsers,
+            allowDeviceMappingForRegularUsers,
+            allowBindMountsForRegularUsers,
+            allowPrivilegedModeForRegularUsers,
+          } = appState.application;
+
+          const settingRestrictsRegularUsers =
+            !allowContainerCapabilitiesForRegularUsers ||
+            !allowBindMountsForRegularUsers ||
+            !allowDeviceMappingForRegularUsers ||
+            !allowHostNamespaceForRegularUsers ||
+            !allowPrivilegedModeForRegularUsers;
 
           ExtensionService.extensionEnabled(ExtensionService.EXTENSIONS.RBAC).then((rbacEnabled) => {
-            $scope.displayRecreateButton = !inSwarm && !autoRemove && (rbacEnabled ? admin : true);
+            $scope.displayRecreateButton = !inSwarm && !autoRemove && (settingRestrictsRegularUsers || rbacEnabled ? admin : true);
           });
         })
         .catch(function error(err) {

--- a/app/portainer/models/settings.js
+++ b/app/portainer/models/settings.js
@@ -26,6 +26,7 @@ export function PublicSettingsViewModel(settings) {
   this.AllowDeviceMappingForRegularUsers = settings.AllowDeviceMappingForRegularUsers;
   this.AllowStackManagementForRegularUsers = settings.AllowStackManagementForRegularUsers;
   this.AllowContainerCapabilitiesForRegularUsers = settings.AllowContainerCapabilitiesForRegularUsers;
+  this.AllowHostNamespaceForRegularUsers = settings.AllowHostNamespaceForRegularUsers;
   this.AuthenticationMethod = settings.AuthenticationMethod;
   this.EnableHostManagementFeatures = settings.EnableHostManagementFeatures;
   this.EnableEdgeComputeFeatures = settings.EnableEdgeComputeFeatures;

--- a/app/portainer/services/stateManager.js
+++ b/app/portainer/services/stateManager.js
@@ -96,6 +96,16 @@ angular.module('portainer.app').factory('StateManager', [
       LocalStorage.storeApplicationState(state.application);
     };
 
+    manager.updateAllowBindMountsForRegularUsers = function updateAllowBindMountsForRegularUsers(allowBindMountsForRegularUsers) {
+      state.application.allowBindMountsForRegularUsers = allowBindMountsForRegularUsers;
+      LocalStorage.storeApplicationState(state.application);
+    };
+
+    manager.updateAllowPrivilegedModeForRegularUsers = function (AllowPrivilegedModeForRegularUsers) {
+      state.application.allowPrivilegedModeForRegularUsers = AllowPrivilegedModeForRegularUsers;
+      LocalStorage.storeApplicationState(state.application);
+    };
+
     function assignStateFromStatusAndSettings(status, settings) {
       state.application.analytics = status.Analytics;
       state.application.version = status.Version;
@@ -107,6 +117,9 @@ angular.module('portainer.app').factory('StateManager', [
       state.application.allowDeviceMappingForRegularUsers = settings.AllowDeviceMappingForRegularUsers;
       state.application.allowStackManagementForRegularUsers = settings.AllowStackManagementForRegularUsers;
       state.application.allowContainerCapabilitiesForRegularUsers = settings.AllowContainerCapabilitiesForRegularUsers;
+      state.application.allowBindMountsForRegularUsers = settings.AllowBindMountsForRegularUsers;
+      state.application.allowPrivilegedModeForRegularUsers = settings.AllowPrivilegedModeForRegularUsers;
+      state.application.allowHostNamespaceForRegularUsers = settings.AllowHostNamespaceForRegularUsers;
       state.application.validity = moment().unix();
     }
 

--- a/app/portainer/views/settings/settings.html
+++ b/app/portainer/views/settings/settings.html
@@ -149,6 +149,12 @@
               </label>
             </div>
           </div>
+
+          <div class="form-group" ng-if="isContainerEditDisabled()">
+            <span class="col-sm-12 text-muted small">
+              Note: The recreate/duplicate/edit feature is currently disabled (for non-admin users) by one or more security settings.
+            </span>
+          </div>
           <!-- !security -->
           <!-- edge -->
           <div class="col-sm-12 form-section-title">

--- a/app/portainer/views/settings/settingsController.js
+++ b/app/portainer/views/settings/settingsController.js
@@ -38,6 +38,19 @@ angular.module('portainer.app').controller('SettingsController', [
       disableContainerCapabilitiesForRegularUsers: false,
     };
 
+    $scope.isContainerEditDisabled = function isContainerEditDisabled() {
+      const {
+        restrictBindMounts,
+        restrictHostNamespaceForRegularUsers,
+        restrictPrivilegedMode,
+        disableDeviceMappingForRegularUsers,
+        disableContainerCapabilitiesForRegularUsers,
+      } = this.formValues;
+      return (
+        restrictBindMounts || restrictHostNamespaceForRegularUsers || restrictPrivilegedMode || disableDeviceMappingForRegularUsers || disableContainerCapabilitiesForRegularUsers
+      );
+    };
+
     $scope.removeFilteredContainerLabel = function (index) {
       var settings = $scope.settings;
       settings.BlackListedLabels.splice(index, 1);
@@ -90,6 +103,8 @@ angular.module('portainer.app').controller('SettingsController', [
           StateManager.updateAllowDeviceMappingForRegularUsers(settings.AllowDeviceMappingForRegularUsers);
           StateManager.updateAllowStackManagementForRegularUsers(settings.AllowStackManagementForRegularUsers);
           StateManager.updateAllowContainerCapabilitiesForRegularUsers(settings.AllowContainerCapabilitiesForRegularUsers);
+          StateManager.updateAllowPrivilegedModeForRegularUsers(settings.AllowPrivilegedModeForRegularUsers);
+          StateManager.updateAllowBindMountsForRegularUsers(settings.AllowBindMountsForRegularUsers);
           $state.reload();
         })
         .catch(function error(err) {


### PR DESCRIPTION
fix #4069 

* feat(settings): add info about container edit disable

* feat(settings): set security settings

* feat(containers): hide recreate button when the setting is enabled

* feat(settings): rephrase security notice

* fix(settings): save allowHostNamespaceForRegularUsers to state