### PR TITLE
feat(k8s): add the ability to deploy from a manifest URL

### DIFF
--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -149,6 +149,8 @@ func (handler *Handler) createKubernetesStack(w http.ResponseWriter, r *http.Req
 		return handler.createKubernetesStackFromFileContent(w, r, endpoint)
 	case "repository":
 		return handler.createKubernetesStackFromGitRepository(w, r, endpoint)
+	case "url":
+		return handler.createKubernetesStackFromManifestURL(w, r, endpoint)		
 	}
 	return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Invalid value for query parameter: method. Value must be one of: string or repository", Err: errors.New(request.ErrInvalidQueryParameter)}
 }

--- a/app/kubernetes/models/deploy.js
+++ b/app/kubernetes/models/deploy.js
@@ -7,9 +7,11 @@ export const KubernetesDeployBuildMethods = Object.freeze({
   GIT: 1,
   WEB_EDITOR: 2,
   CUSTOM_TEMPLATE: 3,
+  URL: 4
 });
 
 export const KubernetesDeployRequestMethods = Object.freeze({
   REPOSITORY: 'repository',
   STRING: 'string',
+  URL: 'url'
 });

--- a/app/kubernetes/views/deploy/deploy.html
+++ b/app/kubernetes/views/deploy/deploy.html
@@ -111,6 +111,33 @@
                 </web-editor-form>
 
                 <!-- !editor -->
+                
+                <!-- url -->
+                <div ng-show="ctrl.state.BuildMethod === ctrl.BuildMethods.URL">
+                  <div class="col-sm-12 form-section-title">
+                    URL
+                  </div>
+                  <div class="form-group">
+                    <span class="col-sm-12 text-muted small">
+                      Indicate the URL to the manifest.
+                    </span>
+                  </div>
+                  <div class="form-group">
+                    <label for="manifest_url" class="col-sm-1 control-label text-left">URL</label>
+                    <div class="col-sm-11">
+                      <input
+                        type="text"
+                        class="form-control"
+                        ng-model="ctrl.formValues.ManifestURL"
+                        id="manifest_url"
+                        placeholder="https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/controllers/nginx-deployment.yaml"
+                        data-cy="k8sAppDeploy-urlFileUrl"
+                      />
+                    </div>
+                  </div>
+                </div>                
+                <!-- !url -->
+
                 <!-- actions -->
                 <div class="col-sm-12 form-section-title">
                   Actions


### PR DESCRIPTION
Closes [EE-1546](https://portainer.atlassian.net/browse/EE-1546)

It brings the following:

* Introduce a new URL build method in advanced deployment to deploy a manifest from a URL

NOTE: Requires https://github.com/portainer/portainer/pull/5535 to be able to deploy from a URL in the default namespace

Requires portainer/agent#206 to be used with an agent deployment.