### PR TITLE
fix(metrics): disable metric server api calls if metric server is disabled on k8s endpoint EE-1273 EE-1274

### DIFF
--- a/app/kubernetes/views/cluster/cluster.html
+++ b/app/kubernetes/views/cluster/cluster.html
@@ -17,7 +17,7 @@
               cpu-limit="ctrl.CPULimit"
               memory-reservation="ctrl.resourceReservation.Memory"
               memory-limit="ctrl.MemoryLimit"
-              display-usage="ctrl.state.displayResourceUsage"
+              display-usage="ctrl.hasResourceUsageAccess()"
               cpu-usage="ctrl.resourceUsage.CPU"
               memory-usage="ctrl.resourceUsage.Memory"
             >

--- a/app/kubernetes/views/cluster/cluster.html
+++ b/app/kubernetes/views/cluster/cluster.html
@@ -17,7 +17,7 @@
               cpu-limit="ctrl.CPULimit"
               memory-reservation="ctrl.resourceReservation.Memory"
               memory-limit="ctrl.MemoryLimit"
-              display-usage="ctrl.isAdmin"
+              display-usage="ctrl.state.displayResourceUsage"
               cpu-usage="ctrl.resourceUsage.CPU"
               memory-usage="ctrl.resourceUsage.Memory"
             >

--- a/app/kubernetes/views/cluster/clusterController.js
+++ b/app/kubernetes/views/cluster/clusterController.js
@@ -107,7 +107,7 @@ class KubernetesClusterController {
       );
       this.resourceReservation.Memory = KubernetesResourceReservationHelper.megaBytesValue(this.resourceReservation.Memory);
 
-      if (this.isAdmin) {
+      if (this.state.displayResourceUsage) {
         await this.getResourceUsage(this.endpoint.Id);
       }
     } catch (err) {
@@ -137,15 +137,16 @@ class KubernetesClusterController {
   }
 
   async onInit() {
+    this.isAdmin = this.Authentication.isAdmin();
+    const useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
+
     this.state = {
       applicationsLoading: true,
       viewReady: false,
       hasUnhealthyComponentStatus: false,
-      useServerMetrics: false,
+      useServerMetrics,
+      displayResourceUsage: this.isAdmin && useServerMetrics,
     };
-
-    this.isAdmin = this.Authentication.isAdmin();
-    this.state.useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
 
     await this.getNodes();
     if (this.isAdmin) {

--- a/app/kubernetes/views/cluster/clusterController.js
+++ b/app/kubernetes/views/cluster/clusterController.js
@@ -36,6 +36,7 @@ class KubernetesClusterController {
     this.getComponentStatus = this.getComponentStatus.bind(this);
     this.getComponentStatusAsync = this.getComponentStatusAsync.bind(this);
     this.getEndpointsAsync = this.getEndpointsAsync.bind(this);
+    this.hasResourceUsageAccess = this.hasResourceUsageAccess.bind(this);
   }
 
   async getComponentStatusAsync() {
@@ -107,7 +108,7 @@ class KubernetesClusterController {
       );
       this.resourceReservation.Memory = KubernetesResourceReservationHelper.megaBytesValue(this.resourceReservation.Memory);
 
-      if (this.state.displayResourceUsage) {
+      if (this.hasResourceUsageAccess()) {
         await this.getResourceUsage(this.endpoint.Id);
       }
     } catch (err) {
@@ -136,6 +137,14 @@ class KubernetesClusterController {
     }
   }
 
+  /**
+   * Check if resource usage stats can be displayed
+   * @returns {boolean}
+   */
+  hasResourceUsageAccess() {
+    return this.isAdmin && this.state.useServerMetrics;
+  }
+
   async onInit() {
     this.isAdmin = this.Authentication.isAdmin();
     const useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
@@ -145,7 +154,6 @@ class KubernetesClusterController {
       viewReady: false,
       hasUnhealthyComponentStatus: false,
       useServerMetrics,
-      displayResourceUsage: this.isAdmin && useServerMetrics,
     };
 
     await this.getNodes();

--- a/app/kubernetes/views/cluster/node/node.html
+++ b/app/kubernetes/views/cluster/node/node.html
@@ -85,7 +85,7 @@
                     memory-usage="ctrl.resourceUsage.Memory"
                     memory-limit="ctrl.memoryLimit"
                     description="Resource reservation represents the total amount of resource assigned to all the applications running on this node."
-                    display-usage="ctrl.state.displayResourceUsage"
+                    display-usage="ctrl.hasResourceUsageAccess()"
                   >
                   </kubernetes-resource-reservation>
                 </div>

--- a/app/kubernetes/views/cluster/node/node.html
+++ b/app/kubernetes/views/cluster/node/node.html
@@ -85,7 +85,7 @@
                     memory-usage="ctrl.resourceUsage.Memory"
                     memory-limit="ctrl.memoryLimit"
                     description="Resource reservation represents the total amount of resource assigned to all the applications running on this node."
-                    display-usage="ctrl.state.isAdmin"
+                    display-usage="ctrl.state.displayResourceUsage"
                   >
                   </kubernetes-resource-reservation>
                 </div>

--- a/app/kubernetes/views/cluster/node/nodeController.js
+++ b/app/kubernetes/views/cluster/node/nodeController.js
@@ -46,6 +46,7 @@ class KubernetesNodeController {
     this.getEndpointsAsync = this.getEndpointsAsync.bind(this);
     this.updateNodeAsync = this.updateNodeAsync.bind(this);
     this.drainNodeAsync = this.drainNodeAsync.bind(this);
+    this.hasResourceUsageAccess = this.hasResourceUsageAccess.bind(this);
     this.getNodeUsageAsync = this.getNodeUsageAsync.bind(this);
   }
 
@@ -332,6 +333,10 @@ class KubernetesNodeController {
     return this.$async(this.getNodesAsync);
   }
 
+  hasResourceUsageAccess() {
+    return this.state.isAdmin && this.state.useServerMetrics;
+  }
+
   async getNodeUsageAsync() {
     try {
       const nodeName = this.$transition$.params().name;
@@ -397,7 +402,7 @@ class KubernetesNodeController {
       this.memoryLimit = KubernetesResourceReservationHelper.megaBytesValue(this.node.Memory);
       this.state.isContainPortainer = _.find(this.applications, { ApplicationName: 'portainer' });
 
-      if (this.state.displayResourceUsage) {
+      if (this.hasResourceUsageAccess()) {
         await this.getNodeUsage();
       }
     } catch (err) {
@@ -413,11 +418,9 @@ class KubernetesNodeController {
 
   async onInit() {
     this.availabilities = KubernetesNodeAvailabilities;
-    const isAdmin = this.Authentication.isAdmin();
-    const useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
 
     this.state = {
-      isAdmin,
+      isAdmin: this.Authentication.isAdmin(),
       activeTab: this.LocalStorage.getActiveTab('node'),
       currentName: this.$state.$current.name,
       dataLoading: true,
@@ -432,8 +435,7 @@ class KubernetesNodeController {
       hasDuplicateLabelKeys: false,
       isDrainOperation: false,
       isContainPortainer: false,
-      useServerMetrics,
-      displayResourceUsage: isAdmin && useServerMetrics,
+      useServerMetrics: this.endpoint.Kubernetes.Configuration.UseServerMetrics,
     };
 
     await this.getNodes();

--- a/app/kubernetes/views/cluster/node/nodeController.js
+++ b/app/kubernetes/views/cluster/node/nodeController.js
@@ -397,7 +397,7 @@ class KubernetesNodeController {
       this.memoryLimit = KubernetesResourceReservationHelper.megaBytesValue(this.node.Memory);
       this.state.isContainPortainer = _.find(this.applications, { ApplicationName: 'portainer' });
 
-      if (this.state.isAdmin) {
+      if (this.state.displayResourceUsage) {
         await this.getNodeUsage();
       }
     } catch (err) {
@@ -412,9 +412,13 @@ class KubernetesNodeController {
   }
 
   async onInit() {
+    this.availabilities = KubernetesNodeAvailabilities;
+    const isAdmin = this.Authentication.isAdmin();
+    const useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
+
     this.state = {
-      isAdmin: this.Authentication.isAdmin(),
-      activeTab: 0,
+      isAdmin,
+      activeTab: this.LocalStorage.getActiveTab('node'),
       currentName: this.$state.$current.name,
       dataLoading: true,
       eventsLoading: true,
@@ -428,14 +432,9 @@ class KubernetesNodeController {
       hasDuplicateLabelKeys: false,
       isDrainOperation: false,
       isContainPortainer: false,
-      useServerMetrics: false,
+      useServerMetrics,
+      displayResourceUsage: isAdmin && useServerMetrics,
     };
-
-    this.availabilities = KubernetesNodeAvailabilities;
-
-    this.state.useServerMetrics = this.endpoint.Kubernetes.Configuration.UseServerMetrics;
-
-    this.state.activeTab = this.LocalStorage.getActiveTab('node');
 
     await this.getNodes();
     await this.getEvents();

--- a/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
+++ b/app/kubernetes/views/resource-pools/edit/resourcePoolController.js
@@ -244,7 +244,9 @@ class KubernetesResourcePoolController {
           return app;
         });
 
-        await this.getResourceUsage(this.pool.Namespace.Name);
+        if (this.state.useServerMetrics) {
+          await this.getResourceUsage(this.pool.Namespace.Name);
+        }
       } catch (err) {
         this.Notifications.error('Failure', err, 'Unable to retrieve applications.');
       } finally {


### PR DESCRIPTION
Closes [EE-1273](https://portainer.atlassian.net/browse/EE-1273), [EE-1274](https://portainer.atlassian.net/browse/EE-1274).

If metric server api is disabled for k8s endpoint, this bugfix will also:
- disable metric server api call on cluster view
- disable metric server api call on node view
- disable metric server api call on namespace view