### PR TITLE
#4411 docs: make build steps for local development more easily discoverable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,23 @@ Our contribution process is described below. Some of the steps can be visualized
 The feature request process is similar to the bug report process but has an extra functional validation before the technical validation as well as a documentation validation before the testing phase.
 
 ![portainer_featurerequest_workflow](https://user-images.githubusercontent.com/5485061/45727229-5ad39f00-bbf5-11e8-9550-16ba66c50615.png)
+
+## Build Portainer locally
+
+Ensure you have Docker, Node.js, yarn, and Golang installed in the correct versions.
+
+Install dependencies with yarn:
+
+```sh
+$ yarn
+```
+
+Then build and run the project:
+
+```sh
+$ yarn start
+```
+
+Portainer can now be accessed at <http://localhost:9000>.
+
+Find more detailed steps at <https://documentation.portainer.io/contributing/instructions/>.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Unlike the public demo, the playground sessions are deleted after 4 hours. Apart
 
 - [Deploy Portainer](https://www.portainer.io/installation/)
 - [Documentation](https://documentation.portainer.io)
+- [Building Portainer](https://documentation.portainer.io/contributing/instructions/)
 
 ## Getting help
 


### PR DESCRIPTION
Provide build instructions directly in the `CONTRIBUTING.md` file of the repository and make the link to build documentation stand out more.

Closes #4411 
Closes #3929 