### PR TITLE
Enable `console.log` by default in `develop` branch

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,3 +26,4 @@ rules:
   no-empty-function: warn
   no-useless-escape: off
   import/order: error
+  no-console: off


### PR DESCRIPTION
In develop branch debug mode must be enabled by default.