### PR TITLE
feat(kubernetes/shell): backport of kubeconfig export functionality EE-927

### DIFF
--- a/api/http/handler/kubernetes/kubernetes_config.go
+++ b/api/http/handler/kubernetes/kubernetes_config.go
@@ -77,8 +77,8 @@ func (handler *Handler) getKubernetesConfig(w http.ResponseWriter, r *http.Reque
 		return &httperror.HandlerError{http.StatusNotFound, "Unable to generate Kubeconfig", err}
 	}
 
-	contentTypeHeader := r.Header.Get("Content-Type")
-	if contentTypeHeader == "text/yaml" {
+	contentAcceptHeader := r.Header.Get("Accept")
+	if contentAcceptHeader == "text/yaml" {
 		yaml, err := kcli.GenerateYAML(config)
 		if err != nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Failed to generate Kubeconfig", err}

--- a/app/constants.js
+++ b/app/constants.js
@@ -2,6 +2,7 @@ angular
   .module('portainer')
   .constant('API_ENDPOINT_AUTH', 'api/auth')
   .constant('API_ENDPOINT_DOCKERHUB', 'api/dockerhub')
+  .constant('API_ENDPOINT_KUBERNETES', 'api/kubernetes')
   .constant('API_ENDPOINT_CUSTOM_TEMPLATES', 'api/custom_templates')
   .constant('API_ENDPOINT_EDGE_GROUPS', 'api/edge_groups')
   .constant('API_ENDPOINT_EDGE_JOBS', 'api/edge_jobs')

--- a/app/kubernetes/components/kubectl-shell/kubectlShell.css
+++ b/app/kubernetes/components/kubectl-shell/kubectlShell.css
@@ -1,5 +1,6 @@
 .shell-container {
   display: flex;
+  justify-content: space-between;
   color: #424242;
   background: rgb(245, 245, 245);
   padding: 8px;

--- a/app/kubernetes/components/kubectl-shell/kubectlShell.html
+++ b/app/kubernetes/components/kubectl-shell/kubectlShell.html
@@ -5,8 +5,8 @@
 <div ng-if="checked" class="{{ css }}-kubectl-shell">
   <div class="shell-container">
     <div class="shell-item">Kubectl Shell</div>
-    <div class="shell-item-center">
-      <a href="">Download Kubeconfig</a>
+    <div ng-if="isHTTPS" class="shell-item-center">
+      <a href="" ng-click="ctrl.downloadKubeconfig()">Download Kubeconfig</a>
     </div>
     <div class="shell-item-right">
       <i class="fas fa-redo-alt" ng-click="ctrl.screenclear();"></i>

--- a/app/kubernetes/components/kubectl-shell/kubectlShellController.js
+++ b/app/kubernetes/components/kubectl-shell/kubectlShellController.js
@@ -3,7 +3,7 @@ import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 class KubectlShellController {
-  constructor($window, $async, $scope, $state, Notifications, EndpointProvider, LocalStorage) {
+  constructor($window, $async, $scope, $state, Notifications, EndpointProvider, LocalStorage, KubernetesConfigService) {
     this.$scope = $scope;
     this.$state = $state;
     this.$async = $async;
@@ -11,6 +11,7 @@ class KubectlShellController {
     this.Notifications = Notifications;
     this.EndpointProvider = EndpointProvider;
     this.LocalStorage = LocalStorage;
+    this.KubernetesConfigService = KubernetesConfigService;
 
     this.onInit = this.onInit.bind(this);
   }
@@ -97,10 +98,15 @@ class KubectlShellController {
     this.configureSocketAndTerminal(this.state.socket, this.state.term);
   }
 
+  async downloadKubeconfig() {
+    await this.KubernetesConfigService.downloadConfig();
+  }
+
   async onInit() {
     this.$scope.css = 'normal';
     this.$scope.checked = false;
     this.$scope.icon = 'fa-window-minimize';
+    this.$scope.isHTTPS = this.$window.location.protocol === 'https:';
 
     this.state = {
       connected: false,

--- a/app/kubernetes/rest/kubeconfig.js
+++ b/app/kubernetes/rest/kubeconfig.js
@@ -1,0 +1,22 @@
+angular.module('portainer.kubernetes').factory('KubernetesConfig', [
+  '$http',
+  'EndpointProvider',
+  function KubernetesConfigFactory($http, EndpointProvider) {
+    'use strict';
+    const BASE_URL = '/api/kubernetes';
+
+    return { get };
+
+    async function get() {
+      const endpointID = EndpointProvider.endpointID();
+      return $http({
+        method: 'GET',
+        url: `${BASE_URL}/${endpointID}/config`,
+        responseType: 'blob',
+        headers: {
+          Accept: 'text/yaml',
+        },
+      });
+    }
+  },
+]);

--- a/app/kubernetes/rest/kubeconfig.js
+++ b/app/kubernetes/rest/kubeconfig.js
@@ -1,9 +1,9 @@
 angular.module('portainer.kubernetes').factory('KubernetesConfig', [
   '$http',
   'EndpointProvider',
-  function KubernetesConfigFactory($http, EndpointProvider) {
+  'API_ENDPOINT_KUBERNETES',
+  function KubernetesConfigFactory($http, EndpointProvider, API_ENDPOINT_KUBERNETES) {
     'use strict';
-    const BASE_URL = '/api/kubernetes';
 
     return { get };
 
@@ -11,7 +11,7 @@ angular.module('portainer.kubernetes').factory('KubernetesConfig', [
       const endpointID = EndpointProvider.endpointID();
       return $http({
         method: 'GET',
-        url: `${BASE_URL}/${endpointID}/config`,
+        url: `${API_ENDPOINT_KUBERNETES}/${endpointID}/config`,
         responseType: 'blob',
         headers: {
           Accept: 'text/yaml',

--- a/app/kubernetes/services/kubeconfigService.js
+++ b/app/kubernetes/services/kubeconfigService.js
@@ -1,0 +1,21 @@
+import angular from 'angular';
+
+class KubernetesConfigService {
+  /* @ngInject */
+  constructor(KubernetesConfig, FileSaver) {
+    this.KubernetesConfig = KubernetesConfig;
+    this.FileSaver = FileSaver;
+  }
+
+  async downloadConfig() {
+    try {
+      const response = await this.KubernetesConfig.get();
+      return this.FileSaver.saveAs(response.data, 'config.yaml');
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+export default KubernetesConfigService;
+angular.module('portainer.kubernetes').service('KubernetesConfigService', KubernetesConfigService);


### PR DESCRIPTION
Closes [EE-927](https://portainer.atlassian.net/browse/EE-927).

# Context
The following PR enables one to download `kubeconfig` file as `config.yaml`
Note: A change was made to backend to parse `Accept` header instead of `Content-Type` header as this aligns more closely to what k8s API server requires/does.