### PR TITLE
feat(k8s): display namespace status [EE-1550]

### DIFF
--- a/app/kubernetes/components/datatables/resource-pools-datatable/resourcePoolsDatatable.html
+++ b/app/kubernetes/components/datatables/resource-pools-datatable/resourcePoolsDatatable.html
@@ -93,6 +93,13 @@
                 </a>
               </th>
               <th>
+                <a ng-click="$ctrl.changeOrderBy('Namespace.Status')">
+                  Status
+                  <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Namespace.Status' && !$ctrl.state.reverseOrder"></i>
+                  <i class="fa fa-sort-alpha-up" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Namespace.Status' && $ctrl.state.reverseOrder"></i>
+                </a>
+              </th>  
+              <th>
                 <a ng-click="$ctrl.changeOrderBy('Quota')">
                   Quota
                   <i class="fa fa-sort-alpha-down" aria-hidden="true" ng-if="$ctrl.state.orderBy === 'Quota' && !$ctrl.state.reverseOrder"></i>
@@ -123,6 +130,9 @@
                 </span>
                 <a ui-sref="kubernetes.resourcePools.resourcePool({ id: item.Namespace.Name })">{{ item.Namespace.Name }}</a>
                 <span style="margin-left: 5px;" class="label label-info image-tag" ng-if="$ctrl.isSystemNamespace(item)">system</span>
+              </td>
+              <td>
+                <span class="label label-{{ $ctrl.namespaceStatusColor(item.Namespace.Status) }}">{{ item.Namespace.Status }}</span>
               </td>
               <td> <i class="fa {{ item.Quota ? 'fa-toggle-on' : 'fa-toggle-off' }}" aria-hidden="true" style="margin-right: 2px;"></i> {{ item.Quota ? 'Yes' : 'No' }} </td>
               <td>{{ item.Namespace.CreationDate | getisodate }} {{ item.Namespace.ResourcePoolOwner ? 'by ' + item.Namespace.ResourcePoolOwner : '' }}</td>

--- a/app/kubernetes/components/datatables/resource-pools-datatable/resourcePoolsDatatableController.js
+++ b/app/kubernetes/components/datatables/resource-pools-datatable/resourcePoolsDatatableController.js
@@ -38,6 +38,17 @@ angular.module('portainer.docker').controller('KubernetesResourcePoolsDatatableC
       return !ctrl.isSystemNamespace(item) || (ctrl.settings.showSystem && ctrl.isAdmin);
     };
 
+    this.namespaceStatusColor = function(status) {
+      switch (status.toLowerCase()) {
+        case 'active':
+          return 'success';
+        case 'terminating':
+          return 'danger';
+        default:
+          return 'primary';
+      }
+    };
+
     /**
      * Do not allow system namespaces to be selected
      */

--- a/app/kubernetes/services/namespaceService.js
+++ b/app/kubernetes/services/namespaceService.js
@@ -41,14 +41,11 @@ class KubernetesNamespaceService {
       const data = await this.KubernetesNamespaces().get().$promise;
       const promises = _.map(data.items, (item) => this.KubernetesNamespaces().status({ id: item.metadata.name }).$promise);
       const namespaces = await $allSettled(promises);
-      const visibleNamespaces = _.map(namespaces.fulfilled, (item) => {
-        if (item.status.phase !== 'Terminating') {
-          return KubernetesNamespaceConverter.apiToNamespace(item);
-        }
+      const allNamespaces = _.map(namespaces.fulfilled, (item) => {
+        return KubernetesNamespaceConverter.apiToNamespace(item);
       });
-      const res = _.without(visibleNamespaces, undefined);
-      updateNamespaces(res);
-      return res;
+      updateNamespaces(allNamespaces);
+      return allNamespaces;
     } catch (err) {
       throw new PortainerError('Unable to retrieve namespaces', err);
     }


### PR DESCRIPTION
Closes [EE-1550](https://portainer.atlassian.net/browse/EE-1550)

This PRs brings the following:
- [x] Display the namespace status in the namespace datatable
- [x] Display terminating namespaces

![image](https://user-images.githubusercontent.com/5485061/131480207-779611e7-95a3-46fd-89c4-751d8f5d3ae4.png)
