### PR TITLE
fix(app/settings): update link to template definition docs

### DIFF
--- a/app/portainer/views/settings/settings.html
+++ b/app/portainer/views/settings/settings.html
@@ -62,7 +62,7 @@
             <div class="form-group">
               <span class="col-sm-12 text-muted small">
                 You can specify the URL to your own template definitions file here. See
-                <a href="https://www.portainer.io/documentation/how-to-use-templates/" target="_blank">Portainer documentation</a> for more details.
+                <a href="https://documentation.portainer.io/v2.0/settings/apps/#build-and-host-your-own-templates" target="_blank">Portainer documentation</a> for more details.
               </span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
Minor change, under the 'App Templates' section in settings the link to the 'how to use templates' page returns a 404, updated it to point to the same(?) section in newer docs.

Glanced through existing PRs and I don't think this has been done yet.

Closes https://github.com/portainer/portainer/issues/4832