### PR TITLE
chore(lint): add lint command

### DIFF
--- a/.vscode.example/settings.json
+++ b/.vscode.example/settings.json
@@ -1,0 +1,4 @@
+{
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": ["--fast", "-E", "exportloopref"]
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "start:toolkit": "grunt start:toolkit",
     "build:server:offline": "cd ./api/cmd/portainer && CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s' && mv -f portainer ../../../dist/portainer",
     "clean:all": "grunt clean:all",
-    "format": "prettier --loglevel warn --write \"**/*.{js,css,html}\""
+    "format": "prettier --loglevel warn --write \"**/*.{js,css,html}\"",
+    "lint": "yarn lint:client; yarn lint:server",
+    "lint:server": "cd api && golangci-lint run -E exportloopref",
+    "lint:client": "eslint --cache --fix ."
   },
   "scriptsComments": {
     "build": "Build the entire app (backend/frontend) in development mode",


### PR DESCRIPTION
[DTD-56]

this PR adds the following:

- yarn scripts:
  - `yarn lint:server` - will run go linter
  - `yarn lint:client` - will run eslint
  - `yarn lint` will run both
- vscode example settings for go linter - this enables a developer to copy the settings to his own `.vscode` folder and will run the same linter for go files (if using the vscode go extension)

[DTD-56]: https://portainer.atlassian.net/browse/DTD-56