### PR TITLE
fix(applications/ports-mapping): load balancer link expand only if item length > 1

### DIFF
--- a/app/kubernetes/views/applications/applicationsController.js
+++ b/app/kubernetes/views/applications/applicationsController.js
@@ -87,7 +87,7 @@ class KubernetesApplicationsController {
     _.forEach(this.ports, (item) => {
       item.Expanded = false;
       item.Highlighted = false;
-      if (item.Name === application.Name) {
+      if (item.Name === application.Name && item.Ports.length > 1) {
         item.Expanded = true;
         item.Highlighted = true;
       }


### PR DESCRIPTION
Fix #4490 