### PR TITLE
style(UX): add toggle functionality to log viewer settings

### DIFF
--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -2,12 +2,14 @@
   <div class="col-sm-12">
     <rd-widget>
       <rd-widget-header icon="fa-file-alt" title-text="Log viewer settings">
-        <button class="btn btn-sm" ng-click="$ctrl.hideLogSettings()" title="Toggle settings visibility"><i class="fa fa-eye" style="margin-right: 0;"></i></button>
+        <button id="logSettingsToggleBtn" class="btn btn-sm" ng-click="$ctrl.hideLogSettings()" title="Toggle settings visibility"
+          ><i class="fa fa-eye" style="margin-right: 0;"></i>&nbsp;Hide panel</button
+        >
       </rd-widget-header>
       <rd-widget-body id="logsWidgetBody">
         <form class="form-horizontal">
           <div class="form-group">
-            <div class="col-sm-4">
+            <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 Auto-refresh logs
                 <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
@@ -20,13 +22,17 @@
                 /><i></i>
               </label>
             </div>
-            <div class="col-sm-4">
+          </div>
+          <div class="form-group">
+            <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 Wrap lines
               </label>
               <label class="switch" style="margin-left: 20px;"> <input type="checkbox" ng-model="$ctrl.state.wrapLines" /><i></i> </label>
             </div>
-            <div class="col-sm-4">
+          </div>
+          <div class="form-group">
+            <div class="col-sm-12">
               <label for="tls" class="control-label text-left">
                 Display timestamps
               </label>
@@ -65,7 +71,6 @@
               Actions
             </label>
             <div class="col-sm-11">
-              <button class="btn btn-primary btn-sm" type="button" ng-click="$ctrl.downloadLogs()" style="margin-left: 0;"><i class="fa fa-download"></i> Download logs</button>
               <button
                 class="btn btn-primary btn-sm"
                 ng-click="$ctrl.copy()"

--- a/app/docker/components/log-viewer/logViewer.html
+++ b/app/docker/components/log-viewer/logViewer.html
@@ -1,11 +1,13 @@
 <div class="row">
   <div class="col-sm-12">
     <rd-widget>
-      <rd-widget-header icon="fa-file-alt" title-text="Log viewer settings"></rd-widget-header>
-      <rd-widget-body>
+      <rd-widget-header icon="fa-file-alt" title-text="Log viewer settings">
+        <button class="btn btn-sm" ng-click="$ctrl.hideLogSettings()" title="Toggle settings visibility"><i class="fa fa-eye" style="margin-right: 0;"></i></button>
+      </rd-widget-header>
+      <rd-widget-body id="logsWidgetBody">
         <form class="form-horizontal">
           <div class="form-group">
-            <div class="col-sm-12">
+            <div class="col-sm-4">
               <label for="tls" class="control-label text-left">
                 Auto-refresh logs
                 <portainer-tooltip position="bottom" message="Disabling this option allows you to pause the log collection process and the auto-scrolling."></portainer-tooltip>
@@ -18,17 +20,13 @@
                 /><i></i>
               </label>
             </div>
-          </div>
-          <div class="form-group">
-            <div class="col-sm-12">
+            <div class="col-sm-4">
               <label for="tls" class="control-label text-left">
                 Wrap lines
               </label>
               <label class="switch" style="margin-left: 20px;"> <input type="checkbox" ng-model="$ctrl.state.wrapLines" /><i></i> </label>
             </div>
-          </div>
-          <div class="form-group">
-            <div class="col-sm-12">
+            <div class="col-sm-4">
               <label for="tls" class="control-label text-left">
                 Display timestamps
               </label>
@@ -94,7 +92,7 @@
 </div>
 
 <div class="row" style="height: 54%;">
-  <div class="col-sm-12" style="height: 100%;">
+  <div class="col-sm-12" style="height: 90vh;">
     <pre ng-class="{ wrap_lines: $ctrl.state.wrapLines }" class="log_viewer" scroll-glue="$ctrl.state.autoScroll" force-glue>
       <div ng-repeat="line in $ctrl.state.filteredLogs = ($ctrl.data | filter:$ctrl.state.search) track by $index" class="line" ng-if="line"><p class="inner_line" ng-click="$ctrl.selectLine(line)" ng-class="{ 'line_selected': $ctrl.state.selectedLines.indexOf(line) > -1 }">{{ line }}</p></div>
       <div ng-if="!$ctrl.state.filteredLogs.length" class="line"><p class="inner_line">No log line matching the '{{ $ctrl.state.search }}' filter</p></div>

--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -43,5 +43,9 @@ angular.module('portainer.docker').controller('LogViewerController', [
         this.state.selectedLines.splice(idx, 1);
       }
     };
+
+    this.hideLogSettings = function () {
+      $('#logsWidgetBody').toggle();
+    };
   },
 ]);

--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import moment from 'moment';
 import _ from 'lodash-es';
 
@@ -49,6 +50,11 @@ angular.module('portainer.docker').controller('LogViewerController', [
 
     this.hideLogSettings = function () {
       $('#logsWidgetBody').toggle();
+
+      var icon = '<i class="fa fa-eye" style="margin-right: 0;"></i>';
+      var currentText = $('#logSettingsToggleBtn').text().trim();
+      var updatedText = currentText === 'Hide panel' ? icon + '&nbsp;Show panel' : icon + '&nbsp;Hide panel';
+      $('#logSettingsToggleBtn').html(updatedText);
     };
 
     this.downloadLogs = function () {

--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -1,8 +1,11 @@
 import moment from 'moment';
+import _ from 'lodash-es';
 
 angular.module('portainer.docker').controller('LogViewerController', [
   'clipboard',
-  function (clipboard) {
+  'Blob',
+  'FileSaver',
+  function (clipboard, Blob, FileSaver) {
     this.state = {
       availableSinceDatetime: [
         { desc: 'Last day', value: moment().subtract(1, 'days').format() },
@@ -46,6 +49,11 @@ angular.module('portainer.docker').controller('LogViewerController', [
 
     this.hideLogSettings = function () {
       $('#logsWidgetBody').toggle();
+    };
+
+    this.downloadLogs = function () {
+      const data = new Blob([_.reduce(this.state.filteredLogs, (acc, log) => acc + '\n' + log, '')]);
+      FileSaver.saveAs(data, this.resourceName + '_logs.txt');
     };
   },
 ]);


### PR DESCRIPTION
This commit tries to address #4477

An "eye" icon is added to the header on the right to toggle the widget body on click. The toggle switches are also arranged horizontally as mentioned in the issue.

![image](https://user-images.githubusercontent.com/41547081/103797066-f9f25e00-506d-11eb-8354-9313e013400e.png)

![image](https://user-images.githubusercontent.com/41547081/103796893-c9122900-506d-11eb-909c-0f9b55bf38d1.png)
