### PR TITLE
feat(container-stats): introduce container block I/O stats

### DIFF
--- a/app/docker/models/container.js
+++ b/app/docker/models/container.js
@@ -91,6 +91,14 @@ export function ContainerStatsViewModel(data) {
     this.CPUCores = data.cpu_stats.cpu_usage.percpu_usage.length;
   }
   this.Networks = _.values(data.networks);
+  if (data.blkio_stats !== undefined) {
+    //TODO: take care of multiple block devices
+    this.BytesRead = data.blkio_stats.io_service_bytes_recursive[0].value;
+    this.BytesWrite = data.blkio_stats.io_service_bytes_recursive[1].value;
+  } else {
+    //no IO related data is available
+    this.noIOdata = true;
+  }
 }
 
 export function ContainerDetailsViewModel(data) {

--- a/app/docker/views/containers/stats/containerstats.html
+++ b/app/docker/views/containers/stats/containerstats.html
@@ -42,6 +42,11 @@
               <span class="small text-muted"> <i class="fa fa-exclamation-triangle orange-icon" aria-hidden="true"></i> Network stats are unavailable for this container. </span>
             </div>
           </div>
+          <div class="form-group" ng-if="state.ioStatsUnavailable">
+            <div class="col-sm-12">
+              <span class="small text-muted"> <i class="fa fa-exclamation-triangle orange-icon" aria-hidden="true"></i> I/O stats are unavailable for this container. </span>
+            </div>
+          </div>
         </form>
       </rd-widget-body>
     </rd-widget>
@@ -75,6 +80,17 @@
       <rd-widget-body>
         <div class="chart-container" style="position: relative;">
           <canvas id="networkChart" width="770" height="300"></canvas>
+        </div>
+      </rd-widget-body>
+    </rd-widget>
+  </div>
+
+  <div class="col-md-6 col-sm-12" ng-if="!state.ioStatsUnavailable">
+    <rd-widget>
+      <rd-widget-header icon="fa-chart-area" title-text="I/O usage (aggregate)"></rd-widget-header>
+      <rd-widget-body>
+        <div class="chart-container" style="position: relative;">
+          <canvas id="ioChart" width="770" height="300"></canvas>
         </div>
       </rd-widget-body>
     </rd-widget>

--- a/app/docker/views/containers/stats/containerstats.html
+++ b/app/docker/views/containers/stats/containerstats.html
@@ -54,7 +54,7 @@
 </div>
 
 <div class="row">
-  <div ng-class="{ true: 'col-md-6 col-sm-12', false: 'col-lg-4 col-md-6 col-sm-12' }[state.networkStatsUnavailable]">
+  <div class="col-lg-6 col-md-6 col-sm-12">
     <rd-widget>
       <rd-widget-header icon="fa-chart-area" title-text="Memory usage"></rd-widget-header>
       <rd-widget-body>
@@ -64,7 +64,8 @@
       </rd-widget-body>
     </rd-widget>
   </div>
-  <div ng-class="{ true: 'col-md-6 col-sm-12', false: 'col-lg-4 col-md-6 col-sm-12' }[state.networkStatsUnavailable]">
+
+  <div class="col-lg-6 col-md-6 col-sm-12">
     <rd-widget>
       <rd-widget-header icon="fa-chart-area" title-text="CPU usage"></rd-widget-header>
       <rd-widget-body>
@@ -74,7 +75,8 @@
       </rd-widget-body>
     </rd-widget>
   </div>
-  <div class="col-lg-4 col-md-12 col-sm-12" ng-if="!state.networkStatsUnavailable">
+
+  <div class="col-lg-6 col-md-6 col-sm-12" ng-if="!state.networkStatsUnavailable">
     <rd-widget>
       <rd-widget-header icon="fa-chart-area" title-text="Network usage (aggregate)"></rd-widget-header>
       <rd-widget-body>
@@ -85,7 +87,7 @@
     </rd-widget>
   </div>
 
-  <div class="col-md-6 col-sm-12" ng-if="!state.ioStatsUnavailable">
+  <div class="col-lg-6 col-md-6 col-sm-12" ng-if="!state.ioStatsUnavailable">
     <rd-widget>
       <rd-widget-header icon="fa-chart-area" title-text="I/O usage (aggregate)"></rd-widget-header>
       <rd-widget-body>
@@ -95,7 +97,9 @@
       </rd-widget-body>
     </rd-widget>
   </div>
+</div>
 
+<div class="row">
   <div class="col-sm-12">
     <container-processes-datatable
       title-text="Processes"

--- a/app/portainer/services/chartService.js
+++ b/app/portainer/services/chartService.js
@@ -98,8 +98,46 @@ angular.module('portainer.app').factory('ChartService', [
       });
     }
 
+    function CreateIOChart(context, tooltipCallback, scalesCallback) {
+      return new Chart(context, {
+        type: 'line',
+        data: {
+          labels: [],
+          datasets: [
+            {
+              label: 'Read (Aggregate)',
+              data: [],
+              fill: true,
+              backgroundColor: 'rgba(151,187,205,0.4)',
+              borderColor: 'rgba(151,187,205,0.6)',
+              pointBackgroundColor: 'rgba(151,187,205,1)',
+              pointBorderColor: 'rgba(151,187,205,1)',
+              pointRadius: 2,
+              borderWidth: 2,
+            },
+            {
+              label: 'Write (Aggregate)',
+              data: [],
+              fill: true,
+              backgroundColor: 'rgba(255,180,174,0.4)',
+              borderColor: 'rgba(255,180,174,0.6)',
+              pointBackgroundColor: 'rgba(255,180,174,1)',
+              pointBorderColor: 'rgba(255,180,174,1)',
+              pointRadius: 2,
+              borderWidth: 2,
+            },
+          ],
+        },
+        options: defaultChartOptions('nearest', tooltipCallback, scalesCallback, true),
+      });
+    }
+
     service.CreateCPUChart = function (context) {
       return CreateChart(context, 'CPU', percentageBasedTooltipLabel, percentageBasedAxisLabel);
+    };
+
+    service.CreateIOChart = function (context) {
+      return CreateIOChart(context, byteBasedTooltipLabel, byteBasedAxisLabel);
     };
 
     service.CreateMemoryChart = function (context) {
@@ -176,6 +214,13 @@ angular.module('portainer.app').factory('ChartService', [
       chart.update(0);
     };
     service.UpdateCPUChart = UpdateChart;
+    service.UpdateIOChart = function (label, read, write, chart) {
+      chart.data.labels.push(label);
+      chart.data.datasets[0].data.push(read);
+      chart.data.datasets[1].data.push(write);
+      LimitChartItems(chart);
+      chart.update(0);
+    };
 
     service.UpdateNetworkChart = function (label, rx, tx, chart) {
       chart.data.labels.push(label);


### PR DESCRIPTION
Potentially closes #4260
Related to #4242

### Description
This PR introduces I/O Read and Write aggregates for container stats.

### Approach
The values for aggregate Read and Write in Bytes is obtained from `blkio_stats` data returned from the Docker API.

### Screenshot of result
![image](https://user-images.githubusercontent.com/30438425/92204571-64697680-eea1-11ea-8de2-8c3418993a43.png)

### Testing Platform
Docker version:
```
Client: Docker Engine - Community
 Version:           19.03.12
 API version:       1.40
 Go version:        go1.13.10
 Git commit:        48a66213fe
 Built:             Mon Jun 22 15:45:47 2020
 OS/Arch:           linux/amd64
 Experimental:      false
```

Relevant Host Information:
```
OS: Kubuntu 20.04.1 LTS
```

### Limitations
- I/O stats may not be available on all systems (current implementation behaves similarly to unavailable network stats)
- This is currently proof-of-concept, hence, there is no support for multiple block devices (can be added later)
- Docker API (as far as my knowledge goes) only reports the accumulated Bytes Read/Written and does not have a value for the previous reading (unlike the values for CPU which has both current and previous values). Unfortunately, this results in a consumption chart for I/O and not the (probably more useful) chart that shows Read/Write rate in Bytes per unit time.

### References
- Docker API Reference for container stats: https://docs.docker.com/engine/api/v1.40/#operation/ContainerStats (interestingly, the content of `blkio_stats` is not shown here)
- DataDog docs for container IO stats: https://www.datadoghq.com/blog/how-to-collect-docker-metrics/#io
