### PR TITLE
fix(kubectl/shell): zombie pods and websocket connection error bugfixes EE-1520

### DIFF
--- a/api/http/handler/websocket/pod.go
+++ b/api/http/handler/websocket/pod.go
@@ -150,9 +150,10 @@ func (handler *Handler) hijackPodExecStartOperation(
 	err = <-errorChan
 	if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
 		log.Printf("websocket error: %s \n", err.Error())
+		return nil
 	}
 
-	return nil
+	return &httperror.HandlerError{http.StatusInternalServerError, "Unable to start exec process inside container", err}
 }
 
 func (handler *Handler) getToken(request *http.Request, endpoint *portainer.Endpoint, setLocalAdminToken bool) (string, bool, error) {

--- a/api/kubernetes/cli/exec.go
+++ b/api/kubernetes/cli/exec.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -15,6 +15,7 @@ import (
 // using the specified command. The stdin parameter will be bound to the stdin process and the stdout process will write
 // to the stdout parameter.
 // This function only works against a local endpoint using an in-cluster config with the user's SA token.
+// This is a blocking operation.
 func (kcl *KubeClient) StartExecProcess(token string, useAdminToken bool, namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer) error {
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1228,7 +1228,7 @@ type (
 		GetServiceAccount(tokendata *TokenData) (*v1.ServiceAccount, error)
 		GetServiceAccountBearerToken(userID int) (string, error)
 		CreateUserShellPod(ctx context.Context, serviceAccountName string) (*KubernetesShellPod, error)
-		StartExecProcess(token string, useAdminToken bool, namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer) error
+		StartExecProcess(token string, useAdminToken bool, namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer, errChan chan error)
 		NamespaceAccessPoliciesDeleteNamespace(namespace string) error
 		GetNodesLimits() (K8sNodesLimits, error)
 		GetNamespaceAccessPolicies() (map[string]K8sNamespaceAccessPolicy, error)


### PR DESCRIPTION
Closes [EE-1520](https://portainer.atlassian.net/browse/EE-1520).

## Fixes - for local k8s endpoint
- fixed zombie kubectl shell pod issue
  - spawned kuebctl shell pods were not removed after websocket disconnection
- fixed bug with websocket connection error - raised when re-opening kubectl shell in quick succession