### PR TITLE
feat(kubernetes/resource-usage): k8s resource usage for cluster, node and namespace EE-3 EE-1112

### DIFF
--- a/app/kubernetes/components/resource-reservation/resourceReservation.html
+++ b/app/kubernetes/components/resource-reservation/resourceReservation.html
@@ -10,22 +10,42 @@
     </span>
   </div>
   <div class="form-group" ng-if="$ctrl.memoryLimit !== 0">
-    <label for="memory-usage" class="col-sm-3 col-lg-2 control-label text-left">
+    <label for="memory-reservation" class="col-sm-3 col-lg-2 control-label text-left">
       Memory reservation
     </label>
     <div class="col-sm-9" style="margin-top: 4px;">
-      <uib-progressbar animate="false" value="$ctrl.memoryUsage" type="{{ $ctrl.memoryUsage | kubernetesUsageLevelInfo }}">
-        <b style="white-space: nowrap;"> {{ $ctrl.memory }} / {{ $ctrl.memoryLimit }} MB - {{ $ctrl.memoryUsage }}% </b>
+      <uib-progressbar animate="false" value="$ctrl.memoryReservationPercent" type="{{ $ctrl.memoryReservationPercent | kubernetesUsageLevelInfo }}">
+        <b style="white-space: nowrap;"> {{ $ctrl.memoryReservation }} / {{ $ctrl.memoryLimit }} MB - {{ $ctrl.memoryReservationPercent }}% </b>
+      </uib-progressbar>
+    </div>
+  </div>
+  <div class="form-group" ng-if="$ctrl.displayUsage && $ctrl.memoryLimit !== 0">
+    <label for="memory-usage" class="col-sm-3 col-lg-2 control-label text-left">
+      Memory used
+    </label>
+    <div class="col-sm-9" style="margin-top: 4px;">
+      <uib-progressbar animate="false" value="$ctrl.memoryUsagePercent" type="{{ $ctrl.memoryUsagePercent | kubernetesUsageLevelInfo }}">
+        <b style="white-space: nowrap;"> {{ $ctrl.memoryUsage }} / {{ $ctrl.memoryLimit }} MB - {{ $ctrl.memoryUsagePercent }}% </b>
       </uib-progressbar>
     </div>
   </div>
   <div class="form-group" ng-if="$ctrl.cpuLimit !== 0">
-    <label for="cpu-usage" class="col-sm-3 col-lg-2 control-label text-left">
+    <label for="cpu-reservation" class="col-sm-3 col-lg-2 control-label text-left">
       CPU reservation
     </label>
     <div class="col-sm-9" style="margin-top: 4px;">
-      <uib-progressbar animate="false" value="$ctrl.cpuUsage" type="{{ $ctrl.cpuUsage | kubernetesUsageLevelInfo }}">
-        <b style="white-space: nowrap;"> {{ $ctrl.cpu | kubernetesApplicationCPUValue }} / {{ $ctrl.cpuLimit }} - {{ $ctrl.cpuUsage }}% </b>
+      <uib-progressbar animate="false" value="$ctrl.cpuReservationPercent" type="{{ $ctrl.cpuReservationPercent | kubernetesUsageLevelInfo }}">
+        <b style="white-space: nowrap;"> {{ $ctrl.cpuReservation | kubernetesApplicationCPUValue }} / {{ $ctrl.cpuLimit }} - {{ $ctrl.cpuReservationPercent }}% </b>
+      </uib-progressbar>
+    </div>
+  </div>
+  <div class="form-group" ng-if="$ctrl.displayUsage && $ctrl.cpuLimit !== 0">
+    <label for="cpu-usage" class="col-sm-3 col-lg-2 control-label text-left">
+      CPU used
+    </label>
+    <div class="col-sm-9" style="margin-top: 4px;">
+      <uib-progressbar animate="false" value="$ctrl.cpuUsagePercent" type="{{ $ctrl.cpuUsagePercent | kubernetesUsageLevelInfo }}">
+        <b style="white-space: nowrap;"> {{ $ctrl.cpuUsage | kubernetesApplicationCPUValue }} / {{ $ctrl.cpuLimit }} - {{ $ctrl.cpuUsagePercent }}% </b>
       </uib-progressbar>
     </div>
   </div>

--- a/app/kubernetes/components/resource-reservation/resourceReservation.js
+++ b/app/kubernetes/components/resource-reservation/resourceReservation.js
@@ -3,9 +3,12 @@ angular.module('portainer.kubernetes').component('kubernetesResourceReservation'
   controller: 'KubernetesResourceReservationController',
   bindings: {
     description: '@',
-    cpu: '<',
+    cpuReservation: '<',
+    cpuUsage: '<',
     cpuLimit: '<',
-    memory: '<',
+    memoryReservation: '<',
+    memoryUsage: '<',
     memoryLimit: '<',
+    displayUsage: '<',
   },
 });

--- a/app/kubernetes/components/resource-reservation/resourceReservationController.js
+++ b/app/kubernetes/components/resource-reservation/resourceReservationController.js
@@ -3,10 +3,15 @@ import angular from 'angular';
 class KubernetesResourceReservationController {
   usageValues() {
     if (this.cpuLimit) {
-      this.cpuUsage = Math.round((this.cpu / this.cpuLimit) * 100);
+      this.cpuReservationPercent = Math.round((this.cpuReservation / this.cpuLimit) * 100);
     }
     if (this.memoryLimit) {
-      this.memoryUsage = Math.round((this.memory / this.memoryLimit) * 100);
+      this.memoryReservationPercent = Math.round((this.memoryReservation / this.memoryLimit) * 100);
+    }
+
+    if (this.displayUsage && this.cpuLimit && this.memoryLimit) {
+      this.cpuUsagePercent = Math.round((this.cpuUsage / this.cpuLimit) * 100);
+      this.memoryUsagePercent = Math.round((this.memoryUsage / this.memoryLimit) * 100);
     }
   }
 

--- a/app/kubernetes/metrics/metrics.js
+++ b/app/kubernetes/metrics/metrics.js
@@ -9,8 +9,12 @@ class KubernetesMetricsService {
     this.KubernetesMetrics = KubernetesMetrics;
 
     this.capabilitiesAsync = this.capabilitiesAsync.bind(this);
+
     this.getPodAsync = this.getPodAsync.bind(this);
     this.getNodeAsync = this.getNodeAsync.bind(this);
+
+    this.getPodsAsync = this.getPodsAsync.bind(this);
+    this.getNodesAsync = this.getNodesAsync.bind(this);
   }
 
   /**
@@ -67,6 +71,42 @@ class KubernetesMetricsService {
 
   getPod(namespace, podName) {
     return this.$async(this.getPodAsync, namespace, podName);
+  }
+
+  /**
+   * Stats of Nodes in cluster
+   *
+   * @param {string} endpointID
+   */
+  async getNodesAsync(endpointID) {
+    try {
+      const data = await this.KubernetesMetrics().getNodes({ endpointId: endpointID }).$promise;
+      return data;
+    } catch (err) {
+      throw new PortainerError('Unable to retrieve nodes stats', err);
+    }
+  }
+
+  getNodes(endpointID) {
+    return this.$async(this.getNodesAsync, endpointID);
+  }
+
+  /**
+   * Stats of Pods in a namespace
+   *
+   * @param {string} namespace
+   */
+  async getPodsAsync(namespace) {
+    try {
+      const data = await this.KubernetesMetrics(namespace).getPods().$promise;
+      return data;
+    } catch (err) {
+      throw new PortainerError('Unable to retrieve pod stats', err);
+    }
+  }
+
+  getPods(namespace) {
+    return this.$async(this.getPodsAsync, namespace);
   }
 }
 

--- a/app/kubernetes/metrics/rest.js
+++ b/app/kubernetes/metrics/rest.js
@@ -24,6 +24,14 @@ angular.module('portainer.kubernetes').factory('KubernetesMetrics', [
             method: 'GET',
             url: `${url}/nodes/:id`,
           },
+          getPods: {
+            method: 'GET',
+            url: `${url}/namespaces/:namespace/pods`,
+          },
+          getNodes: {
+            method: 'GET',
+            url: `${url}/nodes`,
+          },
         }
       );
     };

--- a/app/kubernetes/views/cluster/cluster.html
+++ b/app/kubernetes/views/cluster/cluster.html
@@ -12,11 +12,14 @@
           <!-- resource-reservation -->
           <form class="form-horizontal" ng-if="ctrl.resourceReservation">
             <kubernetes-resource-reservation
-              cpu="ctrl.resourceReservation.CPU"
-              cpu-limit="ctrl.CPULimit"
-              memory="ctrl.resourceReservation.Memory"
-              memory-limit="ctrl.MemoryLimit"
               description="Resource reservation represents the total amount of resource assigned to all the applications inside the cluster."
+              cpu-reservation="ctrl.resourceReservation.CPU"
+              cpu-limit="ctrl.CPULimit"
+              memory-reservation="ctrl.resourceReservation.Memory"
+              memory-limit="ctrl.MemoryLimit"
+              display-usage="ctrl.isAdmin"
+              cpu-usage="ctrl.resourceUsage.CPU"
+              memory-usage="ctrl.resourceUsage.Memory"
             >
             </kubernetes-resource-reservation>
           </form>

--- a/app/kubernetes/views/cluster/cluster.js
+++ b/app/kubernetes/views/cluster/cluster.js
@@ -2,4 +2,7 @@ angular.module('portainer.kubernetes').component('kubernetesClusterView', {
   templateUrl: './cluster.html',
   controller: 'KubernetesClusterController',
   controllerAs: 'ctrl',
+  bindings: {
+    endpoint: '<',
+  },
 });

--- a/app/kubernetes/views/cluster/clusterController.js
+++ b/app/kubernetes/views/cluster/clusterController.js
@@ -16,8 +16,7 @@ class KubernetesClusterController {
     KubernetesMetricsService,
     KubernetesApplicationService,
     KubernetesComponentStatusService,
-    KubernetesEndpointService,
-    EndpointProvider
+    KubernetesEndpointService
   ) {
     this.$async = $async;
     this.$state = $state;
@@ -29,7 +28,6 @@ class KubernetesClusterController {
     this.KubernetesApplicationService = KubernetesApplicationService;
     this.KubernetesComponentStatusService = KubernetesComponentStatusService;
     this.KubernetesEndpointService = KubernetesEndpointService;
-    this.EndpointProvider = EndpointProvider;
 
     this.onInit = this.onInit.bind(this);
     this.getNodes = this.getNodes.bind(this);
@@ -110,7 +108,7 @@ class KubernetesClusterController {
       this.resourceReservation.Memory = KubernetesResourceReservationHelper.megaBytesValue(this.resourceReservation.Memory);
 
       if (this.isAdmin) {
-        await this.getResourceUsage(this.EndpointProvider.currentEndpoint().Id);
+        await this.getResourceUsage(this.endpoint.Id);
       }
     } catch (err) {
       this.Notifications.error('Failure', 'Unable to retrieve applications', err);
@@ -147,7 +145,7 @@ class KubernetesClusterController {
     };
 
     this.isAdmin = this.Authentication.isAdmin();
-    this.state.useServerMetrics = this.EndpointProvider.currentEndpoint().Kubernetes.Configuration.UseServerMetrics;
+    this.state.useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
 
     await this.getNodes();
     if (this.isAdmin) {

--- a/app/kubernetes/views/cluster/node/node.html
+++ b/app/kubernetes/views/cluster/node/node.html
@@ -78,11 +78,14 @@
                 <div style="padding: 8px;">
                   <kubernetes-resource-reservation
                     ng-if="ctrl.resourceReservation"
-                    cpu="ctrl.resourceReservation.CPU"
+                    cpu-reservation="ctrl.resourceReservation.CPU"
+                    cpu-usage="ctrl.resourceUsage.CPU"
                     cpu-limit="ctrl.node.CPU"
-                    memory="ctrl.resourceReservation.Memory"
+                    memory-reservation="ctrl.resourceReservation.Memory"
+                    memory-usage="ctrl.resourceUsage.Memory"
                     memory-limit="ctrl.memoryLimit"
                     description="Resource reservation represents the total amount of resource assigned to all the applications running on this node."
+                    display-usage="ctrl.state.isAdmin"
                   >
                   </kubernetes-resource-reservation>
                 </div>

--- a/app/kubernetes/views/cluster/node/node.js
+++ b/app/kubernetes/views/cluster/node/node.js
@@ -3,6 +3,7 @@ angular.module('portainer.kubernetes').component('kubernetesNodeView', {
   controller: 'KubernetesNodeController',
   controllerAs: 'ctrl',
   bindings: {
+    endpoint: '<',
     $transition$: '<',
   },
 });

--- a/app/kubernetes/views/cluster/node/nodeController.js
+++ b/app/kubernetes/views/cluster/node/nodeController.js
@@ -23,7 +23,6 @@ class KubernetesNodeController {
     KubernetesApplicationService,
     KubernetesEndpointService,
     KubernetesMetricsService,
-    EndpointProvider,
     Authentication
   ) {
     this.$async = $async;
@@ -37,7 +36,6 @@ class KubernetesNodeController {
     this.KubernetesApplicationService = KubernetesApplicationService;
     this.KubernetesEndpointService = KubernetesEndpointService;
     this.KubernetesMetricsService = KubernetesMetricsService;
-    this.EndpointProvider = EndpointProvider;
     this.Authentication = Authentication;
 
     this.onInit = this.onInit.bind(this);
@@ -435,7 +433,7 @@ class KubernetesNodeController {
 
     this.availabilities = KubernetesNodeAvailabilities;
 
-    this.state.useServerMetrics = this.EndpointProvider.currentEndpoint().Kubernetes.Configuration.UseServerMetrics;
+    this.state.useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
 
     this.state.activeTab = this.LocalStorage.getActiveTab('node');
 

--- a/app/kubernetes/views/resource-pools/edit/resourcePool.html
+++ b/app/kubernetes/views/resource-pools/edit/resourcePool.html
@@ -40,10 +40,13 @@
                   <kubernetes-resource-reservation
                     ng-if="ctrl.pool.Quota"
                     description="Resource reservation represents the total amount of resource assigned to all the applications deployed inside this namespace."
-                    cpu="ctrl.state.cpuUsed"
-                    memory="ctrl.state.memoryUsed"
+                    cpu-reservation="ctrl.state.resourceReservation.CPU"
+                    memory-reservation="ctrl.state.resourceReservation.Memory"
                     cpu-limit="ctrl.formValues.CpuLimit"
                     memory-limit="ctrl.formValues.MemoryLimit"
+                    display-usage="ctrl.state.useServerMetrics"
+                    cpu-usage="ctrl.state.resourceUsage.CPU"
+                    memory-usage="ctrl.state.resourceUsage.Memory"
                   >
                   </kubernetes-resource-reservation>
                 </div>

--- a/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
+++ b/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
@@ -309,8 +309,8 @@ class KubernetesResourcePoolController {
     try {
       const namespaceMetrics = await this.KubernetesMetricsService.getPods(namespace);
       // extract resource usage of all containers within each pod of the namespace
-      const containeResourceUsageList = namespaceMetrics.items.map((i) => i.containers.map((c) => c.usage)).flatMap((c) => c);
-      const namespaceResourceUsage = containeResourceUsageList.reduce((total, u) => {
+      const containerResourceUsageList = namespaceMetrics.items.flatMap((i) => i.containers.map((c) => c.usage));
+      const namespaceResourceUsage = containerResourceUsageList.reduce((total, u) => {
         total.CPU += KubernetesResourceReservationHelper.parseCPU(u.cpu);
         total.Memory += KubernetesResourceReservationHelper.megaBytesValue(u.memory);
         return total;

--- a/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
+++ b/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
@@ -325,7 +325,6 @@ class KubernetesResourcePoolController {
   $onInit() {
     return this.$async(async () => {
       try {
-        const endpoint = this.endpoint;
         this.isAdmin = this.Authentication.isAdmin();
 
         this.state = {
@@ -343,7 +342,7 @@ class KubernetesResourcePoolController {
           ingressesLoading: true,
           viewReady: false,
           eventWarningCount: 0,
-          canUseIngress: endpoint.Kubernetes.Configuration.IngressClasses.length,
+          canUseIngress: this.endpoint.Kubernetes.Configuration.IngressClasses.length,
           useServerMetrics: this.endpoint.Kubernetes.Configuration.UseServerMetrics,
           duplicates: {
             ingressHosts: new KubernetesFormValidationReferences(),
@@ -387,7 +386,7 @@ class KubernetesResourcePoolController {
 
         if (this.state.canUseIngress) {
           await this.getIngresses();
-          const ingressClasses = endpoint.Kubernetes.Configuration.IngressClasses;
+          const ingressClasses = this.endpoint.Kubernetes.Configuration.IngressClasses;
           this.formValues.IngressClasses = KubernetesIngressConverter.ingressClassesToFormValues(ingressClasses, this.ingresses);
           _.forEach(this.formValues.IngressClasses, (ic) => {
             if (ic.Hosts.length === 0) {

--- a/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
+++ b/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
@@ -333,9 +333,8 @@ class KubernetesResourcePoolController {
           sliderMaxMemory: 0,
           sliderMaxCpu: 0,
           cpuUsage: 0,
-          cpuUsed: 0,
           memoryUsage: 0,
-          memoryUsed: 0,
+          resourceReservation: { CPU: 0, Memory: 0 },
           activeTab: 0,
           currentName: this.$state.$current.name,
           showEditorTab: false,
@@ -345,6 +344,7 @@ class KubernetesResourcePoolController {
           viewReady: false,
           eventWarningCount: 0,
           canUseIngress: endpoint.Kubernetes.Configuration.IngressClasses.length,
+          useServerMetrics: this.endpoint.Kubernetes.Configuration.UseServerMetrics,
           duplicates: {
             ingressHosts: new KubernetesFormValidationReferences(),
           },
@@ -373,8 +373,8 @@ class KubernetesResourcePoolController {
           this.formValues = KubernetesResourceQuotaConverter.quotaToResourcePoolFormValues(quota);
           this.formValues.EndpointId = this.endpoint.Id;
 
-          this.state.cpuUsed = quota.CpuLimitUsed;
-          this.state.memoryUsed = KubernetesResourceReservationHelper.megaBytesValue(quota.MemoryLimitUsed);
+          this.state.resourceReservation.CPU = quota.CpuLimitUsed;
+          this.state.resourceReservation.Memory = KubernetesResourceReservationHelper.megaBytesValue(quota.MemoryLimitUsed);
         }
 
         this.isEditable = !this.KubernetesNamespaceHelper.isSystemNamespace(this.pool.Namespace.Name);


### PR DESCRIPTION
Closes EE-1112.

This PR introduces displaying resource usage on the cluster, node and namespace views for a k8s endpoint - if metrics server is enabled.

Note: The usage is only viewable by admin role

---
Display k8s resource usage on cluster view - using k8s metrics server API:
<img width="1440" alt="Screen Shot 2021-07-13 at 11 38 09 AM" src="https://user-images.githubusercontent.com/63374656/125368777-21d0ce80-e3cf-11eb-84b9-d182636509b1.png">

---
Display k8s resource usage on node view - using k8s metrics server API:
<img width="1440" alt="Screen Shot 2021-07-13 at 11 37 39 AM" src="https://user-images.githubusercontent.com/63374656/125368796-27c6af80-e3cf-11eb-8556-4f5d33399b48.png">

---
Display k8s resource usage on namespace view - using k8s metrics server API:
<img width="1440" alt="Screen Shot 2021-07-13 at 11 38 34 AM" src="https://user-images.githubusercontent.com/63374656/125368812-301eea80-e3cf-11eb-9cb5-d10643e74847.png">

---