### PR TITLE
#4374 feat(images): Add link to Docker Hub on container creation page

### DIFF
--- a/app/docker/components/imageRegistry/porImageRegistry.html
+++ b/app/docker/components/imageRegistry/porImageRegistry.html
@@ -28,6 +28,14 @@
           ng-change="$ctrl.onImageChange()"
           required
         />
+        <span ng-if="$ctrl.displayedRegistryURL() === 'docker.io'" class="input-group-btn">
+          <a href="https://hub.docker.com/search?type=image&q={{$ctrl.model.Image | trimshasum | trimversiontag}}"
+             class="btn btn-default"
+             title="Search image on Docker Hub"
+             target="_blank">
+            <i class="fab fa-docker"></i> Search
+          </a>
+        </span>
       </div>
     </div>
   </div>

--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -305,4 +305,21 @@ angular
       }
       return _.split(imageName, '@sha256')[0];
     };
+  })
+  .filter('trimversiontag', function () {
+    'use strict';
+    return function trimversiontag(fullName) {
+      if (!fullName) {
+        return fullName;
+      }
+      var versionIdx = fullName.lastIndexOf(':');
+      if (versionIdx < 0) {
+        return fullName;
+      }
+      var hostIdx = fullName.indexOf('/');
+      if (hostIdx > versionIdx) {
+        return fullName;
+      }
+      return fullName.substring(0, versionIdx);
+    };
   });


### PR DESCRIPTION
Add a button next to the image field when creating a new container, which
takes the user to the Docker Hub search page for this image. Version
identifiers are trimmed from the image name to ensure that matching images
will be found.

Closes #4374 