### PR TITLE
fix(docker/stack-details): do not display editor tab for external stack

### DIFF
--- a/app/portainer/views/stacks/edit/stack.html
+++ b/app/portainer/views/stacks/edit/stack.html
@@ -89,7 +89,7 @@
           </uib-tab>
           <!-- !tab-info -->
           <!-- tab-file -->
-          <uib-tab index="1" select="showEditor()">
+          <uib-tab index="1" select="showEditor()" ng-if="!state.externalStack">
             <uib-tab-heading> <i class="fa fa-pencil-alt space-right" aria-hidden="true"></i> Editor </uib-tab-heading>
             <form class="form-horizontal" ng-if="state.showEditorTab" style="margin-top: 10px;">
               <div class="form-group">


### PR DESCRIPTION
Fixes #4642 