### PR TITLE
fix(containers): handle multiple ips with the same port

### DIFF
--- a/app/docker/helpers/containerHelper.js
+++ b/app/docker/helpers/containerHelper.js
@@ -220,6 +220,7 @@ angular.module('portainer.docker').factory('ContainerHelper', [
             const portKeySplit = _.split(portKey, '/');
             const containerPort = parseInt(portKeySplit[0]);
             const portBinding = portBindings[portKey][0];
+            portBindings[portKey].shift();
             const hostPort = parsePort(portBinding.HostPort);
 
             // We only combine single ports, and skip the host port ranges on one container port

--- a/app/docker/views/containers/edit/containerController.js
+++ b/app/docker/views/containers/edit/containerController.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import _ from 'lodash-es';
 import { PorImageRegistryModel } from 'Docker/models/porImageRegistry';
 
 angular.module('portainer.docker').controller('ContainerController', [
@@ -83,12 +84,14 @@ angular.module('portainer.docker').controller('ContainerController', [
 
           $scope.portBindings = [];
           if (container.NetworkSettings.Ports) {
-            angular.forEach(Object.keys(container.NetworkSettings.Ports), function (portMapping) {
-              if (container.NetworkSettings.Ports[portMapping]) {
-                var mapping = {};
-                mapping.container = portMapping;
-                mapping.host = container.NetworkSettings.Ports[portMapping][0].HostIp + ':' + container.NetworkSettings.Ports[portMapping][0].HostPort;
-                $scope.portBindings.push(mapping);
+            _.forEach(Object.keys(container.NetworkSettings.Ports), function (key) {
+              if (container.NetworkSettings.Ports[key]) {
+                _.forEach(container.NetworkSettings.Ports[key], (portMapping) => {
+                  const mapping = {};
+                  mapping.container = key;
+                  mapping.host = `${portMapping.HostIp}:${portMapping.HostPort}`;
+                  $scope.portBindings.push(mapping);
+                });
               }
             });
           }


### PR DESCRIPTION
closes #3523

WIP, still need to load host ports correctly on duplicate when multiple host `ip:port` entries point to the same container port

_Container was published as:_
![image](https://user-images.githubusercontent.com/12197793/88766273-d7f5d500-d1cb-11ea-9031-05e777289c62.png)

_On duplicate it was loaded as:_
![image](https://user-images.githubusercontent.com/12197793/88766568-5a7e9480-d1cc-11ea-89e6-808a18217c00.png)