### PR TITLE
feat(core/telemetry): matomo usage POC

### DIFF
--- a/app/__module.js
+++ b/app/__module.js
@@ -37,6 +37,8 @@ angular.module('portainer', [
   'portainer.integrations',
   'rzModule',
   'moment-picker',
+  'angulartics',
+  'angulartics.piwik',
 ]);
 
 if (require) {

--- a/app/config.js
+++ b/app/config.js
@@ -3,6 +3,7 @@ import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 angular.module('portainer').config([
+  '$analyticsProvider',
   '$urlRouterProvider',
   '$httpProvider',
   'localStorageServiceProvider',
@@ -11,7 +12,17 @@ angular.module('portainer').config([
   '$uibTooltipProvider',
   '$compileProvider',
   'cfpLoadingBarProvider',
-  function ($urlRouterProvider, $httpProvider, localStorageServiceProvider, jwtOptionsProvider, AnalyticsProvider, $uibTooltipProvider, $compileProvider, cfpLoadingBarProvider) {
+  function (
+    $analyticsProvider,
+    $urlRouterProvider,
+    $httpProvider,
+    localStorageServiceProvider,
+    jwtOptionsProvider,
+    AnalyticsProvider,
+    $uibTooltipProvider,
+    $compileProvider,
+    cfpLoadingBarProvider
+  ) {
     'use strict';
 
     var environment = '@@ENVIRONMENT';
@@ -52,8 +63,13 @@ angular.module('portainer').config([
       },
     ]);
 
-    AnalyticsProvider.setAccount({ tracker: __CONFIG_GA_ID, set: { anonymizeIp: true } });
-    AnalyticsProvider.startOffline(true);
+    $analyticsProvider.withBase(false);
+    $analyticsProvider.withAutoBase(true);
+
+    // need to set trackRelativePath
+
+    // AnalyticsProvider.setAccount({ tracker: __CONFIG_GA_ID, set: { anonymizeIp: true } });
+    // AnalyticsProvider.startOffline(true);
 
     toastr.options.timeOut = 3000;
 

--- a/app/config.js
+++ b/app/config.js
@@ -3,7 +3,6 @@ import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 angular.module('portainer').config([
-  '$analyticsProvider',
   '$urlRouterProvider',
   '$httpProvider',
   'localStorageServiceProvider',
@@ -12,17 +11,7 @@ angular.module('portainer').config([
   '$uibTooltipProvider',
   '$compileProvider',
   'cfpLoadingBarProvider',
-  function (
-    $analyticsProvider,
-    $urlRouterProvider,
-    $httpProvider,
-    localStorageServiceProvider,
-    jwtOptionsProvider,
-    AnalyticsProvider,
-    $uibTooltipProvider,
-    $compileProvider,
-    cfpLoadingBarProvider
-  ) {
+  function ($urlRouterProvider, $httpProvider, localStorageServiceProvider, jwtOptionsProvider, AnalyticsProvider, $uibTooltipProvider, $compileProvider, cfpLoadingBarProvider) {
     'use strict';
 
     var environment = '@@ENVIRONMENT';
@@ -63,8 +52,8 @@ angular.module('portainer').config([
       },
     ]);
 
-    $analyticsProvider.withBase(false);
-    $analyticsProvider.withAutoBase(true);
+    // $analyticsProvider.withBase(false);
+    // $analyticsProvider.withAutoBase(true);
 
     // need to set trackRelativePath
 

--- a/app/index.html
+++ b/app/index.html
@@ -20,49 +20,26 @@
     <meta name="msapplication-config" content="${require('./assets/ico/browserconfig.xml')}" />
     <meta name="theme-color" content="#ffffff" />
 
-    <script>
-      !(function (t, e) {
-        var o, n, p, r;
-        e.__SV ||
-          ((window.posthog = e),
-          (e._i = []),
-          (e.init = function (i, s, a) {
-            function g(t, e) {
-              var o = e.split('.');
-              2 == o.length && ((t = t[o[0]]), (e = o[1])),
-                (t[e] = function () {
-                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-                });
-            }
-            ((p = t.createElement('script')).type = 'text/javascript'),
-              (p.async = !0),
-              (p.src = s.api_host + '/static/array.js'),
-              (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
-            var u = e;
-            for (
-              void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-                u.people = u.people || [],
-                u.toString = function (t) {
-                  var e = 'posthog';
-                  return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
-                },
-                u.people.toString = function () {
-                  return u.toString(1) + '.people (stub)';
-                },
-                o = 'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags'.split(
-                  ' '
-                ),
-                n = 0;
-              n < o.length;
-              n++
-            )
-              g(u, o[n]);
-            e._i.push([i, s, a]);
-          }),
-          (e.__SV = 1));
-      })(document, window.posthog || []);
-      posthog.init('LCRjxEU0Td4RLzxjJgyN1V2N8GkmALlkc_1vmUdfVbY', { api_host: 'http://188.166.250.54' });
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function () {
+        var u = '//188.166.250.54/';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0];
+        g.type = 'text/javascript';
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+      })();
     </script>
+    <!-- End Matomo Code -->
   </head>
 
   <body ng-controller="MainController">

--- a/app/index.html
+++ b/app/index.html
@@ -19,6 +19,50 @@
     <link rel="shortcut icon" href="${require('./assets/ico/favicon.ico')}" />
     <meta name="msapplication-config" content="${require('./assets/ico/browserconfig.xml')}" />
     <meta name="theme-color" content="#ffffff" />
+
+    <script>
+      !(function (t, e) {
+        var o, n, p, r;
+        e.__SV ||
+          ((window.posthog = e),
+          (e._i = []),
+          (e.init = function (i, s, a) {
+            function g(t, e) {
+              var o = e.split('.');
+              2 == o.length && ((t = t[o[0]]), (e = o[1])),
+                (t[e] = function () {
+                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+                });
+            }
+            ((p = t.createElement('script')).type = 'text/javascript'),
+              (p.async = !0),
+              (p.src = s.api_host + '/static/array.js'),
+              (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r);
+            var u = e;
+            for (
+              void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+                u.people = u.people || [],
+                u.toString = function (t) {
+                  var e = 'posthog';
+                  return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e;
+                },
+                u.people.toString = function () {
+                  return u.toString(1) + '.people (stub)';
+                },
+                o = 'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags'.split(
+                  ' '
+                ),
+                n = 0;
+              n < o.length;
+              n++
+            )
+              g(u, o[n]);
+            e._i.push([i, s, a]);
+          }),
+          (e.__SV = 1));
+      })(document, window.posthog || []);
+      posthog.init('6MaYoed3QRr0sfxLSWQUF4YCSSBMX8PXrngO2q7K6z8', { api_host: 'http://188.166.250.54' });
+    </script>
   </head>
 
   <body ng-controller="MainController">

--- a/app/index.html
+++ b/app/index.html
@@ -24,7 +24,6 @@
     <script type="text/javascript">
       var _paq = (window._paq = window._paq || []);
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function () {
         var u = '//188.166.250.54/';
@@ -38,26 +37,6 @@
         g.src = u + 'matomo.js';
         s.parentNode.insertBefore(g, s);
       })();
-
-      var currentUrl = location.href;
-      window.addEventListener('hashchange', function () {
-        _paq.push(['setReferrerUrl', currentUrl]);
-        currentUrl = '/' + window.location.hash.substr(1);
-        _paq.push(['setCustomUrl', currentUrl]);
-        _paq.push(['setDocumentTitle', 'My New Title']);
-
-        // remove all previously assigned custom variables, requires Matomo (formerly Piwik) 3.0.2
-        _paq.push(['deleteCustomVariables', 'page']);
-        _paq.push(['setGenerationTimeMs', 0]);
-        _paq.push(['trackPageView']);
-
-        // make Matomo aware of newly added content
-        var content = document.getElementById('content');
-        _paq.push(['MediaAnalytics::scanForMedia', content]);
-        _paq.push(['FormAnalytics::scanForForms', content]);
-        _paq.push(['trackContentImpressionsWithinNode', content]);
-        _paq.push(['enableLinkTracking']);
-      });
     </script>
     <!-- End Matomo Code -->
   </head>

--- a/app/index.html
+++ b/app/index.html
@@ -38,6 +38,26 @@
         g.src = u + 'matomo.js';
         s.parentNode.insertBefore(g, s);
       })();
+
+      var currentUrl = location.href;
+      window.addEventListener('hashchange', function () {
+        _paq.push(['setReferrerUrl', currentUrl]);
+        currentUrl = '/' + window.location.hash.substr(1);
+        _paq.push(['setCustomUrl', currentUrl]);
+        _paq.push(['setDocumentTitle', 'My New Title']);
+
+        // remove all previously assigned custom variables, requires Matomo (formerly Piwik) 3.0.2
+        _paq.push(['deleteCustomVariables', 'page']);
+        _paq.push(['setGenerationTimeMs', 0]);
+        _paq.push(['trackPageView']);
+
+        // make Matomo aware of newly added content
+        var content = document.getElementById('content');
+        _paq.push(['MediaAnalytics::scanForMedia', content]);
+        _paq.push(['FormAnalytics::scanForForms', content]);
+        _paq.push(['trackContentImpressionsWithinNode', content]);
+        _paq.push(['enableLinkTracking']);
+      });
     </script>
     <!-- End Matomo Code -->
   </head>

--- a/app/index.html
+++ b/app/index.html
@@ -61,7 +61,7 @@
           }),
           (e.__SV = 1));
       })(document, window.posthog || []);
-      posthog.init('6MaYoed3QRr0sfxLSWQUF4YCSSBMX8PXrngO2q7K6z8', { api_host: 'http://188.166.250.54' });
+      posthog.init('LCRjxEU0Td4RLzxjJgyN1V2N8GkmALlkc_1vmUdfVbY', { api_host: 'http://188.166.250.54' });
     </script>
   </head>
 

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -15,15 +15,15 @@ async function initAuthentication(authManager, Authentication, $rootScope, $stat
   await Authentication.init();
 }
 
-function initAnalytics(Analytics, $rootScope) {
-  Analytics.offline(false);
-  Analytics.registerScriptTags();
-  Analytics.registerTrackers();
-  $rootScope.$on('$stateChangeSuccess', function (event, toState) {
-    Analytics.trackPage(toState.url);
-    Analytics.pageView();
-  });
-}
+// function initAnalytics(Analytics, $rootScope) {
+//   Analytics.offline(false);
+//   Analytics.registerScriptTags();
+//   Analytics.registerTrackers();
+//   $rootScope.$on('$stateChangeSuccess', function (event, toState) {
+//     Analytics.trackPage(toState.url);
+//     Analytics.pageView();
+//   });
+// }
 
 angular.module('portainer.app', []).config([
   '$stateRegistryProvider',
@@ -51,10 +51,10 @@ angular.module('portainer.app', []).config([
               deferred.resolve();
             } else {
               StateManager.initialize()
-                .then(function success(state) {
-                  if (state.application.analytics) {
-                    initAnalytics(Analytics, $rootScope);
-                  }
+                .then(function success() {
+                  // if (state.application.analytics) {
+                  //   initAnalytics(Analytics, $rootScope);
+                  // }
                   return $async(initAuthentication, authManager, Authentication, $rootScope, $state);
                 })
                 .then(() => deferred.resolve())

--- a/app/vendors.js
+++ b/app/vendors.js
@@ -38,6 +38,6 @@ import 'angular-ui-bootstrap';
 import 'angular-moment-picker';
 import 'angular-multiselect/isteven-multi-select.js';
 import 'angulartics/dist/angulartics.min.js';
-import 'angulartics-piwik/dist/angulartics-piwik.min.js';
+import 'angulartics-piwik/src/angulartics-piwik.js';
 
 window.angular = angular;

--- a/app/vendors.js
+++ b/app/vendors.js
@@ -37,5 +37,7 @@ import 'js-yaml/dist/js-yaml.js';
 import 'angular-ui-bootstrap';
 import 'angular-moment-picker';
 import 'angular-multiselect/isteven-multi-select.js';
+import 'angulartics/dist/angulartics.min.js';
+import 'angulartics-piwik/dist/angulartics-piwik.min.js';
 
 window.angular = angular;

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "angular-utils-pagination": "~0.11.1",
     "angularjs-scroll-glue": "^2.2.0",
     "angularjs-slider": "^6.4.0",
+    "angulartics": "^1.6.0",
+    "angulartics-piwik": "^1.0.6",
     "babel-plugin-angularjs-annotate": "^0.10.0",
     "bootbox": "^5.4.0",
     "bootstrap": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,18 @@ angularjs-slider@^6.4.0:
   resolved "https://registry.yarnpkg.com/angularjs-slider/-/angularjs-slider-6.7.0.tgz#eb2229311b81b79315a36e7b5eb700e128f50319"
   integrity sha512-Cizsuax65wN2Y+htmA3safE5ALOSCyWcKyWkziaO8vCVymi26bQQs6kKDhkYc8GFix/KE7Oc9gH3QLlTUgD38w==
 
+angulartics-piwik@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/angulartics-piwik/-/angulartics-piwik-1.0.6.tgz#cf050b65e8974f3f9ae9a2a1cef4bc1cac82099f"
+  integrity sha1-zwULZeiXTz+a6aKhzvS8HKyCCZ8=
+  dependencies:
+    angulartics "*"
+
+angulartics@*, angulartics@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/angulartics/-/angulartics-1.6.0.tgz#a89c17ef8ea2334ebced65d6265951846f848172"
+  integrity sha512-fywhCi1InawcX+rpLv9NQ32Ed87KoZeH20SUIsRUz9dYJSxuk4/uxiKiopITveGxTC8THYHFEATj9Y/X+BvMqA==
+
 ansi-colors@^3.0.0, ansi-colors@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"


### PR DESCRIPTION
This is a POC for the usage of Matomo instead of GA.

This is leveraging the following libraries:

- https://github.com/angulartics/angulartics
- https://github.com/angulartics/angulartics-piwik

I had to alter the following piece of code in the angulartics-piwik library to achieve what we want:

https://github.com/angulartics/angulartics-piwik/blob/master/src/angulartics-piwik.js#L117-L124

Replaced with:

```javascript
// locationObj is the angular $location object
$analyticsProvider.registerPageTrack(function (path, locationObj) {

  if ($window._paq) {
    $window._paq.push(['setDocumentTitle', $window.document.title]);
    $window._paq.push(['setReferrerUrl', '']);
    $window._paq.push(['setCustomUrl', 'http://portainer.app' + path]);
    $window._paq.push(['trackPageView']);
  }
});
```

Draft that should only be used as a reference when implementing #3742

Related to #3742 