### PR TITLE
fix(k8s) parse empty configuration as empty string yaml instead of {} (ce#395)

### DIFF
--- a/app/kubernetes/helpers/configurationHelper.js
+++ b/app/kubernetes/helpers/configurationHelper.js
@@ -52,6 +52,8 @@ class KubernetesConfigurationHelper {
   }
 
   static parseData(formValues) {
+    if (!formValues.Data.length) return '';
+
     const data = _.reduce(
       formValues.Data,
       (acc, entry) => {


### PR DESCRIPTION
close ce#395