### PR TITLE
style(proxy): fix function name

### DIFF
--- a/api/http/proxy/factory/docker/configs.go
+++ b/api/http/proxy/factory/docker/configs.go
@@ -58,7 +58,7 @@ func (transport *Transport) configListOperation(response *http.Response, executo
 func (transport *Transport) configInspectOperation(response *http.Response, executor *operationExecutor) error {
 	// ConfigInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.30/#operation/ConfigInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/containers.go
+++ b/api/http/proxy/factory/docker/containers.go
@@ -77,7 +77,7 @@ func (transport *Transport) containerListOperation(response *http.Response, exec
 func (transport *Transport) containerInspectOperation(response *http.Response, executor *operationExecutor) error {
 	//ContainerInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.28/#operation/ContainerInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/networks.go
+++ b/api/http/proxy/factory/docker/networks.go
@@ -62,7 +62,7 @@ func (transport *Transport) networkListOperation(response *http.Response, execut
 func (transport *Transport) networkInspectOperation(response *http.Response, executor *operationExecutor) error {
 	// NetworkInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.28/#operation/NetworkInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/secrets.go
+++ b/api/http/proxy/factory/docker/secrets.go
@@ -58,7 +58,7 @@ func (transport *Transport) secretListOperation(response *http.Response, executo
 func (transport *Transport) secretInspectOperation(response *http.Response, executor *operationExecutor) error {
 	// SecretInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.28/#operation/SecretInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/services.go
+++ b/api/http/proxy/factory/docker/services.go
@@ -63,7 +63,7 @@ func (transport *Transport) serviceListOperation(response *http.Response, execut
 func (transport *Transport) serviceInspectOperation(response *http.Response, executor *operationExecutor) error {
 	//ServiceInspect response is a JSON object
 	//https://docs.docker.com/engine/api/v1.28/#operation/ServiceInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/swarm.go
+++ b/api/http/proxy/factory/docker/swarm.go
@@ -11,7 +11,7 @@ import (
 func swarmInspectOperation(response *http.Response, executor *operationExecutor) error {
 	// SwarmInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.30/#operation/SwarmInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/transport.go
+++ b/api/http/proxy/factory/docker/transport.go
@@ -530,7 +530,7 @@ func (transport *Transport) interceptAndRewriteRequest(request *http.Request, op
 // https://docs.docker.com/engine/api/v1.37/#operation/SecretCreate
 // https://docs.docker.com/engine/api/v1.37/#operation/ConfigCreate
 func (transport *Transport) decorateGenericResourceCreationResponse(response *http.Response, resourceIdentifierAttribute string, resourceType portainer.ResourceControlType, userID portainer.UserID) error {
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/docker/volumes.go
+++ b/api/http/proxy/factory/docker/volumes.go
@@ -37,7 +37,7 @@ func getInheritedResourceControlFromVolumeLabels(dockerClient *client.Client, en
 func (transport *Transport) volumeListOperation(response *http.Response, executor *operationExecutor) error {
 	// VolumeList response is a JSON object
 	// https://docs.docker.com/engine/api/v1.28/#operation/VolumeList
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (transport *Transport) volumeListOperation(response *http.Response, executo
 func (transport *Transport) volumeInspectOperation(response *http.Response, executor *operationExecutor) error {
 	// VolumeInspect response is a JSON object
 	// https://docs.docker.com/engine/api/v1.28/#operation/VolumeInspect
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (transport *Transport) decorateVolumeResourceCreationOperation(request *htt
 }
 
 func (transport *Transport) decorateVolumeCreationResponse(response *http.Response, resourceIdentifierAttribute string, resourceType portainer.ResourceControlType, userID portainer.UserID) error {
-	responseObject, err := responseutils.GetResponseAsJSONOBject(response)
+	responseObject, err := responseutils.GetResponseAsJSONObject(response)
 	if err != nil {
 		return err
 	}

--- a/api/http/proxy/factory/responseutils/response.go
+++ b/api/http/proxy/factory/responseutils/response.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 )
 
-// GetResponseAsJSONOBject returns the response content as a generic JSON object
-func GetResponseAsJSONOBject(response *http.Response) (map[string]interface{}, error) {
+// GetResponseAsJSONObject returns the response content as a generic JSON object
+func GetResponseAsJSONObject(response *http.Response) (map[string]interface{}, error) {
 	responseData, err := getResponseBodyAsGenericJSON(response)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
closes [EE-479]

`responseutils.GetResponseAsJSONOBject` should be `responseutils.GetResponseAsJSONObject`

[EE-479]: https://portainer.atlassian.net/browse/EE-479