### PR TITLE
Remove trailing slash & protocol in registry URLs

### DIFF
--- a/app/portainer/components/forms/registry-form-custom/registry-form-custom.html
+++ b/app/portainer/components/forms/registry-form-custom/registry-form-custom.html
@@ -30,7 +30,7 @@
   <div class="form-group">
     <label for="registry_url" class="col-sm-3 col-lg-2 control-label text-left">
       Registry URL
-      <portainer-tooltip position="bottom" message="URL or IP address of a Docker registry. Any protocol will be stripped."></portainer-tooltip>
+      <portainer-tooltip position="bottom" message="URL or IP address of a Docker registry. Any protocol and trailing slash will be stripped if present."></portainer-tooltip>
     </label>
     <div class="col-sm-9 col-lg-10">
       <input type="text" class="form-control" id="registry_url" name="registry_url" ng-model="$ctrl.model.URL" placeholder="10.0.0.10:5000 or myregistry.domain.tld" required />

--- a/app/portainer/models/registry.js
+++ b/app/portainer/models/registry.js
@@ -51,6 +51,7 @@ export function RegistryCreateRequest(model) {
   this.Name = model.Name;
   this.Type = model.Type;
   this.URL = _.replace(model.URL, /^https?\:\/\//i, '');
+  this.URL = _.replace(this.URL, /\/$/, '');
   this.Authentication = model.Authentication;
   if (model.Authentication) {
     this.Username = model.Username;

--- a/app/portainer/services/api/registryService.js
+++ b/app/portainer/services/api/registryService.js
@@ -62,6 +62,7 @@ angular.module('portainer.app').factory('RegistryService', [
     };
 
     service.updateRegistry = function (registry) {
+      registry.URL = _.replace(registry.URL, /^https?\:\/\//i, '');
       registry.URL = registry.URL.replace(/\/$/, '');
       return Registries.update({ id: registry.Id }, registry).$promise;
     };

--- a/app/portainer/services/api/registryService.js
+++ b/app/portainer/services/api/registryService.js
@@ -62,6 +62,7 @@ angular.module('portainer.app').factory('RegistryService', [
     };
 
     service.updateRegistry = function (registry) {
+      registry.URL = registry.URL.replace(/\/$/, '');
       return Registries.update({ id: registry.Id }, registry).$promise;
     };
 

--- a/app/portainer/services/api/registryService.js
+++ b/app/portainer/services/api/registryService.js
@@ -63,7 +63,7 @@ angular.module('portainer.app').factory('RegistryService', [
 
     service.updateRegistry = function (registry) {
       registry.URL = _.replace(registry.URL, /^https?\:\/\//i, '');
-      registry.URL = registry.URL.replace(/\/$/, '');
+      registry.URL = _.replace(registry.URL, /\/$/, '');
       return Registries.update({ id: registry.Id }, registry).$promise;
     };
 

--- a/app/portainer/views/registries/edit/registry.html
+++ b/app/portainer/views/registries/edit/registry.html
@@ -22,7 +22,10 @@
           <div class="form-group">
             <label for="registry_url" class="col-sm-3 col-lg-2 control-label text-left">
               Registry URL
-              <portainer-tooltip position="bottom" message="URL or IP address of a Docker registry. Trailing slash will be stripped if present."></portainer-tooltip>
+              <portainer-tooltip
+                position="bottom"
+                message="URL or IP address of a Docker registry. Any protocol or trailing slash will be stripped if present."
+              ></portainer-tooltip>
             </label>
             <div class="col-sm-9 col-lg-10">
               <input type="text" class="form-control" id="registry_url" ng-model="registry.URL" placeholder="e.g. 10.0.0.10:5000 or myregistry.domain.tld" />

--- a/app/portainer/views/registries/edit/registry.html
+++ b/app/portainer/views/registries/edit/registry.html
@@ -22,7 +22,7 @@
           <div class="form-group">
             <label for="registry_url" class="col-sm-3 col-lg-2 control-label text-left">
               Registry URL
-              <portainer-tooltip position="bottom" message="URL or IP address of a Docker registry."></portainer-tooltip>
+              <portainer-tooltip position="bottom" message="URL or IP address of a Docker registry. Trailing slash will be stripped if present."></portainer-tooltip>
             </label>
             <div class="col-sm-9 col-lg-10">
               <input type="text" class="form-control" id="registry_url" ng-model="registry.URL" placeholder="e.g. 10.0.0.10:5000 or myregistry.domain.tld" />


### PR DESCRIPTION
Closes #3965 .

Removes trailing slash from registry URLs when:
 - Adding a new registry
 - Updating an existing registry