### PR TITLE
refactor(perf): Avoid string allocations

### DIFF
--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -201,7 +201,11 @@ angular
     'use strict';
     return function (imageName) {
       if (imageName) {
-        return imageName.split('@sha')[0];
+        var idx = imageName.indexOf('@sha');
+        if (idx < 0) {
+          return imageName;
+        }
+        return imageName.substring(0, idx);
       }
       return '';
     };
@@ -296,13 +300,17 @@ angular
   })
   .filter('trimshasum', function () {
     'use strict';
-    return function (imageName) {
+    return function trimshasum(imageName) {
       if (!imageName) {
         return;
       }
       if (imageName.indexOf('sha256:') === 0) {
         return imageName.substring(7, 19);
       }
-      return _.split(imageName, '@sha256')[0];
+      var idx = imageName.indexOf('@sha256');
+      if (idx < 0) {
+        return imageName;
+      }
+      return imageName.substring(0, idx);
     };
   });

--- a/app/docker/helpers/constraintsHelper.js
+++ b/app/docker/helpers/constraintsHelper.js
@@ -38,11 +38,15 @@ function matchesLabel(labels, constraint) {
 }
 
 function extractValue(constraint, op) {
-  return constraint.split(op).pop().trim();
+  return constraint.substring(constraint.lastIndexOf(op) + 1).trim();
 }
 
 function extractCustomLabelKey(constraint, op, baseLabelKey) {
-  return constraint.split(op).shift().trim().replace(baseLabelKey, '');
+  var idx = constraint.indexOf(op);
+  if (idx >= 0) {
+    constraint = constraint.substring(0, idx);
+  }
+  return constraint.trim().replace(baseLabelKey, '');
 }
 
 angular.module('portainer.docker').factory('ConstraintsHelper', [

--- a/app/docker/helpers/containerHelper.js
+++ b/app/docker/helpers/containerHelper.js
@@ -60,6 +60,18 @@ function createPortRange(portRangeText, port) {
   }
 }
 
+function extractPort(portKey) {
+  if (!portKey) {
+    return;
+  }
+
+  var idx = portKey.indexOf('/');
+  if (idx < 0) {
+    return parseInt(portKey);
+  }
+  return parseInt(portKey.substring(0, idx));
+}
+
 angular.module('portainer.docker').factory('ContainerHelper', [
   function ContainerHelperFactory() {
     'use strict';
@@ -210,15 +222,12 @@ angular.module('portainer.docker').factory('ContainerHelper', [
 
         _.forEach(portBindingKeysByHostIp, (portBindingKeys, ip) => {
           // Sort by host port
-          const sortedPortBindingKeys = _.orderBy(portBindingKeys, (portKey) => {
-            return parseInt(_.split(portKey, '/')[0]);
-          });
+          const sortedPortBindingKeys = _.orderBy(portBindingKeys, (portKey) => extractPort(portKey));
 
           let previousHostPort = -1;
           let previousContainerPort = -1;
           _.forEach(sortedPortBindingKeys, (portKey) => {
-            const portKeySplit = _.split(portKey, '/');
-            const containerPort = parseInt(portKeySplit[0]);
+            const containerPort = extractPort(portKey);
             const portBinding = portBindings[portKey][0];
             portBindings[portKey].shift();
             const hostPort = parsePort(portBinding.HostPort);

--- a/app/docker/helpers/imageHelper.js
+++ b/app/docker/helpers/imageHelper.js
@@ -65,7 +65,11 @@ angular.module('portainer.docker').factory('ImageHelper', [
     }
 
     function removeDigestFromRepository(repository) {
-      return repository.split('@sha')[0];
+      var idx = repository.indexOf('@sha');
+      if (idx < 0) {
+        return repository;
+      }
+      return repository.substring(0, idx);
     }
 
     return helper;

--- a/app/docker/helpers/serviceHelper.js
+++ b/app/docker/helpers/serviceHelper.js
@@ -225,9 +225,10 @@ angular.module('portainer.docker').factory('ServiceHelper', [
       var ipHostEntries = [];
       if (entries) {
         entries.forEach(function (entry) {
-          if (entry.indexOf(' ') && entry.split(' ').length === 2) {
-            var keyValue = entry.split(' ');
-            ipHostEntries.push({ hostname: keyValue[1], ip: keyValue[0] });
+          var ipAndHost = entry.split(' ');
+          if (ipAndHost.length === 2) {
+            var keyValue = ipAndHost;
+            ipHostEntries.push({hostname: keyValue[1], ip: keyValue[0]});
           }
         });
       }

--- a/app/docker/views/services/create/createServiceController.js
+++ b/app/docker/views/services/create/createServiceController.js
@@ -330,10 +330,13 @@ angular.module('portainer.docker').controller('CreateServiceController', [
       var hostsEntries = [];
       if (input.HostsEntries) {
         input.HostsEntries.forEach(function (host_ip) {
-          if (host_ip.value && host_ip.value.indexOf(':') && host_ip.value.split(':').length === 2) {
-            var keyVal = host_ip.value.split(':');
-            // Hosts file format, IP_address canonical_hostname
-            hostsEntries.push(keyVal[1] + ' ' + keyVal[0]);
+          if (host_ip.value) {
+            var ipAndHost = host_ip.value.split(':');
+            if (ipAndHost.length === 2) {
+              var keyVal = ipAndHost;
+              // Hosts file format, IP_address canonical_hostname
+              hostsEntries.push(keyVal[1] + ' ' + keyVal[0]);
+            }
           }
         });
         if (hostsEntries.length > 0) {

--- a/app/kubernetes/endpoint/converter.js
+++ b/app/kubernetes/endpoint/converter.js
@@ -10,8 +10,13 @@ class KubernetesEndpointConverter {
     const leaderAnnotation = data.metadata.annotations ? data.metadata.annotations[KubernetesEndpointAnnotationLeader] : '';
     if (leaderAnnotation) {
       const parsedJson = JSON.parse(leaderAnnotation);
-      const split = _.split(parsedJson.holderIdentity, '_');
-      res.HolderIdentity = split[0];
+      var holderIdentity = parsedJson.holderIdentity || '';
+      const idx = holderIdentity.indexOf('_');
+      if (idx < 0) {
+        res.HolderIdentity = holderIdentity;
+      } else {
+        res.HolderIdentity = holderIdentity.substring(0, idx);
+      }
     }
 
     if (data.subsets) {

--- a/app/portainer/views/init/endpoint/initEndpointController.js
+++ b/app/portainer/views/init/endpoint/initEndpointController.js
@@ -111,7 +111,10 @@ class InitEndpointController {
       this.state.actionInProgress = true;
       const name = this.formValues.Name;
       const URL = this.formValues.URL;
-      const PublicURL = URL.split(':')[0];
+      const idx = URL.indexOf(':');
+      const PublicURL = idx < 0
+        ? URL
+        : URL.substring(0, idx);
 
       const endpoint = await this.EndpointService.createRemoteEndpoint(
         name,


### PR DESCRIPTION
Do not split strings only to extract the first or last element of the array.
This avoids allocating an array to hold all substrings and allocating each
substring itself.