### PR TITLE
feat(kubernetes/shell): backport kubectl shell backend functionality EE-849

### DIFF
--- a/api/go.sum
+++ b/api/go.sum
@@ -80,6 +80,7 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
+github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -395,6 +396,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a h1:UcxjrRMyNx/i/y8G7kPvLyy7rfbeuf1PYyBf973pgyU=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCuiMMNF8YUVLF3vJo=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/api/http/handler/websocket/handler.go
+++ b/api/http/handler/websocket/handler.go
@@ -33,5 +33,7 @@ func NewHandler(bouncer *security.RequestBouncer) *Handler {
 		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.websocketAttach)))
 	h.PathPrefix("/websocket/pod").Handler(
 		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.websocketPodExec)))
+	h.PathPrefix("/websocket/kubernetes-shell").Handler(
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.websocketShellPodExec)))
 	return h
 }

--- a/api/http/handler/websocket/shell_pod.go
+++ b/api/http/handler/websocket/shell_pod.go
@@ -40,12 +40,12 @@ func (handler *Handler) websocketShellPodExec(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create Kubernetes client", err}
 	}
 
-	serviceAccountName, err := cli.GetServiceAccountName(tokenData)
+	serviceAccount, err := cli.GetServiceAccount(tokenData)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find serviceaccount associated with user", err}
 	}
 
-	shellPod, err := cli.CreateUserShellPod(r.Context(), serviceAccountName)
+	shellPod, err := cli.CreateUserShellPod(r.Context(), serviceAccount.Name)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create user shell", err}
 	}

--- a/api/http/handler/websocket/shell_pod.go
+++ b/api/http/handler/websocket/shell_pod.go
@@ -1,0 +1,104 @@
+package websocket
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+// websocketShellPodExec handles GET requests on /websocket/pod?token=<token>&endpointId=<endpointID>
+// The request will be upgraded to the websocket protocol.
+// Authentication and access is controlled via the mandatory token query parameter.
+// The request will proxy input from the client to the pod via long-lived websocket connection.
+// The following query parameters are mandatory:
+// * token: JWT token used for authentication against this endpoint
+// * endpointId: endpoint ID of the endpoint where the resource is located
+func (handler *Handler) websocketShellPodExec(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	endpointID, err := request.RetrieveNumericQueryParameter(r, "endpointId", false)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid query parameter: endpointId", err}
+	}
+
+	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
+	if err == bolterrors.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to find the endpoint associated to the stack inside the database", err}
+	} else if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find the endpoint associated to the stack inside the database", err}
+	}
+
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to access endpoint", err}
+	}
+
+	cli, err := handler.KubernetesClientFactory.GetKubeClient(endpoint)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create Kubernetes client", err}
+	}
+
+	serviceAccountName, err := cli.GetServiceAccountName(tokenData)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find serviceaccount associated with user", err}
+	}
+
+	shellPod, err := cli.CreateUserShellPod(r.Context(), serviceAccountName)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create user shell", err}
+	}
+
+	// Modifying request params mid-flight before forewarding to K8s API server (websocket)
+	q := r.URL.Query()
+
+	q.Add("namespace", shellPod.Namespace)
+	q.Add("podName", shellPod.PodName)
+	q.Add("containerName", shellPod.ContainerName)
+	q.Add("command", shellPod.ShellExecCommand)
+
+	r.URL.RawQuery = q.Encode()
+
+	// Modify url path mid-flight before forewarding to k8s API server (websocket)
+	r.URL.Path = "/websocket/pod"
+
+	/*
+		Note: The following websocket proxying logic is duplicated from `api/http/handler/websocket/pod.go`
+	*/
+	params := &webSocketRequestParams{
+		endpoint: endpoint,
+	}
+
+	r.Header.Del("Origin")
+
+	if endpoint.Type == portainer.AgentOnKubernetesEnvironment {
+		err := handler.proxyAgentWebsocketRequest(w, r, params)
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to proxy websocket request to agent", err}
+		}
+		return nil
+	} else if endpoint.Type == portainer.EdgeAgentOnKubernetesEnvironment {
+		err := handler.proxyEdgeAgentWebsocketRequest(w, r, params)
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to proxy websocket request to Edge agent", err}
+		}
+		return nil
+	}
+
+	handlerErr := handler.hijackPodExecStartOperation(
+		w,
+		r,
+		cli,
+		endpoint,
+		shellPod.Namespace,
+		shellPod.PodName,
+		shellPod.ContainerName,
+		shellPod.ShellExecCommand,
+	)
+	if handlerErr != nil {
+		return handlerErr
+	}
+
+	return nil
+}

--- a/api/kubernetes/cli/client.go
+++ b/api/kubernetes/cli/client.go
@@ -25,7 +25,7 @@ type (
 
 	// KubeClient represent a service used to execute Kubernetes operations
 	KubeClient struct {
-		cli        *kubernetes.Clientset
+		cli        kubernetes.Interface
 		instanceID string
 	}
 )

--- a/api/kubernetes/cli/naming.go
+++ b/api/kubernetes/cli/naming.go
@@ -1,6 +1,10 @@
 package cli
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/gofrs/uuid"
+)
 
 const (
 	defaultNamespace                    = "default"
@@ -11,6 +15,7 @@ const (
 	portainerRBPrefix                   = "portainer-rb"
 	portainerConfigMapName              = "portainer-config"
 	portainerConfigMapAccessPoliciesKey = "NamespaceAccessPolicies"
+	portainerShellPodPrefix             = "portainer-pod-kubectl-shell"
 )
 
 func userServiceAccountName(userID int, instanceID string) string {
@@ -23,4 +28,12 @@ func userServiceAccountTokenSecretName(serviceAccountName string, instanceID str
 
 func namespaceClusterRoleBindingName(namespace string, instanceID string) string {
 	return fmt.Sprintf("%s-%s-%s", portainerRBPrefix, instanceID, namespace)
+}
+
+func userShellPodName(serviceAccountName string) (string, error) {
+	uid, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-%s", portainerShellPodPrefix, serviceAccountName, uid), nil
 }

--- a/api/kubernetes/cli/naming.go
+++ b/api/kubernetes/cli/naming.go
@@ -2,20 +2,19 @@ package cli
 
 import (
 	"fmt"
-
-	"github.com/gofrs/uuid"
 )
 
 const (
-	defaultNamespace                    = "default"
-	portainerNamespace                  = "portainer"
-	portainerUserCRName                 = "portainer-cr-user"
-	portainerUserCRBName                = "portainer-crb-user"
-	portainerUserServiceAccountPrefix   = "portainer-sa-user"
-	portainerRBPrefix                   = "portainer-rb"
-	portainerConfigMapName              = "portainer-config"
-	portainerConfigMapAccessPoliciesKey = "NamespaceAccessPolicies"
-	portainerShellPodPrefix             = "portainer-pod-kubectl-shell"
+	defaultNamespace                        = "default"
+	portainerNamespace                      = "portainer"
+	portainerUserCRName                     = "portainer-cr-user"
+	portainerUserCRBName                    = "portainer-crb-user"
+	portainerClusterAdminServiceAccountName = "portainer-sa-clusteradmin"
+	portainerUserServiceAccountPrefix       = "portainer-sa-user"
+	portainerRBPrefix                       = "portainer-rb"
+	portainerConfigMapName                  = "portainer-config"
+	portainerConfigMapAccessPoliciesKey     = "NamespaceAccessPolicies"
+	portainerShellPodPrefix                 = "portainer-pod-kubectl-shell"
 )
 
 func userServiceAccountName(userID int, instanceID string) string {
@@ -30,10 +29,6 @@ func namespaceClusterRoleBindingName(namespace string, instanceID string) string
 	return fmt.Sprintf("%s-%s-%s", portainerRBPrefix, instanceID, namespace)
 }
 
-func userShellPodName(serviceAccountName string) (string, error) {
-	uid, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s-%s-%s", portainerShellPodPrefix, serviceAccountName, uid), nil
+func userShellPodPrefix(serviceAccountName string) string {
+	return fmt.Sprintf("%s-%s-", portainerShellPodPrefix, serviceAccountName)
 }

--- a/api/kubernetes/cli/pod.go
+++ b/api/kubernetes/cli/pod.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/pkg/errors"
+	portainer "github.com/portainer/portainer/api"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateUserShellPod will create a kubectl based shell for the specified user by mounting their respective service account.
+// The lifecycle of the pod is managed in this function; this entails management of the following pod operations:
+// - The shell pod will be scoped to specified service accounts access permissions
+// - The shell pod will be automatically removed if it's not ready after specified period of time
+// - The shell pod will be automatically removed after a specified max life (prevent zombie pods)
+// - The shell pod will be automatically removed if request is cancelled (or client closes websocket connection)
+func (kcl *KubeClient) CreateUserShellPod(ctx context.Context, serviceAccountName string) (*portainer.KubernetesShellPod, error) {
+	// Schedule the pod for automatic removal
+	maxPodKeepAlive := 1 * time.Hour
+	maxPodKeepAliveSecondsStr := fmt.Sprintf("%d", int(maxPodKeepAlive.Seconds()))
+
+	podName, err := userShellPodName(serviceAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	podSpec := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: portainerNamespace,
+			Annotations: map[string]string{
+				"kubernetes.io/pod.type": "kubectl-shell",
+			},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: serviceAccountName,
+			Containers: []v1.Container{
+				{
+					Name: "kubectl-shell-container",
+					// TODO update the image details
+					Image:   "zeeshans/k8s-shell",
+					Command: []string{"sleep"},
+					// Specify sleep time to prevent zombie pods in case portainer process is terminated
+					Args: []string{maxPodKeepAliveSecondsStr},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	shellPod, err := kcl.cli.CoreV1().Pods(portainerNamespace).Create(podSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating shell pod")
+	}
+
+	// Wait for pod to reach ready state
+	timeoutCtx, cancelFunc := context.WithTimeout(ctx, 20*time.Second)
+	defer cancelFunc()
+	err = kcl.waitForPodStatus(timeoutCtx, v1.PodRunning, shellPod)
+	if err != nil {
+		kcl.cli.CoreV1().Pods(portainerNamespace).Delete(shellPod.Name, nil)
+		return nil, errors.Wrap(err, "aborting pod creation; error waiting for shell pod ready status")
+	}
+
+	if len(shellPod.Spec.Containers) != 1 {
+		kcl.cli.CoreV1().Pods(portainerNamespace).Delete(shellPod.Name, nil)
+		return nil, fmt.Errorf("incorrect shell pod state, expecting single container to be present")
+	}
+
+	podData := &portainer.KubernetesShellPod{
+		Namespace:        shellPod.Namespace,
+		PodName:          shellPod.Name,
+		ContainerName:    shellPod.Spec.Containers[0].Name,
+		ShellExecCommand: "/bin/bash",
+	}
+
+	// Handle pod lifecycle/cleanup - terminate pod after maxPodKeepAlive or upon request (long-lived) cancellation
+	go func() {
+		select {
+		case <-time.After(maxPodKeepAlive):
+			log.Println("[DEBUG] [internal,kubernetes/pod] [message: pod removal schedule duration exceeded]")
+			kcl.cli.CoreV1().Pods(portainerNamespace).Delete(shellPod.Name, nil)
+		case <-ctx.Done():
+			err := ctx.Err()
+			log.Printf("[DEBUG] [internal,kubernetes/pod] [message: context error: err=%s ]\n", err)
+			kcl.cli.CoreV1().Pods(portainerNamespace).Delete(shellPod.Name, nil)
+		}
+	}()
+
+	return podData, nil
+}
+
+// waitForPodStatus will wait until duration d (from now) for a pod to reach defined phase/status.
+// The pod status will be polled at specified delay until the pod reaches ready state.
+func (kcl *KubeClient) waitForPodStatus(ctx context.Context, phase v1.PodPhase, pod *v1.Pod) error {
+	log.Printf("[DEBUG] [internal,kubernetes/pod] [message: waiting for pod ready: pod=%s... ]\n", pod.Name)
+
+	pollDelay := 500 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			pod, err := kcl.cli.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if pod.Status.Phase == phase {
+				return nil
+			}
+
+			<-time.After(pollDelay)
+		}
+	}
+}

--- a/api/kubernetes/cli/pod_test.go
+++ b/api/kubernetes/cli/pod_test.go
@@ -52,7 +52,7 @@ func Test_waitForPodStatus(t *testing.T) {
 
 		pod, err := k.cli.CoreV1().Pods(defaultNamespace).Create(podSpec)
 		if err != nil {
-			t.Errorf("failed to create service acount; err=%s", err)
+			t.Errorf("failed to create pod; err=%s", err)
 		}
 		defer k.cli.CoreV1().Pods(defaultNamespace).Delete(pod.Name, nil)
 

--- a/api/kubernetes/cli/pod_test.go
+++ b/api/kubernetes/cli/pod_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_waitForPodStatus(t *testing.T) {
+
+	t.Run("successfully errors on cancelled context", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		podSpec := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNamespace},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "test-pod", Image: "containous/whoami"},
+				},
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+		err := k.waitForPodStatus(ctx, v1.PodRunning, podSpec)
+		if err != context.Canceled {
+			t.Errorf("waitForPodStatus should throw context cancellation error; err=%s", err)
+		}
+	})
+
+	t.Run("successfully errors on timeout", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		podSpec := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNamespace},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "test-pod", Image: "containous/whoami"},
+				},
+			},
+		}
+
+		pod, err := k.cli.CoreV1().Pods(defaultNamespace).Create(podSpec)
+		if err != nil {
+			t.Errorf("failed to create service acount; err=%s", err)
+		}
+		defer k.cli.CoreV1().Pods(defaultNamespace).Delete(pod.Name, nil)
+
+		ctx, cancelFunc := context.WithTimeout(context.TODO(), 0*time.Second)
+		defer cancelFunc()
+		err = k.waitForPodStatus(ctx, v1.PodRunning, podSpec)
+		if err != context.DeadlineExceeded {
+			t.Errorf("waitForPodStatus should throw deadline exceeded error; err=%s", err)
+		}
+	})
+
+}

--- a/api/kubernetes/cli/service_account.go
+++ b/api/kubernetes/cli/service_account.go
@@ -8,8 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetServiceAccountName returns the portainer ServiceAccountName associated to the specified user.
-func (kcl *KubeClient) GetServiceAccountName(tokenData *portainer.TokenData) (string, error) {
+// GetServiceAccount returns the portainer ServiceAccountName associated to the specified user.
+func (kcl *KubeClient) GetServiceAccount(tokenData *portainer.TokenData) (*v1.ServiceAccount, error) {
 	var portainerServiceAccountName string
 	if tokenData.Role == portainer.AdministratorRole {
 		portainerServiceAccountName = portainerClusterAdminServiceAccountName
@@ -18,12 +18,12 @@ func (kcl *KubeClient) GetServiceAccountName(tokenData *portainer.TokenData) (st
 	}
 
 	// verify name exists as service account resource within portainer namespace
-	serviceAccountName, err := kcl.cli.CoreV1().ServiceAccounts(portainerNamespace).Get(portainerServiceAccountName, metav1.GetOptions{})
+	serviceAccount, err := kcl.cli.CoreV1().ServiceAccounts(portainerNamespace).Get(portainerServiceAccountName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return serviceAccountName.Name, nil
+	return serviceAccount, nil
 }
 
 // GetServiceAccountBearerToken returns the ServiceAccountToken associated to the specified user.

--- a/api/kubernetes/cli/service_account.go
+++ b/api/kubernetes/cli/service_account.go
@@ -12,7 +12,7 @@ import (
 func (kcl *KubeClient) GetServiceAccountName(tokenData *portainer.TokenData) (string, error) {
 	var portainerServiceAccountName string
 	if tokenData.Role == portainer.AdministratorRole {
-		portainerServiceAccountName = portainer.K8sServiceAccountClusterAdmin
+		portainerServiceAccountName = portainerClusterAdminServiceAccountName
 	} else {
 		portainerServiceAccountName = userServiceAccountName(int(tokenData.ID), kcl.instanceID)
 	}

--- a/api/kubernetes/cli/service_account_test.go
+++ b/api/kubernetes/cli/service_account_test.go
@@ -9,7 +9,7 @@ import (
 	kfake "k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_GetServiceAccountName(t *testing.T) {
+func Test_GetServiceAccount(t *testing.T) {
 
 	t.Run("returns error if non-existent", func(t *testing.T) {
 		k := &KubeClient{
@@ -17,9 +17,9 @@ func Test_GetServiceAccountName(t *testing.T) {
 			instanceID: "test",
 		}
 		tokenData := &portainer.TokenData{ID: 1}
-		_, err := k.GetServiceAccountName(tokenData)
+		_, err := k.GetServiceAccount(tokenData)
 		if err == nil {
-			t.Error("GetServiceAccountName should fail with service account not found")
+			t.Error("GetServiceAccount should fail with service account not found")
 		}
 	})
 
@@ -45,14 +45,14 @@ func Test_GetServiceAccountName(t *testing.T) {
 		}
 		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
 
-		saName, err := k.GetServiceAccountName(tokenData)
+		sa, err := k.GetServiceAccount(tokenData)
 		if err != nil {
-			t.Errorf("GetServiceAccountName should succeed; err=%s", err)
+			t.Errorf("GetServiceAccount should succeed; err=%s", err)
 		}
 
 		want := "portainer-sa-clusteradmin"
-		if saName != want {
-			t.Errorf("GetServiceAccountName should succeed and return correct sa name; got=%s want=%s", saName, want)
+		if sa.Name != want {
+			t.Errorf("GetServiceAccount should succeed and return correct sa name; got=%s want=%s", sa.Name, want)
 		}
 	})
 
@@ -78,14 +78,14 @@ func Test_GetServiceAccountName(t *testing.T) {
 		}
 		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
 
-		saName, err := k.GetServiceAccountName(tokenData)
+		sa, err := k.GetServiceAccount(tokenData)
 		if err != nil {
-			t.Errorf("GetServiceAccountName should succeed; err=%s", err)
+			t.Errorf("GetServiceAccount should succeed; err=%s", err)
 		}
 
 		want := "portainer-sa-user-test-1"
-		if saName != want {
-			t.Errorf("GetServiceAccountName should succeed and return correct sa name; got=%s want=%s", saName, want)
+		if sa.Name != want {
+			t.Errorf("GetServiceAccount should succeed and return correct sa name; got=%s want=%s", sa.Name, want)
 		}
 	})
 

--- a/api/kubernetes/cli/service_account_test.go
+++ b/api/kubernetes/cli/service_account_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_GetServiceAccountName(t *testing.T) {
+
+	t.Run("returns error if non-existent", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+		tokenData := &portainer.TokenData{ID: 1}
+		_, err := k.GetServiceAccountName(tokenData)
+		if err == nil {
+			t.Error("GetServiceAccountName should fail with service account not found")
+		}
+	})
+
+	t.Run("succeeds for cluster admin role", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		tokenData := &portainer.TokenData{
+			ID:       1,
+			Role:     portainer.AdministratorRole,
+			Username: portainer.K8sServiceAccountClusterAdmin,
+		}
+		serviceAccount := &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tokenData.Username,
+			},
+		}
+		_, err := k.cli.CoreV1().ServiceAccounts(portainerNamespace).Create(serviceAccount)
+		if err != nil {
+			t.Errorf("failed to create service acount; err=%s", err)
+		}
+		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
+
+		saName, err := k.GetServiceAccountName(tokenData)
+		if err != nil {
+			t.Errorf("GetServiceAccountName should succeed; err=%s", err)
+		}
+
+		want := "portainer-sa-clusteradmin"
+		if saName != want {
+			t.Errorf("GetServiceAccountName should succeed and return correct sa name; got=%s want=%s", saName, want)
+		}
+	})
+
+	t.Run("succeeds for standard user role", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		tokenData := &portainer.TokenData{
+			ID:   1,
+			Role: portainer.StandardUserRole,
+		}
+		serviceAccountName := userServiceAccountName(int(tokenData.ID), k.instanceID)
+		serviceAccount := &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceAccountName,
+			},
+		}
+		_, err := k.cli.CoreV1().ServiceAccounts(portainerNamespace).Create(serviceAccount)
+		if err != nil {
+			t.Errorf("failed to create service acount; err=%s", err)
+		}
+		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
+
+		saName, err := k.GetServiceAccountName(tokenData)
+		if err != nil {
+			t.Errorf("GetServiceAccountName should succeed; err=%s", err)
+		}
+
+		want := "portainer-sa-user-test-1"
+		if saName != want {
+			t.Errorf("GetServiceAccountName should succeed and return correct sa name; got=%s want=%s", saName, want)
+		}
+	})
+
+}

--- a/api/kubernetes/cli/service_account_test.go
+++ b/api/kubernetes/cli/service_account_test.go
@@ -32,7 +32,7 @@ func Test_GetServiceAccountName(t *testing.T) {
 		tokenData := &portainer.TokenData{
 			ID:       1,
 			Role:     portainer.AdministratorRole,
-			Username: portainer.K8sServiceAccountClusterAdmin,
+			Username: portainerClusterAdminServiceAccountName,
 		}
 		serviceAccount := &v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1,6 +1,7 @@
 package portainer
 
 import (
+	"context"
 	"io"
 	"time"
 )
@@ -425,6 +426,14 @@ type (
 	KubernetesIngressClassConfig struct {
 		Name string `json:"Name"`
 		Type string `json:"Type"`
+	}
+
+	// KubernetesShellPod represents a Kubectl Shell details to facilitate pod exec functionality
+	KubernetesShellPod struct {
+		Namespace        string
+		PodName          string
+		ContainerName    string
+		ShellExecCommand string
 	}
 
 	// LDAPGroupSearchSettings represents settings used to search for groups in a LDAP server
@@ -1154,8 +1163,10 @@ type (
 
 	// KubeClient represents a service used to query a Kubernetes environment
 	KubeClient interface {
+		GetServiceAccountName(tokendata *TokenData) (string, error)
 		SetupUserServiceAccount(userID int, teamIDs []int) error
 		GetServiceAccountBearerToken(userID int) (string, error)
+		CreateUserShellPod(ctx context.Context, serviceAccountName string) (*KubernetesShellPod, error)
 		StartExecProcess(namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer) error
 	}
 
@@ -1569,6 +1580,9 @@ const (
 	// EdgeAgentActive represents an active state for a tunnel connected to an Edge endpoint
 	EdgeAgentActive string = "ACTIVE"
 )
+
+// K8sServiceAccountClusterAdmin is built in cluster admin service account
+const K8sServiceAccountClusterAdmin string = "portainer-sa-clusteradmin"
 
 // represents an authorization type
 const (

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1581,9 +1581,6 @@ const (
 	EdgeAgentActive string = "ACTIVE"
 )
 
-// K8sServiceAccountClusterAdmin is built in cluster admin service account
-const K8sServiceAccountClusterAdmin string = "portainer-sa-clusteradmin"
-
 // represents an authorization type
 const (
 	OperationDockerContainerArchiveInfo         Authorization = "DockerContainerArchiveInfo"

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 type (
@@ -1163,7 +1165,7 @@ type (
 
 	// KubeClient represents a service used to query a Kubernetes environment
 	KubeClient interface {
-		GetServiceAccountName(tokendata *TokenData) (string, error)
+		GetServiceAccount(tokendata *TokenData) (*v1.ServiceAccount, error)
 		SetupUserServiceAccount(userID int, teamIDs []int) error
 		GetServiceAccountBearerToken(userID int) (string, error)
 		CreateUserShellPod(ctx context.Context, serviceAccountName string) (*KubernetesShellPod, error)


### PR DESCRIPTION
Closes [EE-849](https://portainer.atlassian.net/browse/EE-849).

This is the backport for the backend kubectl shell functionality from EE.
The overall feature is still WIP. 