### PR TITLE
fix(container/logs): make auto refresh take into account container state

### DIFF
--- a/app/docker/components/log-viewer/log-viewer.js
+++ b/app/docker/components/log-viewer/log-viewer.js
@@ -4,6 +4,7 @@ angular.module('portainer.docker').component('logViewer', {
   bindings: {
     data: '=',
     displayTimestamps: '=',
+    containerRunning: '=',
     logCollectionChange: '<',
     sinceTimestamp: '=',
     lineCount: '=',

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -8,13 +8,17 @@
             <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 Auto-refresh logs
-                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
+                <portainer-tooltip
+                  position="bottom"
+                  message="Disabling this option allows you to pause the log collection process and the auto-scrolling. If a container is not running, this will be disabled by default."
+                ></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
                 <input
                   type="checkbox"
+                  ng-init="$ctrl.state.logCollection = $ctrl.containerRunning"
                   ng-model="$ctrl.state.logCollection"
-                  ng-change="$ctrl.state.autoScroll = $ctrl.state.logCollection; $ctrl.logCollectionChange($ctrl.state.logCollection)"
+                  ng-change="$ctrl.state.logCollection = $ctrl.state.logCollection && $ctrl.containerRunning; $ctrl.state.autoScroll = $ctrl.state.logCollection; $ctrl.logCollectionChange($ctrl.state.logCollection)"
                 /><i></i>
               </label>
             </div>

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -4,8 +4,8 @@
       <rd-widget-header icon="fa-file-alt" title-text="Log viewer settings"></rd-widget-header>
       <rd-widget-body>
         <form class="form-horizontal">
-          <div class="form-group">
-            <div class="col-sm-12" ng-style="{ visibility: $ctrl.containerRunning ? 'visible' : 'hidden' }">
+          <div class="form-group" ng-if="$ctrl.containerRunning">
+            <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 Auto-refresh logs
                 <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -5,20 +5,17 @@
       <rd-widget-body>
         <form class="form-horizontal">
           <div class="form-group">
-            <div class="col-sm-12">
+            <div class="col-sm-12" ng-style="{ visibility: $ctrl.containerRunning ? 'visible' : 'hidden' }">
               <label for="tls" class="control-label text-left">
                 Auto-refresh logs
-                <portainer-tooltip
-                  position="bottom"
-                  message="Disabling this option allows you to pause the log collection process and the auto-scrolling. If a container is not running, this will be disabled by default."
-                ></portainer-tooltip>
+                <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
               </label>
               <label class="switch" style="margin-left: 20px;">
                 <input
                   type="checkbox"
                   ng-init="$ctrl.state.logCollection = $ctrl.containerRunning"
                   ng-model="$ctrl.state.logCollection"
-                  ng-change="$ctrl.state.logCollection = $ctrl.state.logCollection && $ctrl.containerRunning; $ctrl.state.autoScroll = $ctrl.state.logCollection; $ctrl.logCollectionChange($ctrl.state.logCollection)"
+                  ng-change="$ctrl.state.autoScroll = $ctrl.state.logCollection && $ctrl.containerRunning; $ctrl.logCollectionChange($ctrl.state.logCollection && $ctrl.containerRunning); $ctrl.state.logCollection = $ctrl.state.logCollection && $ctrl.containerRunning;"
                 /><i></i>
               </label>
             </div>

--- a/app/docker/views/containers/logs/containerLogsController.js
+++ b/app/docker/views/containers/logs/containerLogsController.js
@@ -13,10 +13,11 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
       lineCount: 100,
       sinceTimestamp: '',
       displayTimestamps: false,
+      containerRunning: true,
     };
 
-    $scope.changeLogCollection = function (logCollectionStatus) {
-      if (!logCollectionStatus) {
+    $scope.changeLogCollection = function (autoRefreshStatus) {
+      if (!autoRefreshStatus) {
         stopRepeater();
       } else {
         setUpdateRepeater(!$scope.container.Config.Tty);
@@ -75,6 +76,7 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
         .then(function success(data) {
           var container = data;
           $scope.container = container;
+          $scope.state.containerRunning = container.State.Running;
           startLogPolling(!container.Config.Tty);
         })
         .catch(function error(err) {

--- a/app/docker/views/containers/logs/containerlogs.html
+++ b/app/docker/views/containers/logs/containerlogs.html
@@ -10,6 +10,7 @@
   ng-if="logs"
   log-collection-change="changeLogCollection"
   display-timestamps="state.displayTimestamps"
+  container-running="state.containerRunning"
   line-count="state.lineCount"
   since-timestamp="state.sinceTimestamp"
 ></log-viewer>


### PR DESCRIPTION
### Description

This PR fixes the fact that non-running containers have Auto Refresh enabled.
Closes #4338 

### The new behaviour:
- Inactive containers: Auto-refresh is off by default. Clicking the toggle will not change it (it will remain off).
- Running containers: Auto-refresh is on by default. Clicking the toggle will toggle the setting as usual.