### PR TITLE
Skip errors while decoding config data

### DIFF
--- a/app/docker/models/config.js
+++ b/app/docker/models/config.js
@@ -18,7 +18,12 @@ export function ConfigViewModel(data) {
   this.Version = data.Version.Index;
   this.Name = data.Spec.Name;
   this.Labels = data.Spec.Labels;
-  this.Data = b64DecodeUnicode(data.Spec.Data);
+  try {
+    this.Data = b64DecodeUnicode(data.Spec.Data);
+  } except (e) {
+    console.error("Failed to decode config data for", this.name, ":", e);
+    this.Data = "Failed to decode config data.";
+  }
 
   if (data.Portainer && data.Portainer.ResourceControl) {
     this.ResourceControl = new ResourceControlViewModel(data.Portainer.ResourceControl);


### PR DESCRIPTION
When docker configs are used to store binary data, `b64DecodeUnicode` will fail, the error bubbels up, and the result is that none of the configs is displayed. A single binary config will break the whole view, and no config whatsoever will be displayed. 
This commit fixes this by catching decoding errors, logging them, and displaying a note instead of the decoded data. Let me know if you require a change in the wording on line 25, or if I should use a logging facility other than `console.error`.