### PR TITLE
#4470 fix(stack): fix a display issue with the stack editor tab.

### DIFF
--- a/app/portainer/views/stacks/edit/stack.html
+++ b/app/portainer/views/stacks/edit/stack.html
@@ -89,7 +89,7 @@
           </uib-tab>
           <!-- !tab-info -->
           <!-- tab-file -->
-          <uib-tab index="1" ng-if="stackFileContent" select="showEditor()">
+          <uib-tab index="1" select="showEditor()">
             <uib-tab-heading> <i class="fa fa-pencil-alt space-right" aria-hidden="true"></i> Editor </uib-tab-heading>
             <form class="form-horizontal" ng-if="state.showEditorTab" style="margin-top: 10px;">
               <div class="form-group">
@@ -165,7 +165,7 @@
                     <button
                       type="button"
                       class="btn btn-sm btn-primary"
-                      ng-disabled="state.actionInProgress || stack.Status === 2"
+                      ng-disabled="state.actionInProgress || stack.Status === 2 || !stackFileContent"
                       ng-click="deployStack()"
                       button-spinner="state.actionInProgress"
                     >


### PR DESCRIPTION
This will solve #4470.
Instead of removing the entire editor tab we are now disabling the "Update the Stack" button when the editor content is empty.

![stack](https://user-images.githubusercontent.com/70788131/100884380-68745700-34d7-11eb-9b00-59b9706c7ac4.png)
