### PR TITLE
feat(k8s/deploy): change default namespace behavior EE-1545

### DIFF
--- a/api/exec/kubernetes_deploy.go
+++ b/api/exec/kubernetes_deploy.go
@@ -95,7 +95,7 @@ func (deployer *KubernetesDeployer) Deploy(request *http.Request, endpoint *port
 		args = append(args, "--server", endpoint.URL)
 		args = append(args, "--insecure-skip-tls-verify")
 		args = append(args, "--token", token)
-		fmt.Println("Namespace: %s\n", namespace)
+		fmt.Printf("Namespace: %s\n", namespace)
 		if namespace != "" {
 			args = append(args, "--namespace", namespace)
 		}

--- a/api/exec/kubernetes_deploy.go
+++ b/api/exec/kubernetes_deploy.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"fmt"
 
 	"github.com/portainer/portainer/api/http/proxy/factory/kubernetes"
 	"github.com/portainer/portainer/api/http/security"

--- a/api/exec/kubernetes_deploy.go
+++ b/api/exec/kubernetes_deploy.go
@@ -95,7 +95,9 @@ func (deployer *KubernetesDeployer) Deploy(request *http.Request, endpoint *port
 		args = append(args, "--server", endpoint.URL)
 		args = append(args, "--insecure-skip-tls-verify")
 		args = append(args, "--token", token)
-		args = append(args, "--namespace", namespace)
+		if namespace != "" {
+			args = append(args, "--namespace", namespace)
+		}
 		args = append(args, "apply", "-f", "-")
 
 		var stderr bytes.Buffer

--- a/api/exec/kubernetes_deploy.go
+++ b/api/exec/kubernetes_deploy.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/portainer/portainer/api/http/proxy/factory/kubernetes"
 	"github.com/portainer/portainer/api/http/security"
@@ -95,6 +96,7 @@ func (deployer *KubernetesDeployer) Deploy(request *http.Request, endpoint *port
 		args = append(args, "--server", endpoint.URL)
 		args = append(args, "--insecure-skip-tls-verify")
 		args = append(args, "--token", token)
+		fmt.Println("Namespace: %s\n", namespace)
 		if namespace != "" {
 			args = append(args, "--namespace", namespace)
 		}

--- a/api/http/handler/stacks/create_kubernetes_stack.go
+++ b/api/http/handler/stacks/create_kubernetes_stack.go
@@ -189,6 +189,10 @@ func (handler *Handler) deployKubernetesStack(r *http.Request, endpoint *portain
 		return "", errors.Wrap(err, "failed to add application labels")
 	}
 
+	if !composeFormat && namespace == "default" {
+		namespace = ""
+	}
+
 	return handler.KubernetesDeployer.Deploy(r, endpoint, string(manifest), namespace)
 }
 

--- a/app/kubernetes/views/deploy/deploy.html
+++ b/app/kubernetes/views/deploy/deploy.html
@@ -83,7 +83,7 @@
                   placeholder="# Define or paste the content of your manifest file here"
                 >
                   <editor-description>
-                    <span class="col-sm-12 text-muted small" ng-show="ctrl.state.DeployType === ctrl.ManifestDeployTypes.COMPOSE">
+                    <span class="col-sm-12" ng-show="ctrl.state.DeployType === ctrl.ManifestDeployTypes.COMPOSE">
                       <p>
                         <i class="fa fa-exclamation-circle orange-icon" aria-hidden="true" style="margin-right: 2px;"></i>
                         Portainer uses <a href="https://kompose.io/" target="_blank">Kompose</a> to convert your Compose manifest to a Kubernetes compliant manifest. Be wary that
@@ -95,7 +95,7 @@
                       </p>
                     </span>
                     <span
-                      class="col-sm-12 text-muted small"
+                      class="col-sm-12"
                       ng-show="ctrl.state.DeployType === ctrl.ManifestDeployTypes.KUBERNETES && ctrl.state.BuildMethod === ctrl.BuildMethods.WEB_EDITOR"
                     >
                       <p>

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -175,9 +175,7 @@ function shell_build_binary_azuredevops(p, a) {
 function shell_run_container() {
   return [
     'docker rm -f portainer',
-    'docker run -d -p 8000:8000 -p 9000:9000 -p 9443:9443 -v ' +
-      portainer_root +
-      '/dist:/app -v ' +
+    'docker run -d -p 8000:8000 -p 9000:9000 -v ' + portainer_root + '/dist:/app -v ' +
       portainer_data +
       ':/data -v /var/run/docker.sock:/var/run/docker.sock:z -v /var/run/docker.sock:/var/run/alternative.sock:z -v /tmp:/tmp --name portainer portainer/base /app/portainer',
   ].join(';');


### PR DESCRIPTION
Closes [EE-1545](https://portainer.atlassian.net/browse/EE-1545)

This PRs brings the following:
* Change the behavior of the namespace selector to not pass the `-n` parameter to `kubectl apply` when default is selected for Kubernetes manifests
* This behavior is unaffected when Compose is selected
* Fixes an invalid icon for Compose format
* Fixes invalid text size for web editor descriptions

Requires https://github.com/portainer/agent/pull/206 to be used with an agent deployment.