### PR TITLE
fix(auth): reject main route if logged out

### DIFF
--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -35,6 +35,7 @@ angular.module('portainer.app', ['portainer.oauth']).config([
               await StateManager.initialize();
               if (!loggedIn) {
                 $state.go('portainer.auth');
+                return Promise.reject('Unauthenticated');
               }
             } catch (err) {
               Notifications.error('Failure', err, 'Unable to retrieve application settings');

--- a/app/portainer/services/authentication.js
+++ b/app/portainer/services/authentication.js
@@ -31,7 +31,7 @@ angular.module('portainer.app').factory('Authentication', [
         }
         return !!jwt;
       } catch (error) {
-        throw error;
+        return false;
       }
     }
 


### PR DESCRIPTION
reproduce:
1. login
2. run `yarn start:server` or just restart portainer (`docker restart portainer`)
3. refresh the page

before fix:
stuck on logout even if refreshing again

after fix:
redirected to auth page