### PR TITLE
feat(kubernetes/shell): backport kubeconfig generation backend functionality EE-1004

### DIFF
--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/endpointproxy"
 	"github.com/portainer/portainer/api/http/handler/endpoints"
 	"github.com/portainer/portainer/api/http/handler/file"
+	"github.com/portainer/portainer/api/http/handler/kubernetes"
 	"github.com/portainer/portainer/api/http/handler/motd"
 	"github.com/portainer/portainer/api/http/handler/registries"
 	"github.com/portainer/portainer/api/http/handler/resourcecontrols"
@@ -49,6 +50,7 @@ type Handler struct {
 	EndpointHandler        *endpoints.Handler
 	EndpointProxyHandler   *endpointproxy.Handler
 	FileHandler            *file.Handler
+	KubernetesHandler      *kubernetes.Handler
 	MOTDHandler            *motd.Handler
 	RegistryHandler        *registries.Handler
 	ResourceControlHandler *resourcecontrols.Handler
@@ -104,6 +106,8 @@ type Handler struct {
 // @tag.description Manage Docker environments
 // @tag.name endpoint_groups
 // @tag.description Manage endpoint groups
+// @tag.name kubernetes
+// @tag.description Manage Kubernetes cluster
 // @tag.name motd
 // @tag.description Fetch the message of the day
 // @tag.name registries
@@ -162,6 +166,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.EdgeTemplatesHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/endpoint_groups"):
 		http.StripPrefix("/api", h.EndpointGroupHandler).ServeHTTP(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/kubernetes"):
+		http.StripPrefix("/api", h.KubernetesHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/endpoints"):
 		switch {
 		case strings.Contains(r.URL.Path, "/docker/"):

--- a/api/http/handler/kubernetes/handler.go
+++ b/api/http/handler/kubernetes/handler.go
@@ -1,0 +1,28 @@
+package kubernetes
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	httperror "github.com/portainer/libhttp/error"
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/kubernetes/cli"
+)
+
+// Handler is the HTTP handler which will natively deal with to external endpoints.
+type Handler struct {
+	*mux.Router
+	DataStore               portainer.DataStore
+	KubernetesClientFactory *cli.ClientFactory
+}
+
+// NewHandler creates a handler to process pre-proxied requests to external APIs.
+func NewHandler(bouncer *security.RequestBouncer) *Handler {
+	h := &Handler{
+		Router: mux.NewRouter(),
+	}
+	h.PathPrefix("/kubernetes/{id}/config").Handler(
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.getKubernetesConfig))).Methods(http.MethodGet)
+	return h
+}

--- a/api/http/handler/kubernetes/kubernetes_config.go
+++ b/api/http/handler/kubernetes/kubernetes_config.go
@@ -1,0 +1,133 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
+	kcli "github.com/portainer/portainer/api/kubernetes/cli"
+
+	"net/http"
+)
+
+// @id GetKubernetesConfig
+// @summary Generates kubeconfig file enabling client communication with k8s api server
+// @description Generates kubeconfig file enabling client communication with k8s api server
+// @description **Access policy**: authorized
+// @tags kubernetes
+// @security jwt
+// @accept json
+// @produce json
+// @param id path int true "Endpoint identifier"
+// @success 200 "Success"
+// @failure 400 "Invalid request"
+// @failure 401 "Unauthorized"
+// @failure 403 "Permission denied"
+// @failure 404 "Endpoint or ServiceAccount not found"
+// @failure 500 "Server error"
+// @router /kubernetes/{id}/config [get]
+func (handler *Handler) getKubernetesConfig(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if r.TLS == nil {
+		return &httperror.HandlerError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "Kubernetes config generation only supported on portainer instances running with TLS",
+			Err:        errors.New("missing request TLS config"),
+		}
+	}
+
+	endpointID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid endpoint identifier route variable", err}
+	}
+
+	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
+	if err == bolterrors.ErrObjectNotFound {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to find an endpoint with the specified identifier inside the database", err}
+	} else if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find an endpoint with the specified identifier inside the database", err}
+	}
+
+	bearerToken, err := extractBearerToken(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusUnauthorized, "Unauthorized", err}
+	}
+
+	permissionDeniedErr := "Permission denied to access endpoint"
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusForbidden, permissionDeniedErr, err}
+	}
+
+	cli, err := handler.KubernetesClientFactory.GetKubeClient(endpoint)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to create Kubernetes client", err}
+	}
+
+	apiServerURL := getProxyUrl(r, endpointID)
+
+	config, err := cli.GetKubeConfig(r.Context(), apiServerURL, bearerToken, tokenData)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusNotFound, "Unable to generate Kubeconfig", err}
+	}
+
+	contentTypeHeader := r.Header.Get("Content-Type")
+	if contentTypeHeader == "text/yaml" {
+		yaml, err := kcli.GenerateYAML(config)
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Failed to generate Kubeconfig", err}
+		}
+		w.Header().Set("Content-Disposition", `attachment; filename=config.yaml`)
+		return YAML(w, yaml)
+	}
+
+	w.Header().Set("Content-Disposition", `attachment; filename="config.json"`)
+	return response.JSON(w, config)
+}
+
+// extractBearerToken extracts user's portainer bearer token from request auth header
+func extractBearerToken(r *http.Request) (string, error) {
+	token := ""
+	tokens := r.Header["Authorization"]
+	if len(tokens) >= 1 {
+		token = tokens[0]
+		token = strings.TrimPrefix(token, "Bearer ")
+	}
+	if token == "" {
+		return "", httperrors.ErrUnauthorized
+	}
+	return token, nil
+}
+
+// getProxyUrl generates portainer proxy url which acts as proxy to k8s api server
+func getProxyUrl(r *http.Request, endpointID int) string {
+	return fmt.Sprintf("https://%s/api/endpoints/%d/kubernetes", r.Host, endpointID)
+}
+
+// YAML writes yaml response as string to writer. Returns a pointer to a HandlerError if encoding fails.
+// This could be moved to a more useful place; but that place is most likely not in this project.
+// It should actually go in https://github.com/portainer/libhttp - since that is from where we use response.JSON.
+// We use `data interface{}` as parameter - since im trying to keep it as close to (or the same as) response.JSON method signature:
+// https://github.com/portainer/libhttp/blob/d20481a3da823c619887c440a22fdf4fa8f318f2/response/response.go#L13
+func YAML(rw http.ResponseWriter, data interface{}) *httperror.HandlerError {
+	rw.Header().Set("Content-Type", "text/yaml")
+
+	strData, ok := data.(string)
+	if !ok {
+		return &httperror.HandlerError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "Unable to write YAML response",
+			Err:        errors.New("failed to convert input to string"),
+		}
+	}
+
+	fmt.Fprint(rw, strData)
+
+	return nil
+}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/endpointproxy"
 	"github.com/portainer/portainer/api/http/handler/endpoints"
 	"github.com/portainer/portainer/api/http/handler/file"
+	kube "github.com/portainer/portainer/api/http/handler/kubernetes"
 	"github.com/portainer/portainer/api/http/handler/motd"
 	"github.com/portainer/portainer/api/http/handler/registries"
 	"github.com/portainer/portainer/api/http/handler/resourcecontrols"
@@ -151,6 +152,10 @@ func (server *Server) Start() error {
 
 	var fileHandler = file.NewHandler(filepath.Join(server.AssetsPath, "public"))
 
+	var kubernetesHandler = kube.NewHandler(requestBouncer)
+	kubernetesHandler.DataStore = server.DataStore
+	kubernetesHandler.KubernetesClientFactory = server.KubernetesClientFactory
+
 	var motdHandler = motd.NewHandler(requestBouncer)
 
 	var registryHandler = registries.NewHandler(requestBouncer)
@@ -225,6 +230,7 @@ func (server *Server) Start() error {
 		EndpointEdgeHandler:    endpointEdgeHandler,
 		EndpointProxyHandler:   endpointProxyHandler,
 		FileHandler:            fileHandler,
+		KubernetesHandler:      kubernetesHandler,
 		MOTDHandler:            motdHandler,
 		RegistryHandler:        registryHandler,
 		ResourceControlHandler: resourceControlHandler,

--- a/api/kubernetes/cli/kubeconfig.go
+++ b/api/kubernetes/cli/kubeconfig.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	portainer "github.com/portainer/portainer/api"
+	clientV1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+// GetKubeConfig returns kubeconfig for the current user based on:
+// - portainer server url
+// - portainer user bearer token
+// - portainer token data - which maps to k8s service account
+func (kcl *KubeClient) GetKubeConfig(ctx context.Context, apiServerURL string, bearerToken string, tokenData *portainer.TokenData) (*clientV1.Config, error) {
+	serviceAccount, err := kcl.GetServiceAccount(tokenData)
+	if err != nil {
+		errText := fmt.Sprintf("unable to find serviceaccount associated with user; username=%s", tokenData.Username)
+		return nil, fmt.Errorf("%s; err=%w", errText, err)
+	}
+
+	kubeconfig := generateKubeconfig(apiServerURL, bearerToken, serviceAccount.Name)
+
+	return kubeconfig, nil
+}
+
+// generateKubeconfig will generate and return kubeconfig resource - usable by `kubectl` cli
+// which will allow the client to connect directly to k8s server endpoint via portainer (proxy)
+func generateKubeconfig(apiServerURL, bearerToken, serviceAccountName string) *clientV1.Config {
+	const (
+		KubeConfigPortainerContext = "portainer-ctx"
+		KubeConfigPortainerCluster = "portainer-cluster"
+	)
+
+	return &clientV1.Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: KubeConfigPortainerContext,
+		Contexts: []clientV1.NamedContext{
+			{
+				Name: KubeConfigPortainerContext,
+				Context: clientV1.Context{
+					AuthInfo: serviceAccountName,
+					Cluster:  KubeConfigPortainerCluster,
+				},
+			},
+		},
+		Clusters: []clientV1.NamedCluster{
+			{
+				Name: KubeConfigPortainerCluster,
+				Cluster: clientV1.Cluster{
+					Server:                apiServerURL,
+					InsecureSkipTLSVerify: true,
+				},
+			},
+		},
+		AuthInfos: []clientV1.NamedAuthInfo{
+			{
+				Name: serviceAccountName,
+				AuthInfo: clientV1.AuthInfo{
+					Token: bearerToken,
+				},
+			},
+		},
+	}
+}

--- a/api/kubernetes/cli/kubeconfig_test.go
+++ b/api/kubernetes/cli/kubeconfig_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_GetKubeConfig(t *testing.T) {
+
+	t.Run("returns error if SA non-existent", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		tokenData := &portainer.TokenData{
+			ID:       1,
+			Role:     portainer.AdministratorRole,
+			Username: portainerClusterAdminServiceAccountName,
+		}
+
+		_, err := k.GetKubeConfig(context.Background(), "localhost", "abc", tokenData)
+
+		if err == nil {
+			t.Error("GetKubeConfig should fail as service account does not exist")
+		}
+		if k8sErr := errors.Unwrap(err); !k8serrors.IsNotFound(k8sErr) {
+			t.Error("GetKubeConfig should fail with service account not found k8s error")
+		}
+	})
+
+	t.Run("successfully obtains kubeconfig for cluster admin", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		tokenData := &portainer.TokenData{
+			Role:     portainer.AdministratorRole,
+			Username: portainerClusterAdminServiceAccountName,
+		}
+		serviceAccount := &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: tokenData.Username},
+		}
+
+		k.cli.CoreV1().ServiceAccounts(portainerNamespace).Create(serviceAccount)
+		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
+
+		_, err := k.GetKubeConfig(context.Background(), "localhost", "abc", tokenData)
+
+		if err != nil {
+			t.Errorf("GetKubeConfig should succeed; err=%s", err)
+		}
+	})
+
+	t.Run("successfully obtains kubeconfig for standard user", func(t *testing.T) {
+		k := &KubeClient{
+			cli:        kfake.NewSimpleClientset(),
+			instanceID: "test",
+		}
+
+		tokenData := &portainer.TokenData{
+			ID:   1,
+			Role: portainer.StandardUserRole,
+		}
+		nonAdminUserName := userServiceAccountName(int(tokenData.ID), k.instanceID)
+		serviceAccount := &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: nonAdminUserName},
+		}
+
+		k.cli.CoreV1().ServiceAccounts(portainerNamespace).Create(serviceAccount)
+		defer k.cli.CoreV1().ServiceAccounts(portainerNamespace).Delete(serviceAccount.Name, nil)
+
+		_, err := k.GetKubeConfig(context.Background(), "localhost", "abc", tokenData)
+
+		if err != nil {
+			t.Errorf("GetKubeConfig should succeed; err=%s", err)
+		}
+	})
+}
+
+func Test_generateKubeconfig(t *testing.T) {
+	apiServerURL, bearerToken, serviceAccountName := "localhost", "test-token", "test-user"
+
+	t.Run("generates Config resource kind", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		want := "Config"
+		if config.Kind != want {
+			t.Errorf("generateKubeconfig resource kind should be %s", want)
+		}
+	})
+
+	t.Run("generates v1 version", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		want := "v1"
+		if config.APIVersion != want {
+			t.Errorf("generateKubeconfig api version should be %s", want)
+		}
+	})
+
+	t.Run("generates single entry context cluster and authinfo", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		if len(config.Contexts) != 1 {
+			t.Error("generateKubeconfig should generate single context configuration")
+		}
+		if len(config.Clusters) != 1 {
+			t.Error("generateKubeconfig should generate single cluster configuration")
+		}
+		if len(config.AuthInfos) != 1 {
+			t.Error("generateKubeconfig should generate single user configuration")
+		}
+	})
+
+	t.Run("sets default context appropriately", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		want := "portainer-ctx"
+		if config.CurrentContext != want {
+			t.Errorf("generateKubeconfig set cluster to be %s", want)
+		}
+	})
+
+	t.Run("generates cluster with InsecureSkipTLSVerify to be set to true", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		if config.Clusters[0].Cluster.InsecureSkipTLSVerify != true {
+			t.Error("generateKubeconfig default cluster InsecureSkipTLSVerify should be true")
+		}
+	})
+
+	t.Run("should contain passed in value", func(t *testing.T) {
+		config := generateKubeconfig(apiServerURL, bearerToken, serviceAccountName)
+		if config.Clusters[0].Cluster.Server != apiServerURL {
+			t.Errorf("generateKubeconfig default cluster server url should be %s", apiServerURL)
+		}
+
+		if config.AuthInfos[0].Name != serviceAccountName {
+			t.Errorf("generateKubeconfig default authinfo name should be %s", serviceAccountName)
+		}
+
+		if config.AuthInfos[0].AuthInfo.Token != bearerToken {
+			t.Errorf("generateKubeconfig default authinfo user token should be %s", bearerToken)
+		}
+	})
+}

--- a/api/kubernetes/cli/resource.go
+++ b/api/kubernetes/cli/resource.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+func GenerateYAML(obj runtime.Object) (string, error) {
+	serializer := json.NewSerializerWithOptions(
+		json.DefaultMetaFactory, nil, nil,
+		json.SerializerOptions{
+			Yaml:   true,
+			Pretty: true,
+			Strict: true,
+		},
+	)
+
+	b := new(bytes.Buffer)
+	err := serializer.Encode(obj, b)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/api/kubernetes/cli/resource_test.go
+++ b/api/kubernetes/cli/resource_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientV1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+// compareYAMLStrings will compare 2 strings by stripping tabs, newlines and whitespaces from both strings
+func compareYAMLStrings(in1, in2 string) int {
+	r := strings.NewReplacer("\t", "", "\n", "", " ", "")
+	in1 = r.Replace(in1)
+	in2 = r.Replace(in2)
+	return strings.Compare(in1, in2)
+}
+
+func Test_GenerateYAML(t *testing.T) {
+	resourceYAMLTests := []struct {
+		title    string
+		resource runtime.Object
+		wantYAML string
+	}{
+		{
+			title: "Config",
+			resource: &clientV1.Config{
+				APIVersion:     "v1",
+				Kind:           "Config",
+				CurrentContext: "portainer-ctx",
+				Contexts: []clientV1.NamedContext{
+					{
+						Name: "portainer-ctx",
+						Context: clientV1.Context{
+							AuthInfo: "test-user",
+							Cluster:  "portainer-cluster",
+						},
+					},
+				},
+				Clusters: []clientV1.NamedCluster{
+					{
+						Name: "portainer-cluster",
+						Cluster: clientV1.Cluster{
+							Server:                "localhost",
+							InsecureSkipTLSVerify: true,
+						},
+					},
+				},
+				AuthInfos: []clientV1.NamedAuthInfo{
+					{
+						Name: "test-user",
+						AuthInfo: clientV1.AuthInfo{
+							Token: "test-token",
+						},
+					},
+				},
+			},
+			wantYAML: `
+			apiVersion: v1
+			clusters:
+			- cluster:
+					insecure-skip-tls-verify: true
+					server: localhost
+				name: portainer-cluster
+			contexts:
+			- context:
+					cluster: portainer-cluster
+					user: test-user
+				name: portainer-ctx
+			current-context: portainer-ctx
+			kind: Config
+			preferences: {}
+			users:
+			- name: test-user
+				user:
+					token: test-token
+			`,
+		},
+	}
+
+	for _, ryt := range resourceYAMLTests {
+		t.Run(ryt.title, func(t *testing.T) {
+			yaml, err := GenerateYAML(ryt.resource)
+			if err != nil {
+				t.Errorf("generateYamlConfig failed; err=%s", err)
+			}
+
+			if compareYAMLStrings(yaml, ryt.wantYAML) != 0 {
+				t.Errorf("generateYamlConfig failed;\ngot=\n%s\nwant=\n%s", yaml, ryt.wantYAML)
+			}
+		})
+	}
+}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	clientV1 "k8s.io/client-go/tools/clientcmd/api/v1"
 )
 
 type (
@@ -1170,6 +1171,7 @@ type (
 		GetServiceAccountBearerToken(userID int) (string, error)
 		CreateUserShellPod(ctx context.Context, serviceAccountName string) (*KubernetesShellPod, error)
 		StartExecProcess(namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer) error
+		GetKubeConfig(ctx context.Context, apiServerURL string, bearerToken string, tokenData *TokenData) (*clientV1.Config, error)
 	}
 
 	// KubernetesDeployer represents a service to deploy a manifest inside a Kubernetes endpoint

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1583,9 +1583,6 @@ const (
 	EdgeAgentActive string = "ACTIVE"
 )
 
-// K8sServiceAccountClusterAdmin is built in cluster admin service account
-const K8sServiceAccountClusterAdmin string = "portainer-sa-clusteradmin"
-
 // represents an authorization type
 const (
 	OperationDockerContainerArchiveInfo         Authorization = "DockerContainerArchiveInfo"

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1583,6 +1583,9 @@ const (
 	EdgeAgentActive string = "ACTIVE"
 )
 
+// K8sServiceAccountClusterAdmin is built in cluster admin service account
+const K8sServiceAccountClusterAdmin string = "portainer-sa-clusteradmin"
+
 // represents an authorization type
 const (
 	OperationDockerContainerArchiveInfo         Authorization = "DockerContainerArchiveInfo"


### PR DESCRIPTION
Closes [EE-1004](https://portainer.atlassian.net/browse/EE-1004).

This is the backport for the backend kubeconfig file generation functionality from EE.
The overall feature is still WIP.