### PR TITLE
fix(k8s/endpoint): update endpoint URL

### DIFF
--- a/app/portainer/views/endpoints/edit/endpointController.js
+++ b/app/portainer/views/endpoints/edit/endpointController.js
@@ -142,6 +142,10 @@ angular
         payload.URL = 'tcp://' + endpoint.URL;
       }
 
+      if (endpoint.Type === PortainerEndpointTypes.AgentOnKubernetesEnvironment) {
+        payload.URL = endpoint.URL;
+      }
+
       $scope.state.actionInProgress = true;
       EndpointService.updateEndpoint(endpoint.Id, payload).then(
         function success() {

--- a/app/portainer/views/endpoints/edit/endpointController.js
+++ b/app/portainer/views/endpoints/edit/endpointController.js
@@ -138,7 +138,12 @@ angular
         AzureAuthenticationKey: endpoint.AzureCredentials.AuthenticationKey,
       };
 
-      if ($scope.endpointType !== 'local' && endpoint.Type !== PortainerEndpointTypes.AzureEnvironment && endpoint.Type !== PortainerEndpointTypes.KubernetesLocalEnvironment) {
+      if (
+        $scope.endpointType !== 'local' &&
+        endpoint.Type !== PortainerEndpointTypes.AzureEnvironment &&
+        endpoint.Type !== PortainerEndpointTypes.KubernetesLocalEnvironment &&
+        endpoint.Type !== PortainerEndpointTypes.AgentOnKubernetesEnvironment
+      ) {
         payload.URL = 'tcp://' + endpoint.URL;
       }
 

--- a/app/portainer/views/endpoints/edit/endpointController.js
+++ b/app/portainer/views/endpoints/edit/endpointController.js
@@ -138,12 +138,7 @@ angular
         AzureAuthenticationKey: endpoint.AzureCredentials.AuthenticationKey,
       };
 
-      if (
-        $scope.endpointType !== 'local' &&
-        endpoint.Type !== PortainerEndpointTypes.AzureEnvironment &&
-        endpoint.Type !== PortainerEndpointTypes.KubernetesLocalEnvironment &&
-        endpoint.Type !== PortainerEndpointTypes.AgentOnKubernetesEnvironment
-      ) {
+      if ($scope.endpointType !== 'local' && endpoint.Type !== PortainerEndpointTypes.AzureEnvironment && endpoint.Type !== PortainerEndpointTypes.KubernetesLocalEnvironment) {
         payload.URL = 'tcp://' + endpoint.URL;
       }
 


### PR DESCRIPTION
Fix #4478
[CE-110]

Note that changing the agent URL and trying to access the endpoint creates the following errors 
```
2020/11/23 16:22:47 server: Reverse tunnelling enabled
2020/11/23 16:22:47 server: Fingerprint 3c:dd:80:47:5a:19:c1:d2:41:81:87:71:c3:15:52:ac
2020/11/23 16:22:47 server: Listening on 0.0.0.0:8000...
2020/11/23 16:22:47 Starting Portainer 2.0.0 on :9000
2020/11/23 16:22:47 [DEBUG] [chisel, monitoring] [check_interval_seconds: 10.000000] [message: starting tunnel management process]
2020/11/23 16:23:52 http error: No administrator account found inside the database (err=Object not found inside the database) (code=404)
2020/11/23 16:23:52 http error: No administrator account found inside the database (err=Object not found inside the database) (code=404)
2020/11/23 16:24:24 http error: Unable to initiate communications with endpoint (err=unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined) (code=500)
2020/11/23 16:24:57 http error: Unable to initiate communications with endpoint (err=unknown) (code=500)
2020/11/23 16:27:28 http error: Unable to initiate communications with endpoint (err=unknown) (code=500)
2020/11/23 16:27:56 http error: Unable to initiate communications with endpoint (err=unknown) (code=500)
2020/11/23 16:29:35 http error: Unable to get endpoint type (err=Get "https://192.168.1.16:30778/ping": read tcp 172.17.0.5:50696->192.168.1.16:30778: read: connection reset by peer) (code=500)
2020/11/23 16:30:26 http error: Unable to get endpoint type (err=Get "https://http//192.168.1.16:30778/ping": dial tcp: lookup http on 1.1.1.1:53: no such host) (code=500)
2020/11/23 16:31:39 http error: Unable to get endpoint type (err=Get "https://http//192.168.1.16:30778/ping": dial tcp: lookup http on 1.1.1.1:53: no such host) (code=500)
2020/11/23 16:32:18 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:32:18 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:32:18 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:32:18 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:37:30 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:37:30 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:37:30 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:37:30 http: proxy error: x509: certificate is valid for 10.244.0.2, not 192.168.1.16
2020/11/23 16:38:01 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:38:01 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:38:01 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:38:01 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:39:27 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:39:27 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:39:27 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
2020/11/23 16:39:27 http: proxy error: dial tcp: lookup tcp on 1.1.1.1:53: no such host
```

[CE-110]: https://portainer.atlassian.net/browse/CE-110