### PR TITLE
fix(uac): ignore duplicates, spaces and casing in portainer labels

### DIFF
--- a/api/bolt/team/team.go
+++ b/api/bolt/team/team.go
@@ -1,7 +1,9 @@
 package team
 
 import (
-	"github.com/portainer/portainer/api"
+	"strings"
+
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
 
@@ -58,7 +60,7 @@ func (service *Service) TeamByName(name string) (*portainer.Team, error) {
 				return err
 			}
 
-			if t.Name == name {
+			if strings.EqualFold(t.Name, name) {
 				team = &t
 				break
 			}

--- a/api/bolt/user/user.go
+++ b/api/bolt/user/user.go
@@ -1,10 +1,13 @@
 package user
 
 import (
-	"github.com/portainer/portainer/api"
+	"strings"
+
+	"strings"
+
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"
-	"strings"
 
 	"github.com/boltdb/bolt"
 )
@@ -61,7 +64,7 @@ func (service *Service) UserByUsername(username string) (*portainer.User, error)
 				return err
 			}
 
-			if strings.ToLower(u.Username) == username {
+			if strings.EqualFold(u.Username, username) {
 				user = &u
 				break
 			}

--- a/api/bolt/user/user.go
+++ b/api/bolt/user/user.go
@@ -3,8 +3,6 @@ package user
 import (
 	"strings"
 
-	"strings"
-
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt/errors"
 	"github.com/portainer/portainer/api/bolt/internal"

--- a/api/go.mod
+++ b/api/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/portainer/libcompose v0.5.3
 	github.com/portainer/libcrypto v0.0.0-20190723020515-23ebe86ab2c2
 	github.com/portainer/libhttp v0.0.0-20190806161843-ba068f58be33
-	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/api/http/proxy/factory/docker/access_control.go
+++ b/api/http/proxy/factory/docker/access_control.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -48,7 +47,6 @@ func getUniqueElements(items string) []string {
 }
 
 func (transport *Transport) newResourceControlFromPortainerLabels(labelsObject map[string]interface{}, resourceID string, resourceType portainer.ResourceControlType) (*portainer.ResourceControl, error) {
-	fmt.Println(">> LABELS call:", labelsObject)
 	if labelsObject[resourceLabelForPortainerPublicResourceControl] != nil {
 		resourceControl := authorization.NewPublicResourceControl(resourceID, resourceType)
 
@@ -60,22 +58,16 @@ func (transport *Transport) newResourceControlFromPortainerLabels(labelsObject m
 		return resourceControl, nil
 	}
 
-	fmt.Println(">> fetching users and names.\nteams:", labelsObject[resourceLabelForPortainerTeamResourceControl], "\n users: ", labelsObject[resourceLabelForPortainerUserResourceControl])
-
 	teamNames := make([]string, 0)
 	userNames := make([]string, 0)
 	if labelsObject[resourceLabelForPortainerTeamResourceControl] != nil {
-		fmt.Println("fetching teams")
 		concatenatedTeamNames := labelsObject[resourceLabelForPortainerTeamResourceControl].(string)
 		teamNames = getUniqueElements(concatenatedTeamNames)
-		fmt.Println(">> TEAM names:", teamNames)
 	}
 
 	if labelsObject[resourceLabelForPortainerUserResourceControl] != nil {
-		fmt.Println("fetching users")
 		concatenatedUserNames := labelsObject[resourceLabelForPortainerUserResourceControl].(string)
 		userNames = getUniqueElements(concatenatedUserNames)
-		fmt.Println(">> USERS names:", userNames)
 	}
 
 	if len(teamNames) > 0 || len(userNames) > 0 {
@@ -243,7 +235,6 @@ func (transport *Transport) filterResourceList(parameters *resourceOperationPara
 
 	for _, resource := range resourceData {
 		resourceObject := resource.(map[string]interface{})
-		fmt.Println(">>>> CONTAINERS RESOURCE OBJ ", resourceObject)
 		if resourceObject[parameters.resourceIdentifierAttribute] == nil {
 			log.Printf("[WARN] [http,proxy,docker,filter] [message: unable to find resource identifier property in resource list element] [identifier_attribute: %s]", parameters.resourceIdentifierAttribute)
 			continue

--- a/api/http/proxy/factory/docker/access_control_test.go
+++ b/api/http/proxy/factory/docker/access_control_test.go
@@ -1,0 +1,63 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getUniqueElements(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		expected    []string
+	}{
+		{
+			description: "no items padded",
+			input:       "    ",
+			expected:    []string{},
+		},
+		{
+			description: "single item",
+			input:       "a",
+			expected:    []string{"a"},
+		},
+		{
+			description: "single item padded",
+			input:       " a   ",
+			expected:    []string{"a"},
+		},
+		{
+			description: "multiple items",
+			input:       "a,b",
+			expected:    []string{"a", "b"},
+		},
+		{
+			description: "multiple items padded",
+			input:       " a , b  ",
+			expected:    []string{"a", "b"},
+		},
+		{
+			description: "multiple items with empty values",
+			input:       " a , ,b  ",
+			expected:    []string{"a", "b"},
+		},
+		{
+			description: "duplicates",
+			input:       " a , a  ",
+			expected:    []string{"a"},
+		},
+		{
+			description: "mix with duplicates",
+			input:       " a ,b, a  ",
+			expected:    []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			result := getUniqueElements(tt.input)
+			assert.ElementsMatch(t, result, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
closes #3547
closes [CE-51]

Ignore duplicates, whitespaces and casing in Portainer's users and teams labels

[CE-51]: https://portainer.atlassian.net/browse/CE-51