### PR TITLE
Fix webhook issue with repositories that have a custom port

### DIFF
--- a/api/http/handler/webhooks/webhook_execute.go
+++ b/api/http/handler/webhooks/webhook_execute.go
@@ -67,7 +67,7 @@ func (handler *Handler) executeServiceWebhook(w http.ResponseWriter, endpoint *p
 	service.Spec.TaskTemplate.ForceUpdate++
 
 	if imageTag != "" {
-		service.Spec.TaskTemplate.ContainerSpec.Image = strings.Split(service.Spec.TaskTemplate.ContainerSpec.Image, ":")[0] + ":" + imageTag
+		service.Spec.TaskTemplate.ContainerSpec.Image = string(service.Spec.TaskTemplate.ContainerSpec.Image[:strings.LastIndex(service.Spec.TaskTemplate.ContainerSpec.Image, ":")]) + ":" + imageTag
 	} else {
 		service.Spec.TaskTemplate.ContainerSpec.Image = strings.Split(service.Spec.TaskTemplate.ContainerSpec.Image, "@sha")[0]
 	}


### PR DESCRIPTION
Fixed webhook issue with repositories containing ports in url. Addresses https://github.com/portainer/portainer/issues/4526

If someone could test this I would appreciate it.