### PR TITLE
Show shared access policy in volume details - 2

### DIFF
--- a/app/kubernetes/views/volumes/edit/volume.html
+++ b/app/kubernetes/views/volumes/edit/volume.html
@@ -38,6 +38,17 @@
                       <td>{{ ctrl.volume.PersistentVolumeClaim.StorageClass.Name }}</td>
                     </tr>
                     <tr>
+                      <td>Shared Access Policy</td>
+                      <td
+                        >{{ ctrl.state.volumeSharedAccessPolicy }}
+                        <portainer-tooltip
+                          position="bottom"
+                          ng-if="ctrl.state.volumeSharedAccessPolicyTooltip"
+                          message="{{ ctrl.state.volumeSharedAccessPolicyTooltip }}"
+                        ></portainer-tooltip
+                      ></td>
+                    </tr>
+                    <tr>
                       <td>Provisioner</td>
                       <td>{{ ctrl.volume.PersistentVolumeClaim.StorageClass.Provisioner ? ctrl.volume.PersistentVolumeClaim.StorageClass.Provisioner : '-' }}</td>
                     </tr>

--- a/app/kubernetes/views/volumes/edit/volumeController.js
+++ b/app/kubernetes/views/volumes/edit/volumeController.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import _ from 'lodash-es';
 import KubernetesVolumeHelper from 'Kubernetes/helpers/volumeHelper';
 import KubernetesEventHelper from 'Kubernetes/helpers/eventHelper';
+import { KubernetesStorageClassAccessPolicies } from 'Kubernetes/models/storage-class/models';
 import filesizeParser from 'filesize-parser';
 
 class KubernetesVolumeController {
@@ -179,6 +180,8 @@ class KubernetesVolumeController {
       volumeSize: 0,
       volumeSizeUnit: 'GB',
       volumeSizeError: false,
+      volumeSharedAccessPolicy: '',
+      volumeSharedAccessPolicyTooltip: '',
     };
 
     this.state.activeTab = this.LocalStorage.getActiveTab('volume');
@@ -186,6 +189,16 @@ class KubernetesVolumeController {
     try {
       await this.getVolume();
       await this.getEvents();
+      if (this.volume.PersistentVolumeClaim.StorageClass !== undefined) {
+        this.state.volumeSharedAccessPolicy = this.volume.PersistentVolumeClaim.StorageClass.AccessModes[this.volume.PersistentVolumeClaim.StorageClass.AccessModes.length - 1];
+        let policies = KubernetesStorageClassAccessPolicies();
+
+        policies.forEach((policy) => {
+          if (policy.Name == this.state.volumeSharedAccessPolicy) {
+            this.state.volumeSharedAccessPolicyTooltip = policy.Description;
+          }
+        });
+      }
     } catch (err) {
       this.Notifications.error('Failure', err, 'Unable to load view data');
     } finally {


### PR DESCRIPTION
Updated version of PR #4405 
Closes #4402 
This PR adds the shared access policy entry in the volume details view for Kubernetes.

Any suggestions and advice are welcome!
Thank you!