### PR TITLE
fix(kube/config): show used key warning when needed

### DIFF
--- a/app/kubernetes/components/kubernetes-configuration-data/kubernetesConfigurationData.html
+++ b/app/kubernetes/components/kubernetes-configuration-data/kubernetesConfigurationData.html
@@ -53,7 +53,7 @@
       <div
         class="col-sm-11 small text-warning"
         style="margin-top: 5px;"
-        ng-show="kubernetesConfigurationDataCreationForm['configuration_data_key_' + index].$invalid || $ctrl.state.duplicateKeys[index] !== undefined"
+        ng-show="kubernetesConfigurationDataCreationForm['configuration_data_key_' + index].$invalid || (!entry.Used && $ctrl.state.duplicateKeys[index] !== undefined)"
       >
         <ng-messages for="kubernetesConfigurationDataCreationForm['configuration_data_key_' + index].$error">
           <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This field is required.</p>

--- a/app/kubernetes/components/kubernetes-configuration-data/kubernetesConfigurationDataController.js
+++ b/app/kubernetes/components/kubernetes-configuration-data/kubernetesConfigurationDataController.js
@@ -20,7 +20,7 @@ class KubernetesConfigurationDataController {
   }
 
   onChangeKey(entry) {
-    if (entry.Used) {
+    if (entry && entry.Used) {
       return;
     }
 
@@ -84,6 +84,7 @@ class KubernetesConfigurationDataController {
   showSimpleMode() {
     this.formValues.IsSimple = true;
     this.formValues.Data = KubernetesConfigurationHelper.parseYaml(this.formValues);
+    this.onChangeKey();
   }
 
   showAdvancedMode() {
@@ -93,7 +94,7 @@ class KubernetesConfigurationDataController {
 
   $onInit() {
     this.state = {
-      duplicateKeys: {},
+      duplicateKeys: [],
     };
   }
 }


### PR DESCRIPTION
fix [CE-469]
- recalculate duplcate keys when they are changed
- show used warning on duplicate keys

[CE-469]: https://portainer.atlassian.net/browse/CE-469