### PR TITLE
fix: docker-compose access to private registries

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -74,7 +74,7 @@ func initDataStore(dataStorePath string, fileService portainer.FileService) port
 }
 
 func initComposeStackManager(assetsPath string, dataStorePath string, reverseTunnelService portainer.ReverseTunnelService, proxyManager *proxy.Manager) portainer.ComposeStackManager {
-	composeWrapper := exec.NewComposeWrapper(assetsPath, proxyManager)
+	composeWrapper := exec.NewComposeWrapper(assetsPath, dataStorePath, proxyManager)
 	if composeWrapper != nil {
 		return composeWrapper
 	}

--- a/api/exec/compose_wrapper.go
+++ b/api/exec/compose_wrapper.go
@@ -16,17 +16,19 @@ import (
 // ComposeWrapper is a wrapper for docker-compose binary
 type ComposeWrapper struct {
 	binaryPath   string
+	dataPath     string
 	proxyManager *proxy.Manager
 }
 
 // NewComposeWrapper returns a docker-compose wrapper if corresponding binary present, otherwise nil
-func NewComposeWrapper(binaryPath string, proxyManager *proxy.Manager) *ComposeWrapper {
+func NewComposeWrapper(binaryPath, dataPath string, proxyManager *proxy.Manager) *ComposeWrapper {
 	if !IsBinaryPresent(programPath(binaryPath, "docker-compose")) {
 		return nil
 	}
 
 	return &ComposeWrapper{
 		binaryPath:   binaryPath,
+		dataPath:     dataPath,
 		proxyManager: proxyManager,
 	}
 }
@@ -79,6 +81,8 @@ func (w *ComposeWrapper) command(command []string, stack *portainer.Stack, endpo
 
 	var stderr bytes.Buffer
 	cmd := exec.Command(program, args...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_CONFIG=%s", w.dataPath))
 	cmd.Stderr = &stderr
 
 	out, err := cmd.Output()

--- a/api/exec/compose_wrapper_integration_test.go
+++ b/api/exec/compose_wrapper_integration_test.go
@@ -42,7 +42,7 @@ func Test_UpAndDown(t *testing.T) {
 
 	stack, endpoint := setup(t)
 
-	w := NewComposeWrapper("", nil)
+	w := NewComposeWrapper("", "", nil)
 
 	err := w.Up(stack, endpoint)
 	if err != nil {


### PR DESCRIPTION
closes #4807 
closes #CE-401

Provide `DOCKER_CONFIG` env var to the `docker-compose` executable. Env var points to a directory with the docker's `config.json` file.