### PR TITLE
style(containers): fix word-break on container details table

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -178,6 +178,11 @@ a[ng-click] {
   word-break: break-word;
 }
 
+.widget .widget-body table.container-details-table > tbody > tr > td:first-child {
+  word-break: normal;
+  text-transform: uppercase;
+}
+
 .widget .widget-body table.description-table {
   table-layout: fixed;
 }

--- a/app/docker/views/containers/edit/container.html
+++ b/app/docker/views/containers/edit/container.html
@@ -214,7 +214,7 @@
     <rd-widget>
       <rd-widget-header icon="fa-server" title-text="Container details"></rd-widget-header>
       <rd-widget-body classes="no-padding">
-        <table class="table">
+        <table class="table container-details-table">
           <tbody>
             <tr>
               <td>Image</td>


### PR DESCRIPTION
Fixes #2676 
Please see the screenshot
![image](https://user-images.githubusercontent.com/6953187/94707224-d037e580-0360-11eb-8346-d872226e8af7.png)
