### PR TITLE
(re-)add Healthcheck API

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -33,6 +33,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		TunnelAddr:                kingpin.Flag("tunnel-addr", "Address to serve the tunnel server").Default(defaultTunnelServerAddress).String(),
 		TunnelPort:                kingpin.Flag("tunnel-port", "Port to serve the tunnel server").Default(defaultTunnelServerPort).String(),
 		Assets:                    kingpin.Flag("assets", "Path to the assets").Default(defaultAssetsDirectory).Short('a').String(),
+		CheckHealth:               kingpin.Flag("check-health", "GET http://localhost:<port>/api/health endpoint").Default(defaultCheckHeath).Short('c').Bool(),
 		Data:                      kingpin.Flag("data", "Path to the folder where the data is stored").Default(defaultDataDirectory).Short('d').String(),
 		EndpointURL:               kingpin.Flag("host", "Endpoint URL").Short('H').String(),
 		EnableEdgeComputeFeatures: kingpin.Flag("edge-compute", "Enable Edge Compute features").Bool(),

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -8,6 +8,7 @@ const (
 	defaultTunnelServerPort    = "8000"
 	defaultDataDirectory       = "/data"
 	defaultAssetsDirectory     = "./"
+	defaultCheckHeath          = "false"
 	defaultTLS                 = "false"
 	defaultTLSSkipVerify       = "false"
 	defaultTLSCACertPath       = "/certs/ca.pem"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -6,6 +6,7 @@ const (
 	defaultTunnelServerPort    = "8000"
 	defaultDataDirectory       = "C:\\data"
 	defaultAssetsDirectory     = "./"
+	defaultCheckHeath          = "false"
 	defaultTLS                 = "false"
 	defaultTLSSkipVerify       = "false"
 	defaultTLSCACertPath       = "C:\\certs\\ca.pem"

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -334,7 +334,20 @@ func terminateIfNoAdminCreated(dataStore portainer.DataStore) {
 
 func main() {
 	flags := initCLI()
-
+    
+	if *flags.CheckHealth {
+		statuscode, err := http.HealthCheck(*flags.Addr)
+		if err == nil {
+				if statuscode == 200 {
+					log.Println(*flags.Addr, ": Online - response:", statuscode)
+					os.Exit(0)
+				} else {
+					log.Fatal(*flags.Addr, ": Error - response:", statuscode)
+				}
+			}
+			log.Fatal("Connection error:", err.Error())
+	}
+	
 	fileService := initFileService(*flags.Data)
 
 	dataStore := initDataStore(*flags.Data, fileService)

--- a/api/http/health_check.go
+++ b/api/http/health_check.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"net/http"
+)
+
+// HealthCheck GETs /api/status
+func HealthCheck(addr string) (int, error) {
+	resp, err := http.Get("http://" + addr + "/api/status")
+	return resp.StatusCode, err
+}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -39,6 +39,7 @@ type (
 		AdminPassword             *string
 		AdminPasswordFile         *string
 		Assets                    *string
+		CheckHealth               *bool
 		Data                      *string
 		EnableEdgeComputeFeatures *bool
 		EndpointURL               *string


### PR DESCRIPTION
This readds the healthcheck API from #1366 as discussed in #1364 (and #3572) which was revoked in #1588 
due to #1584 showing healthcheck as a default wouldn't work with --ssl set.

It has been resubmitted for people to itterate on and because it's stil _very_ usable for people using reverse proxies, even in it's current state. Hope is someone can later submit the changes to make it work with SSL too (and possibly make it a default), but for now this at least works for some of us.

Currently it only supports hosts without --ssl and needs to be _manually_ added to a healthcheck in dockercompose/docker to ensure it doesn't break portainer for people using SSL.

Co-authored-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

---
*edit*
- Added references to all the ongoing and older discussions about the subject.
- Removed unneeded caps
