### PR TITLE
fix(swarm): redirect to swarm overview page when the node availability is drain

### DIFF
--- a/app/docker/components/host-view-panels/swarm-node-details-panel/swarm-node-details-panel-controller.js
+++ b/app/docker/components/host-view-panels/swarm-node-details-panel/swarm-node-details-panel-controller.js
@@ -59,9 +59,14 @@ angular.module('portainer.docker').controller('SwarmNodeDetailsPanelController',
 
       NodeService.updateNode(config).then(onUpdateSuccess).catch(notifyOnError);
 
-      function onUpdateSuccess() {
+      function onUpdateSuccess(node) {
         Notifications.success('Node successfully updated', 'Node updated');
-        $state.go('docker.nodes.node', { id: originalNode.Id }, { reload: true });
+
+        if (node.Availability === 'drain') {
+          $state.go('docker.swarm', { reload: true });
+        } else {
+          $state.go('docker.nodes.node', { id: originalNode.Id }, { reload: true });
+        }
       }
 
       function notifyOnError(error) {


### PR DESCRIPTION
Fixes https://github.com/portainer/portainer/issues/3330

Perhaps it would be better to always redirect to the swarm page so the behaviour is consistent? Happy to make that change if needed.