### PR TITLE
feat(image-details): Show labels in images datatable

### DIFF
--- a/app/docker/components/datatables/images-datatable/imagesDatatable.html
+++ b/app/docker/components/datatables/images-datatable/imagesDatatable.html
@@ -142,6 +142,13 @@
                 </a>
               </th>
               <th>
+                <a ng-click="$ctrl.changeOrderBy('Labels')">
+                  Labels
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Labels' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Labels' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>
+              <th>
                 <a ng-click="$ctrl.changeOrderBy('VirtualSize')">
                   Size
                   <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'VirtualSize' && !$ctrl.state.reverseOrder"></i>
@@ -182,6 +189,9 @@
               </td>
               <td>
                 <span class="label label-primary image-tag" ng-repeat="tag in (item | repotags) track by $index">{{ tag }}</span>
+              </td>
+              <td>
+                <span class="label label-primary image-tag" ng-repeat="(key, label) in (item.Labels) track by $index">{{ key }}:{{ label }}</span>
               </td>
               <td>{{ item.VirtualSize | humansize }}</td>
               <td>{{ item.Created | getisodatefromtimestamp }}</td>

--- a/app/docker/components/datatables/images-datatable/imagesDatatable.html
+++ b/app/docker/components/datatables/images-datatable/imagesDatatable.html
@@ -142,13 +142,6 @@
                 </a>
               </th>
               <th>
-                <a ng-click="$ctrl.changeOrderBy('Labels')">
-                  Labels
-                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Labels' && !$ctrl.state.reverseOrder"></i>
-                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Labels' && $ctrl.state.reverseOrder"></i>
-                </a>
-              </th>
-              <th>
                 <a ng-click="$ctrl.changeOrderBy('VirtualSize')">
                   Size
                   <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'VirtualSize' && !$ctrl.state.reverseOrder"></i>
@@ -189,9 +182,6 @@
               </td>
               <td>
                 <span class="label label-primary image-tag" ng-repeat="tag in (item | repotags) track by $index">{{ tag }}</span>
-              </td>
-              <td>
-                <span class="label label-primary image-tag" ng-repeat="(key, label) in (item.Labels) track by $index">{{ key }}:{{ label }}</span>
               </td>
               <td>{{ item.VirtualSize | humansize }}</td>
               <td>{{ item.Created | getisodatefromtimestamp }}</td>

--- a/app/docker/models/image.js
+++ b/app/docker/models/image.js
@@ -4,7 +4,6 @@ export function ImageViewModel(data) {
   this.Repository = data.Repository;
   this.Created = data.Created;
   this.Checked = false;
-
   this.RepoTags = data.RepoTags;
   if (!this.RepoTags && data.RepoDigests) {
     this.RepoTags = [];
@@ -21,6 +20,7 @@ export function ImageViewModel(data) {
   if (data.Portainer && data.Portainer.Agent && data.Portainer.Agent.NodeName) {
     this.NodeName = data.Portainer.Agent.NodeName;
   }
+  this.Labels = data.Labels;
 }
 
 export function ImageBuildModel(data) {

--- a/app/docker/models/imageDetails.js
+++ b/app/docker/models/imageDetails.js
@@ -16,4 +16,5 @@ export function ImageDetailsViewModel(data) {
   this.ExposedPorts = data.ContainerConfig.ExposedPorts ? Object.keys(data.ContainerConfig.ExposedPorts) : [];
   this.Volumes = data.ContainerConfig.Volumes ? Object.keys(data.ContainerConfig.Volumes) : [];
   this.Env = data.ContainerConfig.Env ? data.ContainerConfig.Env : [];
+  this.Labels = data.ContainerConfig.Labels;
 }

--- a/app/docker/views/images/edit/image.html
+++ b/app/docker/views/images/edit/image.html
@@ -128,6 +128,17 @@
               <td>Build</td>
               <td>Docker {{ image.DockerVersion }} on {{ image.Os }}, {{ image.Architecture }}</td>
             </tr>
+            <tr ng-if="!(image.Labels | emptyobject)">
+              <td>Labels</td>
+              <td>
+                <table class="table table-bordered table-condensed">
+                  <tr ng-repeat="(k, v) in image.Labels">
+                    <td>{{ k }}</td>
+                    <td>{{ v }}</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
             <tr ng-if="image.Author">
               <td>Author</td>
               <td>{{ image.Author }}</td>


### PR DESCRIPTION
### Description
Closes #3462 
This PR includes changes that displays labels associated with an image in the images datatable.

### Sample Screenshot
Sample image: `wurstmeister/kafka:latest`
![image](https://user-images.githubusercontent.com/30438425/91679157-239df480-eb65-11ea-8011-2011f7781497.png)
