### PR TITLE
fix(helm): migrating code from user handler to helm handler

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/portainer/docker-compose-wrapper v0.0.0-20210810234209-d01bc85eb481
 	github.com/portainer/libcompose v0.5.3
 	github.com/portainer/libcrypto v0.0.0-20210422035235-c652195c5c3a
-	github.com/portainer/libhelm v0.0.0-20210901032115-ad822f351174
+	github.com/portainer/libhelm v0.0.0-20210903050903-43c3353fd37c
 	github.com/portainer/libhttp v0.0.0-20190806161843-ba068f58be33
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.8.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -247,8 +247,8 @@ github.com/portainer/libcompose v0.5.3 h1:tE4WcPuGvo+NKeDkDWpwNavNLZ5GHIJ4RvuZXs
 github.com/portainer/libcompose v0.5.3/go.mod h1:7SKd/ho69rRKHDFSDUwkbMcol2TMKU5OslDsajr8Ro8=
 github.com/portainer/libcrypto v0.0.0-20210422035235-c652195c5c3a h1:qY8TbocN75n5PDl16o0uVr5MevtM5IhdwSelXEd4nFM=
 github.com/portainer/libcrypto v0.0.0-20210422035235-c652195c5c3a/go.mod h1:n54EEIq+MM0NNtqLeCby8ljL+l275VpolXO0ibHegLE=
-github.com/portainer/libhelm v0.0.0-20210901032115-ad822f351174 h1:6iMxTpjyp/AHW2qCavLzwsE+BgVZVpjOAsRZEi1lFGs=
-github.com/portainer/libhelm v0.0.0-20210901032115-ad822f351174/go.mod h1:YvYAk7krKTzB+rFwDr0jQ3sQu2BtiXK1AR0sZH7nhJA=
+github.com/portainer/libhelm v0.0.0-20210903050903-43c3353fd37c h1:KALKyW7pC75SBMpLgB0zL129OwHxYwYxVc6x0HjPFD0=
+github.com/portainer/libhelm v0.0.0-20210903050903-43c3353fd37c/go.mod h1:YvYAk7krKTzB+rFwDr0jQ3sQu2BtiXK1AR0sZH7nhJA=
 github.com/portainer/libhttp v0.0.0-20190806161843-ba068f58be33 h1:H8HR2dHdBf8HANSkUyVw4o8+4tegGcd+zyKZ3e599II=
 github.com/portainer/libhttp v0.0.0-20190806161843-ba068f58be33/go.mod h1:Y2TfgviWI4rT2qaOTHr+hq6MdKIE5YjgQAu7qwptTV0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/api/http/handler/helm/handler.go
+++ b/api/http/handler/helm/handler.go
@@ -54,6 +54,11 @@ func NewHandler(bouncer requestBouncer, dataStore portainer.DataStore, helmPacka
 	h.Handle("/{id}/kubernetes/helm",
 		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.helmInstall))).Methods(http.MethodPost)
 
+	h.Handle("/{id}/kubernetes/helm/repositories",
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.userGetHelmRepos))).Methods(http.MethodGet)
+	h.Handle("/{id}/kubernetes/helm/repositories",
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.userCreateHelmRepo))).Methods(http.MethodPost)
+
 	return h
 }
 

--- a/api/http/handler/helm/user_helm_repos.go
+++ b/api/http/handler/helm/user_helm_repos.go
@@ -1,0 +1,124 @@
+package helm
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/portainer/libhelm"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+type helmUserRepositoryResponse struct {
+	GlobalRepo string                         `json:"GlobalRepo"`
+	UserRepos  []portainer.HelmUserRepository `json:"UserRepos"`
+}
+
+type addHelmRepoUrlPayload struct {
+	URL string `json:"url"`
+}
+
+func (p *addHelmRepoUrlPayload) Validate(_ *http.Request) error {
+	return libhelm.ValidateHelmRepositoryURL(p.URL)
+}
+
+// @id HelmUserRepositoryCreate
+// @summary Create a user helm repository
+// @description Create a user helm repository.
+// @description **Access policy**: authenticated
+// @tags users
+// @security jwt
+// @accept json
+// @produce json
+// @param payload body addHelmRepoUrlPayload true "Helm Repository"
+// @success 200 {object} portainer.HelmUserRepository "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 500 "Server error"
+// @router /endpoints/:id/kubernetes/helm/repositories [post]
+func (handler *Handler) userCreateHelmRepo(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+	userID := portainer.UserID(tokenData.ID)
+
+	p := new(addHelmRepoUrlPayload)
+	err = request.DecodeAndValidateJSONPayload(r, p)
+	if err != nil {
+		return &httperror.HandlerError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "Invalid Helm repository URL",
+			Err:        err,
+		}
+	}
+
+	records, err := handler.dataStore.HelmUserRepository().HelmUserRepositoryByUserID(userID)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to access the DataStore", err}
+	}
+
+	// check if repo already exists - by doing case insensitive, suffix trimmed comparison
+	for _, record := range records {
+		if strings.EqualFold(strings.TrimSuffix(record.URL, "/"), strings.TrimSuffix(p.URL, "/")) {
+			errMsg := "Helm repo already registered for user"
+			return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: errMsg, Err: errors.New(errMsg)}
+		}
+	}
+
+	record := portainer.HelmUserRepository{
+		UserID: userID,
+		URL:    p.URL,
+	}
+
+	err = handler.dataStore.HelmUserRepository().CreateHelmUserRepository(&record)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to save a user Helm repository URL", err}
+	}
+
+	return response.JSON(w, record)
+}
+
+// @id HelmUserRepositoriesList
+// @summary List a users helm repositories
+// @description Inspect a user helm repositories.
+// @description **Access policy**: authenticated
+// @tags users
+// @security jwt
+// @produce json
+// @param id path int true "User identifier"
+// @success 200 {object} helmUserRepositoryResponse "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 500 "Server error"
+// @router /endpoints/:id/kubernetes/helm/repositories [get]
+func (handler *Handler) userGetHelmRepos(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+	userID := portainer.UserID(tokenData.ID)
+
+	settings, err := handler.dataStore.Settings().Settings()
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve settings from the database", err}
+	}
+
+	userRepos, err := handler.dataStore.HelmUserRepository().HelmUserRepositoryByUserID(userID)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to get user Helm repositories", err}
+	}
+
+	resp := helmUserRepositoryResponse{
+		GlobalRepo: settings.HelmRepositoryURL,
+		UserRepos:  userRepos,
+	}
+
+	return response.JSON(w, resp)
+}

--- a/api/http/handler/users/handler.go
+++ b/api/http/handler/users/handler.go
@@ -54,10 +54,6 @@ func NewHandler(bouncer *security.RequestBouncer, rateLimiter *security.RateLimi
 		bouncer.PublicAccess(httperror.LoggerHandler(h.adminCheck))).Methods(http.MethodGet)
 	h.Handle("/users/admin/init",
 		bouncer.PublicAccess(httperror.LoggerHandler(h.adminInit))).Methods(http.MethodPost)
-	h.Handle("/users/{id}/helm-repositories",
-		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.userGetHelmRepos))).Methods(http.MethodGet)
-	h.Handle("/users/{id}/helm-repositories",
-		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.userCreateHelmRepo))).Methods(http.MethodPost)
 
 	return h
 }

--- a/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.controller.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.controller.js
@@ -1,18 +1,18 @@
 export default class HelmAddRepositoryController {
   /* @ngInject */
-  constructor($async, $window, $analytics, Authentication, UserService, Notifications) {
+  constructor($async, $window, $analytics, HelmService, Notifications, EndpointProvider) {
     this.$async = $async;
     this.$window = $window;
     this.$analytics = $analytics;
-    this.Authentication = Authentication;
-    this.UserService = UserService;
+    this.HelmService = HelmService;
     this.Notifications = Notifications;
+    this.EndpointProvider = EndpointProvider;
   }
 
   async addRepository() {
     this.state.isAddingRepo = true;
     try {
-      const { URL } = await this.UserService.addHelmRepository(this.state.userId, this.state.repository);
+      const { URL } = await this.HelmService.addHelmRepository(this.EndpointProvider.currentEndpoint().Id, { url: this.state.repository });
       this.Notifications.success('Helm repository added successfully');
       this.refreshCharts([URL], true);
     } catch (err) {
@@ -27,7 +27,6 @@ export default class HelmAddRepositoryController {
       this.state = {
         isAddingRepo: false,
         repository: '',
-        userId: this.Authentication.getUserDetails().ID,
       };
     });
   }

--- a/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.js
@@ -7,5 +7,6 @@ angular.module('portainer.kubernetes').component('helmAddRepository', {
   bindings: {
     charts: '@',
     refreshCharts: '<',
+    endpoint: '<',
   },
 });

--- a/app/kubernetes/components/helm/helm-templates/helm-templates.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-templates.js
@@ -4,4 +4,7 @@ import controller from './helm-templates.controller';
 angular.module('portainer.kubernetes').component('helmTemplatesView', {
   templateUrl: './helm-templates.html',
   controller,
+  bindings: {
+    endpoint: '<',
+  },
 });

--- a/app/kubernetes/helm/rest.js
+++ b/app/kubernetes/helm/rest.js
@@ -2,15 +2,13 @@ import angular from 'angular';
 
 angular.module('portainer.kubernetes').factory('HelmFactory', HelmFactory);
 
-function HelmFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
+function HelmFactory($resource, API_ENDPOINT_ENDPOINTS) {
   const helmUrl = API_ENDPOINT_ENDPOINTS + '/:endpointId/kubernetes/helm';
   const templatesUrl = '/api/templates/helm';
 
   return $resource(
     helmUrl,
-    {
-      endpointId: EndpointProvider.endpointID,
-    },
+    {},
     {
       templates: {
         url: templatesUrl,
@@ -26,9 +24,18 @@ function HelmFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
           return { values: data };
         },
       },
+      getHelmRepositories: {
+        method: 'GET',
+        url: `${helmUrl}/repositories`,
+      },
+      addHelmRepository: {
+        method: 'POST',
+        url: `${helmUrl}/repositories`,
+      },
       list: {
         method: 'GET',
         isArray: true,
+        params: { namespace: '@namespace', selector: '@selector', filter: '@filter', output: '@output' },
       },
       install: { method: 'POST' },
       uninstall: {

--- a/app/kubernetes/views/applications/applications.js
+++ b/app/kubernetes/views/applications/applications.js
@@ -4,5 +4,6 @@ angular.module('portainer.kubernetes').component('kubernetesApplicationsView', {
   controllerAs: 'ctrl',
   bindings: {
     $transition$: '<',
+    endpoint: '<',
   },
 });

--- a/app/kubernetes/views/applications/applicationsController.js
+++ b/app/kubernetes/views/applications/applicationsController.js
@@ -69,7 +69,7 @@ class KubernetesApplicationsController {
     for (const application of selectedItems) {
       try {
         if (application.ApplicationType === KubernetesApplicationTypes.HELM) {
-          await this.HelmService.uninstall(application);
+          await this.HelmService.uninstall(this.endpoint.Id, application);
         } else {
           await this.KubernetesApplicationService.delete(application);
         }

--- a/app/kubernetes/views/applications/helm/helm.controller.js
+++ b/app/kubernetes/views/applications/helm/helm.controller.js
@@ -16,7 +16,7 @@ export default class KubernetesHelmApplicationController {
   async getHelmApplication() {
     try {
       this.state.dataLoading = true;
-      const releases = await this.HelmService.listReleases({ selector: `name=${this.state.params.name}`, namespace: 'default' });
+      const releases = await this.HelmService.listReleases(this.endpoint.Id, { selector: `name=${this.state.params.name}`, namespace: 'default' });
       if (releases.length > 0) {
         this.state.release = releases[0];
       } else {

--- a/app/kubernetes/views/applications/helm/index.js
+++ b/app/kubernetes/views/applications/helm/index.js
@@ -5,4 +5,7 @@ import './helm.css';
 angular.module('portainer.kubernetes').component('kubernetesHelmApplicationView', {
   templateUrl: './helm.html',
   controller,
+  bindings: {
+    endpoint: '<',
+  },
 });

--- a/app/portainer/rest/user.js
+++ b/app/portainer/rest/user.js
@@ -16,8 +16,6 @@ angular.module('portainer.app').factory('Users', [
         queryMemberships: { method: 'GET', isArray: true, params: { id: '@id', entity: 'memberships' } },
         checkAdminUser: { method: 'GET', params: { id: 'admin', entity: 'check' }, isArray: true, ignoreLoadingBar: true },
         initAdminUser: { method: 'POST', params: { id: 'admin', entity: 'init' }, ignoreLoadingBar: true },
-        getHelmRepositories: { method: 'GET', params: { id: '@id', entity: 'helm-repositories' } },
-        addHelmRepository: { method: 'POST', params: { id: '@id', entity: 'helm-repositories' } },
       }
     );
   },

--- a/app/portainer/services/api/userService.js
+++ b/app/portainer/services/api/userService.js
@@ -153,15 +153,6 @@ angular.module('portainer.app').factory('UserService', [
       return deferred.promise;
     };
 
-    service.getHelmRepositories = function (id) {
-      return Users.getHelmRepositories({ id }).$promise;
-    };
-
-    service.addHelmRepository = function (id, url) {
-      const payload = { url };
-      return Users.addHelmRepository({ id }, payload).$promise;
-    };
-
     return service;
   },
 ]);


### PR DESCRIPTION
# Tech review fixes/updates

- migrated user_helm_repos to helm endpoint handler
- migrated api operations from user factory/service to helm factory/service
- passing endpointId into helm service/factory as endpoint provider is deprecated