### PR TITLE
fix(logs):  Download logs is broken in relase/2.6 EE-1051

### DIFF
--- a/app/docker/components/log-viewer/logViewerController.js
+++ b/app/docker/components/log-viewer/logViewerController.js
@@ -48,7 +48,7 @@ angular.module('portainer.docker').controller('LogViewerController', [
     };
 
     this.downloadLogs = function () {
-      const data = new Blob([_.reduce(this.state.filteredLogs, (acc, log) => acc + '\n' + log, '')]);
+      const data = new Blob([_.reduce(this.state.filteredLogs, (acc, log) => acc + '\n' + log.line, '')]);
       FileSaver.saveAs(data, this.resourceName + '_logs.txt');
     };
   },


### PR DESCRIPTION
fix issue with download logs file showing `[Object object]` after updating log viewer with ascii colors
closes #5241 