### PR TITLE
fix(api): overwrite existing HTTP header values

### DIFF
--- a/api/http/handler/file/handler.go
+++ b/api/http/handler/file/handler.go
@@ -34,7 +34,7 @@ func (handler *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}
 
-	w.Header().Add("X-XSS-Protection", "1; mode=block")
-	w.Header().Add("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-XSS-Protection", "1; mode=block")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	handler.Handler.ServeHTTP(w, r)
 }

--- a/api/http/proxy/factory/docker.go
+++ b/api/http/proxy/factory/docker.go
@@ -99,7 +99,7 @@ func (proxy *dockerLocalProxy) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	for k, vv := range res.Header {
 		for _, v := range vv {
-			w.Header().Add(k, v)
+			w.Header().Set(k, v)
 		}
 	}
 

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -262,8 +262,8 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 // mwSecureHeaders provides secure headers middleware for handlers.
 func mwSecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
-		w.Header().Add("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/api/kubernetes/cli/client.go
+++ b/api/kubernetes/cli/client.go
@@ -96,8 +96,8 @@ type agentHeaderRoundTripper struct {
 // RoundTrip is the implementation of the http.RoundTripper interface.
 // It decorates the request with specific agent headers
 func (rt *agentHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add(portainer.PortainerAgentPublicKeyHeader, rt.publicKeyHeader)
-	req.Header.Add(portainer.PortainerAgentSignatureHeader, rt.signatureHeader)
+	req.Header.Set(portainer.PortainerAgentPublicKeyHeader, rt.publicKeyHeader)
+	req.Header.Set(portainer.PortainerAgentSignatureHeader, rt.signatureHeader)
 
 	return rt.roundTripper.RoundTrip(req)
 }


### PR DESCRIPTION
When setting HTTP header values, use Set instead of Add in order to
overwrite previously existing values of the header instead of appending
to them.

Fixes #4281 

Best,
Miguel