### PR TITLE
fix(auth): skip security checks with --no-auth flag 

### DIFF
--- a/api/http/handler/stacks/handler.go
+++ b/api/http/handler/stacks/handler.go
@@ -16,6 +16,8 @@ type Handler struct {
 	stackCreationMutex *sync.Mutex
 	stackDeletionMutex *sync.Mutex
 	requestBouncer     *security.RequestBouncer
+	authDisabled       bool
+
 	*mux.Router
 	FileService            portainer.FileService
 	GitService             portainer.GitService
@@ -32,9 +34,10 @@ type Handler struct {
 }
 
 // NewHandler creates a handler to manage stack operations.
-func NewHandler(bouncer *security.RequestBouncer) *Handler {
+func NewHandler(bouncer *security.RequestBouncer, authDisabled bool) *Handler {
 	h := &Handler{
 		Router:             mux.NewRouter(),
+		authDisabled:       authDisabled,
 		stackCreationMutex: &sync.Mutex{},
 		stackDeletionMutex: &sync.Mutex{},
 		requestBouncer:     bouncer,
@@ -57,7 +60,7 @@ func NewHandler(bouncer *security.RequestBouncer) *Handler {
 }
 
 func (handler *Handler) userCanAccessStack(securityContext *security.RestrictedRequestContext, endpointID portainer.EndpointID, resourceControl *portainer.ResourceControl) (bool, error) {
-	if securityContext.IsAdmin {
+	if securityContext.IsAdmin || handler.authDisabled {
 		return true, nil
 	}
 
@@ -90,7 +93,7 @@ func (handler *Handler) userCanAccessStack(securityContext *security.RestrictedR
 }
 
 func (handler *Handler) userCanCreateStack(securityContext *security.RestrictedRequestContext, endpointID portainer.EndpointID) (bool, error) {
-	if securityContext.IsAdmin {
+	if securityContext.IsAdmin || handler.authDisabled {
 		return true, nil
 	}
 

--- a/api/http/proxy/factory/docker.go
+++ b/api/http/proxy/factory/docker.go
@@ -68,6 +68,7 @@ func (factory *ProxyFactory) newDockerHTTPProxy(endpoint *portainer.Endpoint) (h
 		ExtensionService:       factory.extensionService,
 		SignatureService:       factory.signatureService,
 		DockerClientFactory:    factory.dockerClientFactory,
+		AuthDisabled:           factory.authDisabled,
 	}
 
 	dockerTransport, err := docker.NewTransport(transportParameters, httpTransport)

--- a/api/http/proxy/factory/docker/transport.go
+++ b/api/http/proxy/factory/docker/transport.go
@@ -38,6 +38,7 @@ type (
 		extensionService       portainer.ExtensionService
 		dockerClient           *client.Client
 		dockerClientFactory    *docker.ClientFactory
+		authDisabled           bool
 	}
 
 	// TransportParameters is used to create a new Transport
@@ -54,6 +55,7 @@ type (
 		ReverseTunnelService   portainer.ReverseTunnelService
 		ExtensionService       portainer.ExtensionService
 		DockerClientFactory    *docker.ClientFactory
+		AuthDisabled           bool
 	}
 
 	restrictedDockerOperationContext struct {
@@ -94,6 +96,7 @@ func NewTransport(parameters *TransportParameters, httpTransport *http.Transport
 		dockerClientFactory:    parameters.DockerClientFactory,
 		HTTPTransport:          httpTransport,
 		dockerClient:           dockerClient,
+		authDisabled:           parameters.AuthDisabled,
 	}
 
 	return transport, nil
@@ -655,7 +658,6 @@ func (transport *Transport) createRegistryAccessContext(request *http.Request) (
 	if err != nil {
 		return nil, err
 	}
-
 
 	accessContext := &registryAccessContext{
 		isAdmin: true,

--- a/api/http/proxy/factory/docker_unix.go
+++ b/api/http/proxy/factory/docker_unix.go
@@ -24,6 +24,7 @@ func (factory ProxyFactory) newOSBasedLocalProxy(path string, endpoint *portaine
 		ExtensionService:       factory.extensionService,
 		SignatureService:       factory.signatureService,
 		DockerClientFactory:    factory.dockerClientFactory,
+		AuthDisabled:           factory.authDisabled,
 	}
 
 	proxy := &dockerLocalProxy{}

--- a/api/http/proxy/factory/docker_windows.go
+++ b/api/http/proxy/factory/docker_windows.go
@@ -25,6 +25,7 @@ func (factory ProxyFactory) newOSBasedLocalProxy(path string, endpoint *portaine
 		ExtensionService:       factory.extensionService,
 		SignatureService:       factory.signatureService,
 		DockerClientFactory:    factory.dockerClientFactory,
+		AuthDisabled:           factory.authDisabled,
 	}
 
 	proxy := &dockerLocalProxy{}

--- a/api/http/proxy/factory/factory.go
+++ b/api/http/proxy/factory/factory.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/docker"
 )
 
@@ -32,6 +32,7 @@ type (
 		reverseTunnelService   portainer.ReverseTunnelService
 		extensionService       portainer.ExtensionService
 		dockerClientFactory    *docker.ClientFactory
+		authDisabled           bool
 	}
 
 	// ProxyFactoryParameters is used to create a new ProxyFactory
@@ -47,6 +48,7 @@ type (
 		ReverseTunnelService   portainer.ReverseTunnelService
 		ExtensionService       portainer.ExtensionService
 		DockerClientFactory    *docker.ClientFactory
+		AuthDisabled           bool
 	}
 )
 
@@ -64,6 +66,7 @@ func NewProxyFactory(parameters *ProxyFactoryParameters) *ProxyFactory {
 		reverseTunnelService:   parameters.ReverseTunnelService,
 		extensionService:       parameters.ExtensionService,
 		dockerClientFactory:    parameters.DockerClientFactory,
+		authDisabled:           parameters.AuthDisabled,
 	}
 }
 

--- a/api/http/proxy/manager.go
+++ b/api/http/proxy/manager.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/orcaman/concurrent-map"
-	"github.com/portainer/portainer/api"
+	cmap "github.com/orcaman/concurrent-map"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/docker"
 	"github.com/portainer/portainer/api/http/proxy/factory"
 )
@@ -34,6 +34,7 @@ type (
 		ReverseTunnelService   portainer.ReverseTunnelService
 		ExtensionService       portainer.ExtensionService
 		DockerClientFactory    *docker.ClientFactory
+		AuthDisabled           bool
 	}
 )
 
@@ -51,6 +52,7 @@ func NewManager(parameters *ManagerParams) *Manager {
 		ReverseTunnelService:   parameters.ReverseTunnelService,
 		ExtensionService:       parameters.ExtensionService,
 		DockerClientFactory:    parameters.DockerClientFactory,
+		AuthDisabled:           parameters.AuthDisabled,
 	}
 
 	return &Manager{

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -104,6 +104,7 @@ func (server *Server) Start() error {
 		ReverseTunnelService:   server.ReverseTunnelService,
 		ExtensionService:       server.ExtensionService,
 		DockerClientFactory:    server.DockerClientFactory,
+		AuthDisabled:           server.AuthDisabled,
 	}
 	proxyManager := proxy.NewManager(proxyManagerParameters)
 

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -247,7 +247,7 @@ func (server *Server) Start() error {
 	settingsHandler.ExtensionService = server.ExtensionService
 	settingsHandler.AuthorizationService = authorizationService
 
-	var stackHandler = stacks.NewHandler(requestBouncer)
+	var stackHandler = stacks.NewHandler(requestBouncer, server.AuthDisabled)
 	stackHandler.FileService = server.FileService
 	stackHandler.StackService = server.StackService
 	stackHandler.EndpointService = server.EndpointService

--- a/app/docker/views/volumes/volumesController.js
+++ b/app/docker/views/volumes/volumesController.js
@@ -73,14 +73,16 @@ angular.module('portainer.docker').controller('VolumesController', [
 
       $scope.showBrowseAction = $scope.applicationState.endpoint.mode.agentProxy;
 
-      ExtensionService.extensionEnabled(ExtensionService.EXTENSIONS.RBAC).then(function success(extensionEnabled) {
-        if (!extensionEnabled) {
-          var isAdmin = Authentication.isAdmin();
-          if (!$scope.applicationState.application.enableVolumeBrowserForNonAdminUsers && !isAdmin) {
-            $scope.showBrowseAction = false;
+      if ($scope.applicationState.application.authentication) {
+        ExtensionService.extensionEnabled(ExtensionService.EXTENSIONS.RBAC).then(function success(extensionEnabled) {
+          if (!extensionEnabled) {
+            var isAdmin = Authentication.isAdmin();
+            if (!$scope.applicationState.application.enableVolumeBrowserForNonAdminUsers && !isAdmin) {
+              $scope.showBrowseAction = false;
+            }
           }
-        }
-      });
+        });
+      }
     }
 
     initView();


### PR DESCRIPTION
fix #4125

The following are not a problem, because they are hidden behind a check for `tokenData.isAdmin` and this check is true by default, but we might want to add a check for isAuthDisabled so it won't be removed by accident.
```
api/http/proxy/factory/docker/transport.go:
  437: 		user, err := transport.userService.User(tokenData.ID)
  713: 		user, err := transport.userService.User(operationContext.userID)

api/http/security/bouncer.go:
  183: 	user, err := bouncer.userService.User(tokenData.ID)
  261: 		user, err := bouncer.userService.User(tokenData.ID)
```

the following should be tested:
- create swarm stack
- create compose stack
- delete/inspect stack
- create container
- browse volumes (on agent)

