### PR TITLE
fix(auth): don't redirect if route is unauthenticated

### DIFF
--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -33,7 +33,8 @@ angular.module('portainer.app', ['portainer.oauth']).config([
             try {
               const loggedIn = await initAuthentication(authManager, Authentication, $rootScope, $state);
               await StateManager.initialize();
-              if (!loggedIn) {
+              const nextTransition = $state.transition.to();
+              if (!loggedIn && !['portainer.logout', 'portainer.auth', 'portainer.init'].some((route) => nextTransition.name.startsWith(route))) {
                 $state.go('portainer.auth');
                 return Promise.reject('Unauthenticated');
               }

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -39,6 +39,7 @@ angular.module('portainer.app', ['portainer.oauth']).config([
             }
           } catch (err) {
             Notifications.error('Failure', err, 'Unable to retrieve application settings');
+            throw err;
           }
         });
       },

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -23,26 +23,24 @@ angular.module('portainer.app', ['portainer.oauth']).config([
     var root = {
       name: 'root',
       abstract: true,
-      resolve: {
-        initStateManager: /* @ngInject */ function initStateManager($async, StateManager, Authentication, Notifications, authManager, $rootScope, $state) {
-          return $async(async () => {
-            const appState = StateManager.getState();
-            if (!appState.loading) {
-              return;
+      onEnter: /* @ngInject */ function onEnter($async, StateManager, Authentication, Notifications, authManager, $rootScope, $state) {
+        return $async(async () => {
+          const appState = StateManager.getState();
+          if (!appState.loading) {
+            return;
+          }
+          try {
+            const loggedIn = await initAuthentication(authManager, Authentication, $rootScope, $state);
+            await StateManager.initialize();
+            const nextTransition = $state.transition.to();
+            if (!loggedIn && !['portainer.logout', 'portainer.auth', 'portainer.init'].some((route) => nextTransition.name.startsWith(route))) {
+              $state.go('portainer.auth');
+              return Promise.reject('Unauthenticated');
             }
-            try {
-              const loggedIn = await initAuthentication(authManager, Authentication, $rootScope, $state);
-              await StateManager.initialize();
-              const nextTransition = $state.transition.to();
-              if (!loggedIn && !['portainer.logout', 'portainer.auth', 'portainer.init'].some((route) => nextTransition.name.startsWith(route))) {
-                $state.go('portainer.auth');
-                return Promise.reject('Unauthenticated');
-              }
-            } catch (err) {
-              Notifications.error('Failure', err, 'Unable to retrieve application settings');
-            }
-          });
-        },
+          } catch (err) {
+            Notifications.error('Failure', err, 'Unable to retrieve application settings');
+          }
+        });
       },
       views: {
         'sidebar@': {


### PR DESCRIPTION
fixes an issue when spawning a new environment shows an empty screen. basically it checks that the route is protected before redirecting when the user is not logged in.

tests:
1.1. log in
1.2. restart docker container (`docker restart portainer`)
1.3. user should see login page when refreshing or trying to do something in the app

2.1. create a new environment 
2.2. user should see create admin page