### PR TITLE
dep(api): update docker binary version to 19.03.12

### DIFF
--- a/api/exec/swarm_stack.go
+++ b/api/exec/swarm_stack.go
@@ -134,6 +134,8 @@ func (manager *SwarmStackManager) prepareDockerCommandAndArgs(binaryPath, dataPa
 
 		if !endpoint.TLSConfig.TLSSkipVerify {
 			args = append(args, "--tlsverify", "--tlscacert", endpoint.TLSConfig.TLSCACertPath)
+		} else {
+			args = append(args, "--tlscacert", "''")
 		}
 
 		if endpoint.TLSConfig.TLSCertPath != "" && endpoint.TLSConfig.TLSKeyPath != "" {

--- a/build/download_docker_binary.ps1
+++ b/build/download_docker_binary.ps1
@@ -9,6 +9,7 @@ New-Item -Path "docker-binary" -ItemType Directory | Out-Null
 
 $download_folder = "docker-binary"
 
-Invoke-WebRequest -O "$($download_folder)/docker-binaries.zip" "https://download.docker.com/win/static/stable/x86_64/docker-$($docker_version).zip"
+Invoke-WebRequest -O "$($download_folder)/docker-binaries.zip" "https://dockermsft.azureedge.net/dockercontainer/docker-$($docker_version).zip"
 Expand-Archive -Path "$($download_folder)/docker-binaries.zip" -DestinationPath "$($download_folder)"
 Move-Item -Path "$($download_folder)/docker/docker.exe" -Destination "dist"
+Move-Item -Path "$($download_folder)/docker/*.dll" -Destination "dist"

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -17,8 +17,8 @@ module.exports = function (grunt) {
     root: 'dist',
     distdir: 'dist/public',
     binaries: {
-      dockerLinuxVersion: '18.09.3',
-      dockerWindowsVersion: '17.09.0-ce',
+      dockerLinuxVersion: '19.03.13',
+      dockerWindowsVersion: '19-03-12',
       komposeVersion: 'v1.21.0',
       kubectlVersion: 'v1.18.0',
     },


### PR DESCRIPTION
Update Docker binary version to 19.03.x for both Linux and Windows which adds support for Docker Stack version 3.8 https://docs.docker.com/compose/compose-file/

Because Docker, Inc does not any more publish Windows binaries separately I change script to use binaries published by Microsoft. Links to those can be found from https://go.microsoft.com/fwlink/?LinkID=825636&clcid=0x409

Closes #3206 #3036