### PR TITLE
fix(git): proxy git requests

### DIFF
--- a/api/git/git.go
+++ b/api/git/git.go
@@ -74,6 +74,7 @@ func NewService() *Service {
 	httpsCli := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
 		},
 		Timeout: 300 * time.Second,
 	}


### PR DESCRIPTION
Our client usage of go-git library was ignoring the proxy server settings