### PR TITLE
fix(helm): helm epic bugfixes EE-1582 EE-1593

### DIFF
--- a/api/http/handler/helm/helm_delete.go
+++ b/api/http/handler/helm/helm_delete.go
@@ -10,10 +10,10 @@ import (
 )
 
 // @id HelmDelete
-// @summary Delete Helm Chart(s)
+// @summary Delete Helm Release
 // @description
 // @description **Access policy**: authorized
-// @tags helm_chart
+// @tags helm
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/helm/helm_install.go
+++ b/api/http/handler/helm/helm_install.go
@@ -32,7 +32,7 @@ var errChartNameInvalid = errors.New("invalid chart name. " +
 // @summary Install Helm Chart
 // @description
 // @description **Access policy**: authorized
-// @tags helm_chart
+// @tags helm
 // @security jwt
 // @accept json
 // @produce json
@@ -41,7 +41,7 @@ var errChartNameInvalid = errors.New("invalid chart name. " +
 // @failure 401 "Unauthorized"
 // @failure 404 "Endpoint or ServiceAccount not found"
 // @failure 500 "Server error"
-// @router /endpoints/:id/kubernetes/helm/{release} [post]
+// @router /endpoints/:id/kubernetes/helm [post]
 func (handler *Handler) helmInstall(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
 	var payload installChartPayload
 	err := request.DecodeAndValidateJSONPayload(r, &payload)

--- a/api/http/handler/helm/helm_list.go
+++ b/api/http/handler/helm/helm_list.go
@@ -10,10 +10,10 @@ import (
 )
 
 // @id HelmList
-// @summary List Helm Chart(s)
+// @summary List Helm Releases
 // @description
 // @description **Access policy**: authorized
-// @tags helm_chart
+// @tags helm
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/helm/helm_repo_search.go
+++ b/api/http/handler/helm/helm_repo_search.go
@@ -15,7 +15,7 @@ import (
 // @summary Search Helm Charts
 // @description
 // @description **Access policy**: authorized
-// @tags helm_chart
+// @tags helm
 // @param repo query string true "Helm repository URL"
 // @security jwt
 // @produce json

--- a/api/http/handler/helm/helm_show.go
+++ b/api/http/handler/helm/helm_show.go
@@ -13,7 +13,7 @@ import (
 )
 
 // @id HelmShow
-// @summary Show Helm Chart(s)
+// @summary Show Helm Chart Information
 // @description
 // @description **Access policy**: authorized
 // @tags helm_chart

--- a/api/http/handler/helm/user_helm_repos.go
+++ b/api/http/handler/helm/user_helm_repos.go
@@ -58,15 +58,17 @@ func (handler *Handler) userCreateHelmRepo(w http.ResponseWriter, r *http.Reques
 			Err:        err,
 		}
 	}
+	// lowercase, remove trailing slash
+	p.URL = strings.TrimSuffix(strings.ToLower(p.URL), "/")
 
 	records, err := handler.dataStore.HelmUserRepository().HelmUserRepositoryByUserID(userID)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to access the DataStore", err}
 	}
 
-	// check if repo already exists - by doing case insensitive, suffix trimmed comparison
+	// check if repo already exists - by doing case insensitive comparison
 	for _, record := range records {
-		if strings.EqualFold(strings.TrimSuffix(record.URL, "/"), strings.TrimSuffix(p.URL, "/")) {
+		if strings.EqualFold(record.URL, p.URL) {
 			errMsg := "Helm repo already registered for user"
 			return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: errMsg, Err: errors.New(errMsg)}
 		}

--- a/api/http/handler/helm/user_helm_repos.go
+++ b/api/http/handler/helm/user_helm_repos.go
@@ -16,8 +16,8 @@ import (
 )
 
 type helmUserRepositoryResponse struct {
-	GlobalRepo string                         `json:"GlobalRepo"`
-	UserRepos  []portainer.HelmUserRepository `json:"UserRepos"`
+	GlobalRepository string                         `json:"GlobalRepository"`
+	UserRepositories []portainer.HelmUserRepository `json:"UserRepositories"`
 }
 
 type addHelmRepoUrlPayload struct {
@@ -32,7 +32,7 @@ func (p *addHelmRepoUrlPayload) Validate(_ *http.Request) error {
 // @summary Create a user helm repository
 // @description Create a user helm repository.
 // @description **Access policy**: authenticated
-// @tags users
+// @tags helm
 // @security jwt
 // @accept json
 // @produce json
@@ -91,7 +91,7 @@ func (handler *Handler) userCreateHelmRepo(w http.ResponseWriter, r *http.Reques
 // @summary List a users helm repositories
 // @description Inspect a user helm repositories.
 // @description **Access policy**: authenticated
-// @tags users
+// @tags helm
 // @security jwt
 // @produce json
 // @param id path int true "User identifier"
@@ -118,8 +118,8 @@ func (handler *Handler) userGetHelmRepos(w http.ResponseWriter, r *http.Request)
 	}
 
 	resp := helmUserRepositoryResponse{
-		GlobalRepo: settings.HelmRepositoryURL,
-		UserRepos:  userRepos,
+		GlobalRepository: settings.HelmRepositoryURL,
+		UserRepositories: userRepos,
 	}
 
 	return response.JSON(w, resp)

--- a/api/http/handler/kubernetes/kubernetes_nodes_limits.go
+++ b/api/http/handler/kubernetes/kubernetes_nodes_limits.go
@@ -1,12 +1,13 @@
 package kubernetes
 
 import (
+	"net/http"
+
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
 	bolterrors "github.com/portainer/portainer/api/bolt/errors"
-	"net/http"
 )
 
 // @id getKubernetesNodesLimits
@@ -18,7 +19,7 @@ import (
 // @accept json
 // @produce json
 // @param id path int true "Endpoint identifier"
-// @success 200 {object} K8sNodesLimits "Success"
+// @success 200 {object} portainer.K8sNodesLimits "Success"
 // @failure 400 "Invalid request"
 // @failure 401 "Unauthorized"
 // @failure 403 "Permission denied"

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -112,7 +112,7 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.HelmRepositoryURL != nil {
-		settings.HelmRepositoryURL = strings.TrimSuffix(*payload.HelmRepositoryURL, "/")
+		settings.HelmRepositoryURL = strings.TrimSuffix(strings.ToLower(*payload.HelmRepositoryURL), "/")
 	}
 
 	if payload.BlackListedLabels != nil {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -396,7 +396,7 @@ type (
 		// Membership Identifier
 		ID HelmUserRepositoryID `json:"Id" example:"1"`
 		// User identifier
-		UserID UserID `json:"UserID" example:"1"`
+		UserID UserID `json:"UserId" example:"1"`
 		// Helm repository URL
 		URL string `json:"URL" example:"https://charts.bitnami.com/bitnami"`
 	}

--- a/app/kubernetes/__module.js
+++ b/app/kubernetes/__module.js
@@ -57,7 +57,7 @@ angular.module('portainer.kubernetes', ['portainer.app', registriesModule, custo
 
     const helmTemplates = {
       name: 'kubernetes.templates.helm',
-      url: '/templates/helm',
+      url: '/helm',
       views: {
         'content@': {
           component: 'helmTemplatesView',

--- a/app/kubernetes/__module.js
+++ b/app/kubernetes/__module.js
@@ -47,7 +47,7 @@ angular.module('portainer.kubernetes', ['portainer.app', registriesModule, custo
 
     const helmApplication = {
       name: 'kubernetes.helm',
-      url: '/helm/:name',
+      url: '/helm/:namespace/:name',
       views: {
         'content@': {
           component: 'kubernetesHelmApplicationView',

--- a/app/kubernetes/components/datatables/applications-datatable-url/applications-datatable-url.css
+++ b/app/kubernetes/components/datatables/applications-datatable-url/applications-datatable-url.css
@@ -2,5 +2,9 @@
   display: grid;
   grid-template-columns: 1fr 1fr 3fr;
   padding-top: 1rem;
-  padding-bottom: 2rem;
+  padding-bottom: 0.5rem;
+}
+
+.publish-url-link {
+  width: min-content;
 }

--- a/app/kubernetes/components/datatables/applications-datatable-url/applications-datatable-url.html
+++ b/app/kubernetes/components/datatables/applications-datatable-url/applications-datatable-url.html
@@ -2,5 +2,5 @@
   <div class="text-muted">
     Published URL
   </div>
-  <a ng-href="{{ $ctrl.publishedUrl }}" target="_blank" class="space-left"> <i class="fa fa-external-link-alt" aria-hidden="true"></i> {{ $ctrl.publishedUrl }} </a>
+  <a ng-href="{{ $ctrl.publishedUrl }}" target="_blank" class="publish-url-link"> <i class="fa fa-external-link-alt" aria-hidden="true"></i> {{ $ctrl.publishedUrl }} </a>
 </div>

--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
@@ -161,9 +161,8 @@
             <tr
               ng-click="$ctrl.expandItem(item, !$ctrl.isItemExpanded(item))"
               dir-paginate-start="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | filter:$ctrl.isDisplayed | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit: $ctrl.tableKey))"
-              ng-class="{ active: item.Checked, 'secondary-body': !$ctrl.isPrimary }"
+              ng-class="{ active: item.Checked, interactive: $ctrl.isExpandable(item), 'secondary-body': !$ctrl.isPrimary }"
               pagination-id="$ctrl.tableKey"
-              class="interactive"
             >
               <td>
                 <span ng-if="$ctrl.isPrimary" class="md-checkbox">
@@ -176,9 +175,9 @@
                   />
                   <label for="select_{{ $index }}"></label>
                 </span>
-                <a
-                  ><i ng-class="{ 'fas fa-angle-down': $ctrl.isItemExpanded(item), 'fas fa-angle-right': !$ctrl.isItemExpanded(item) }" class="space-right" aria-hidden="true"></i
-                ></a>
+                <a ng-if="$ctrl.isExpandable(item)">
+                  <i ng-class="{ 'fas fa-angle-down': $ctrl.isItemExpanded(item), 'fas fa-angle-right': !$ctrl.isItemExpanded(item) }" class="space-right" aria-hidden="true"></i>
+                </a>
               </td>
               <td>
                 <a ng-if="item.KubernetesApplications" ui-sref="kubernetes.helm({ name: item.Name, namespace: item.ResourcePool })" ng-click="$event.stopPropagation()"
@@ -225,7 +224,7 @@
               </td>
               <td>{{ item.CreationDate | getisodate }} {{ item.ApplicationOwner ? 'by ' + item.ApplicationOwner : '' }}</td>
             </tr>
-            <tr dir-paginate-end ng-show="$ctrl.isItemExpanded(item)" ng-class="{ 'secondary-body': $ctrl.isPrimary && !item.KubernetesApplications }">
+            <tr dir-paginate-end ng-show="$ctrl.isExpandable(item) && $ctrl.isItemExpanded(item)" ng-class="{ 'secondary-body': $ctrl.isPrimary && !item.KubernetesApplications }">
               <td></td>
               <td colspan="8" class="datatable-padding-vertical">
                 <span ng-if="item.KubernetesApplications">
@@ -241,14 +240,14 @@
                   </kubernetes-applications-datatable>
                 </span>
                 <span ng-if="!item.KubernetesApplications">
-                  <kubernetes-applications-datatable-url ng-if="$ctrl.getPublishUrl(item)" published-url="{{ $ctrl.getPublishUrl(item) }}"> </kubernetes-applications-datatable-url>
+                  <kubernetes-applications-datatable-url
+                    ng-if="$ctrl.getPublishedUrl(item)"
+                    published-url="{{ $ctrl.getPublishedUrl(item) }}"
+                  ></kubernetes-applications-datatable-url>
                   <kubernetes-applications-datatable-details
                     ng-if="$ctrl.hasConfigurationSecrets(item)"
                     configurations="item.Configurations"
                   ></kubernetes-applications-datatable-details>
-                  <div class="small text-muted" ng-if="!$ctrl.hasConfigurationSecrets(item) && !$ctrl.getPublishUrl(item)">
-                    This application has not been exposed.
-                  </div>
                 </span>
               </td>
             </tr>

--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
@@ -179,7 +179,9 @@
                 <a><i ng-class="{ 'fas fa-angle-down': item.Expanded, 'fas fa-angle-right': !item.Expanded }" class="space-right" aria-hidden="true"></i></a>
               </td>
               <td>
-                <a ng-if="item.KubernetesApplications" ui-sref="kubernetes.helm({ name: item.Name })" ng-click="$event.stopPropagation()">{{ item.Name }} </a>
+                <a ng-if="item.KubernetesApplications" ui-sref="kubernetes.helm({ name: item.Name, namespace: item.ResourcePool })" ng-click="$event.stopPropagation()"
+                  >{{ item.Name }}
+                </a>
                 <a
                   ng-if="!item.KubernetesApplications"
                   ui-sref="kubernetes.applications.application({ name: item.Name, namespace: item.ResourcePool })"

--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
@@ -159,7 +159,7 @@
           </thead>
           <tbody>
             <tr
-              ng-click="$ctrl.expandItem(item, !item.Expanded)"
+              ng-click="$ctrl.expandItem(item, !$ctrl.isItemExpanded(item))"
               dir-paginate-start="item in ($ctrl.state.filteredDataSet = ($ctrl.dataset | filter:$ctrl.state.textFilter | filter:$ctrl.isDisplayed | orderBy:$ctrl.state.orderBy:$ctrl.state.reverseOrder | itemsPerPage: $ctrl.state.paginatedItemLimit: $ctrl.tableKey))"
               ng-class="{ active: item.Checked, 'secondary-body': !$ctrl.isPrimary }"
               pagination-id="$ctrl.tableKey"
@@ -176,7 +176,9 @@
                   />
                   <label for="select_{{ $index }}"></label>
                 </span>
-                <a><i ng-class="{ 'fas fa-angle-down': item.Expanded, 'fas fa-angle-right': !item.Expanded }" class="space-right" aria-hidden="true"></i></a>
+                <a
+                  ><i ng-class="{ 'fas fa-angle-down': $ctrl.isItemExpanded(item), 'fas fa-angle-right': !$ctrl.isItemExpanded(item) }" class="space-right" aria-hidden="true"></i
+                ></a>
               </td>
               <td>
                 <a ng-if="item.KubernetesApplications" ui-sref="kubernetes.helm({ name: item.Name, namespace: item.ResourcePool })" ng-click="$event.stopPropagation()"
@@ -223,7 +225,7 @@
               </td>
               <td>{{ item.CreationDate | getisodate }} {{ item.ApplicationOwner ? 'by ' + item.ApplicationOwner : '' }}</td>
             </tr>
-            <tr dir-paginate-end ng-show="item.Expanded" ng-class="{ 'secondary-body': $ctrl.isPrimary && !item.KubernetesApplications }">
+            <tr dir-paginate-end ng-show="$ctrl.isItemExpanded(item)" ng-class="{ 'secondary-body': $ctrl.isPrimary && !item.KubernetesApplications }">
               <td></td>
               <td colspan="8" class="datatable-padding-vertical">
                 <span ng-if="item.KubernetesApplications">

--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatableController.js
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatableController.js
@@ -27,36 +27,24 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
       this.state.filteredDataSet.forEach((item) => this.expandItem(item, this.state.expandAll));
     };
 
+    this.isItemExpanded = function (item) {
+      return this.state.expandedItems.includes(item.Id);
+    };
+
     this.expandItem = function (item, expanded) {
-      item.Expanded = expanded;
-      if (!item.Expanded) {
+      // collapse item
+      if (!expanded) {
         this.state.expandedItems = this.state.expandedItems.filter((id) => id !== item.Id);
-      } else if (item.Expanded && !this.state.expandedItems.includes(item.Id)) {
+        // expanded item
+      } else if (expanded && !this.state.expandedItems.includes(item.Id)) {
         this.state.expandedItems = [...this.state.expandedItems, item.Id];
       }
       DatatableService.setDataTableExpandedItems(this.tableKey, this.state.expandedItems);
     };
 
-    function expandPreviouslyExpandedItem(item, storedExpandedItems) {
-      const expandedItem = storedExpandedItems.some((storedId) => storedId === item.Id);
-      if (expandedItem) {
-        ctrl.expandItem(item, true);
-      }
-    }
-
     this.expandItems = function (storedExpandedItems) {
-      let expandedItemCount = 0;
       this.state.expandedItems = storedExpandedItems;
-
-      for (let i = 0; i < this.dataset.length; i++) {
-        const item = this.dataset[i];
-        expandPreviouslyExpandedItem(item, storedExpandedItems);
-        if (item.Expanded) {
-          ++expandedItemCount;
-        }
-      }
-
-      if (expandedItemCount === this.dataset.length) {
+      if (this.state.expandedItems.length === this.dataset.length) {
         this.state.expandAll = true;
       }
     };
@@ -117,19 +105,19 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
       this.prepareTableFromDataset();
 
       this.state.orderBy = this.orderBy;
-      var storedOrder = DatatableService.getDataTableOrder(this.tableKey);
+      const storedOrder = DatatableService.getDataTableOrder(this.tableKey);
       if (storedOrder !== null) {
         this.state.reverseOrder = storedOrder.reverse;
         this.state.orderBy = storedOrder.orderBy;
       }
 
-      var textFilter = DatatableService.getDataTableTextFilters(this.tableKey);
+      const textFilter = DatatableService.getDataTableTextFilters(this.tableKey);
       if (textFilter !== null) {
         this.state.textFilter = textFilter;
         this.onTextFilterChange();
       }
 
-      var storedFilters = DatatableService.getDataTableFilters(this.tableKey);
+      const storedFilters = DatatableService.getDataTableFilters(this.tableKey);
       if (storedFilters !== null) {
         this.filters = storedFilters;
       }
@@ -137,12 +125,12 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
         this.filters.state.open = false;
       }
 
-      var storedExpandedItems = DatatableService.getDataTableExpandedItems(this.tableKey);
+      const storedExpandedItems = DatatableService.getDataTableExpandedItems(this.tableKey);
       if (storedExpandedItems !== null) {
         this.expandItems(storedExpandedItems);
       }
 
-      var storedSettings = DatatableService.getDataTableSettings(this.tableKey);
+      const storedSettings = DatatableService.getDataTableSettings(this.tableKey);
       if (storedSettings !== null) {
         this.settings = storedSettings;
         this.settings.open = false;

--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatableController.js
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatableController.js
@@ -29,10 +29,10 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
 
     this.expandItem = function (item, expanded) {
       item.Expanded = expanded;
-      if (item.Expanded && !this.state.expandedItems.includes(item.Id)) {
-        this.state.expandedItems = [...this.state.expandedItems, item.Id];
-      } else {
+      if (!item.Expanded) {
         this.state.expandedItems = this.state.expandedItems.filter((id) => id !== item.Id);
+      } else if (item.Expanded && !this.state.expandedItems.includes(item.Id)) {
+        this.state.expandedItems = [...this.state.expandedItems, item.Id];
       }
       DatatableService.setDataTableExpandedItems(this.tableKey, this.state.expandedItems);
     };
@@ -90,7 +90,9 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
 
     this.getPublishUrl = function (item) {
       // Map all ingress rules in published ports to their respective URLs
-      const publishUrls = item.PublishedPorts.flatMap((pp) => pp.IngressRules).map(({ Host, IP, Path }) => `http://${Host || IP}${Path}`);
+      const publishUrls = item.PublishedPorts.flatMap((pp) => pp.IngressRules)
+        .filter(({ Host, IP }) => Host || IP)
+        .map(({ Host, IP, Path }) => `http://${Host || IP}${Path}`);
 
       // Return the first URL
       return publishUrls.length > 0 ? publishUrls[0] : '';
@@ -133,6 +135,11 @@ angular.module('portainer.docker').controller('KubernetesApplicationsDatatableCo
       }
       if (this.filters && this.filters.state) {
         this.filters.state.open = false;
+      }
+
+      var storedExpandedItems = DatatableService.getDataTableExpandedItems(this.tableKey);
+      if (storedExpandedItems !== null) {
+        this.expandItems(storedExpandedItems);
       }
 
       var storedSettings = DatatableService.getDataTableSettings(this.tableKey);

--- a/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.controller.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.controller.js
@@ -1,20 +1,27 @@
 export default class HelmAddRepositoryController {
   /* @ngInject */
-  constructor($async, $window, $analytics, HelmService, Notifications, EndpointProvider) {
+  constructor($state, $async, HelmService, Notifications, EndpointProvider) {
+    this.$state = $state;
     this.$async = $async;
-    this.$window = $window;
-    this.$analytics = $analytics;
     this.HelmService = HelmService;
     this.Notifications = Notifications;
     this.EndpointProvider = EndpointProvider;
   }
 
+  doesRepoExist() {
+    if (!this.state.repository) {
+      return false;
+    }
+    // lowercase, strip trailing slash and compare
+    return this.repos.includes(this.state.repository.toLowerCase().replace(/\/$/, ''));
+  }
+
   async addRepository() {
     this.state.isAddingRepo = true;
     try {
-      const { URL } = await this.HelmService.addHelmRepository(this.EndpointProvider.currentEndpoint().Id, { url: this.state.repository });
+      await this.HelmService.addHelmRepository(this.EndpointProvider.currentEndpoint().Id, { url: this.state.repository });
       this.Notifications.success('Helm repository added successfully');
-      this.refreshCharts([URL], true);
+      this.$state.reload();
     } catch (err) {
       this.Notifications.error('Installation error', err);
     } finally {

--- a/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.html
+++ b/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.html
@@ -31,13 +31,19 @@
           </div>
         </div>
 
+        <div class="form-group" ng-show="$ctrl.doesRepoExist()">
+          <div class="col-sm-12 small text-warning">
+            <div> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Helm repo already exists. </div>
+          </div>
+        </div>
+
         <div class="form-group">
           <div class="col-sm-12">
             <button
               type="button"
               class="btn btn-sm btn-default nomargin"
               ng-click="$ctrl.addRepository()"
-              ng-disabled="$ctrl.state.isAddingRepo || addUserHelmRepoForm.repo.$invalid"
+              ng-disabled="$ctrl.state.isAddingRepo || addUserHelmRepoForm.repo.$invalid || $ctrl.doesRepoExist()"
               analytics-on
               analytics-category="kubernetes"
               analytics-event="kubernetes-helm-add-repository"

--- a/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-add-repository/helm-add-repository.js
@@ -5,8 +5,7 @@ angular.module('portainer.kubernetes').component('helmAddRepository', {
   templateUrl: './helm-add-repository.html',
   controller,
   bindings: {
-    charts: '@',
-    refreshCharts: '<',
+    repos: '<',
     endpoint: '<',
   },
 });

--- a/app/kubernetes/components/helm/helm-templates/helm-templates.controller.js
+++ b/app/kubernetes/components/helm/helm-templates/helm-templates.controller.js
@@ -96,9 +96,9 @@ export default class HelmTemplatesController {
     this.state.reposLoading = true;
     try {
       // fetch globally set helm repo and user helm repos (parallel)
-      const { GlobalRepo, UserRepos } = await this.HelmService.getHelmRepositories(this.endpoint.Id);
-      const userHelmReposUrls = UserRepos.map((repo) => repo.URL);
-      const uniqueHelmRepos = [...new Set([GlobalRepo, ...userHelmReposUrls])].map((url) => url.toLowerCase()); // remove duplicates, to lowercase
+      const { GlobalRepository, UserRepositories } = await this.HelmService.getHelmRepositories(this.endpoint.Id);
+      const userHelmReposUrls = UserRepositories.map((repo) => repo.URL);
+      const uniqueHelmRepos = [...new Set([GlobalRepository, ...userHelmReposUrls])].map((url) => url.toLowerCase()); // remove duplicates, to lowercase
       this.state.repos = uniqueHelmRepos;
       return uniqueHelmRepos;
     } catch (err) {

--- a/app/kubernetes/components/helm/helm-templates/helm-templates.html
+++ b/app/kubernetes/components/helm/helm-templates/helm-templates.html
@@ -161,7 +161,7 @@
 
 <div class="row">
   <div class="col-sm-12">
-    <helm-add-repository charts="$ctrl.state.charts" refresh-charts="$ctrl.getLatestCharts"></helm-add-repository>
+    <helm-add-repository repos="$ctrl.state.repos"></helm-add-repository>
   </div>
 </div>
 

--- a/app/kubernetes/helpers/application/index.js
+++ b/app/kubernetes/helpers/application/index.js
@@ -469,16 +469,19 @@ class KubernetesApplicationHelper {
       helmApp.ApplicationType = KubernetesApplicationTypes.HELM;
       helmApp.KubernetesApplications = applications;
 
-      const applicationPodStatuses = applications.flatMap((app) => app.Pods).map((pod) => pod.Status);
-      const isNotReady = applicationPodStatuses.some((status) => status !== 'Running');
-
-      helmApp.Status = isNotReady ? 'Not ready' : 'Ready';
+      // the status of helm app is `Ready` based on whether the underlying RunningPodsCount of the k8s app
+      // reaches the TotalPodsCount of the app
+      const appsNotReady = applications.some((app) => app.RunningPodsCount < app.TotalPodsCount);
+      helmApp.Status = appsNotReady ? 'Not ready' : 'Ready';
 
       // use earliest date
       helmApp.CreationDate = applications.map((app) => app.CreationDate).sort((a, b) => new Date(a) - new Date(b))[0];
 
       // use first app namespace as helm app namespace
       helmApp.ResourcePool = applications[0].ResourcePool;
+
+      // required for persisting table expansion state
+      helmApp.Id = helmApp.Name.toLowerCase().replaceAll(' ', '-');
 
       return helmApp;
     });

--- a/app/kubernetes/views/applications/applications.html
+++ b/app/kubernetes/views/applications/applications.html
@@ -13,7 +13,7 @@
             <uib-tab index="0" classes="btn-sm" select="ctrl.selectTab(0)">
               <uib-tab-heading> <i class="fa fa-laptop-code space-right" aria-hidden="true"></i> Applications </uib-tab-heading>
               <kubernetes-applications-datatable
-                dataset="ctrl.applications"
+                dataset="ctrl.state.applications"
                 table-key="kubernetes.applications"
                 order-by="Name"
                 remove-action="ctrl.removeAction"
@@ -25,13 +25,13 @@
             </uib-tab>
             <uib-tab index="1" classes="btn-sm" select="ctrl.selectTab(1)">
               <uib-tab-heading> <i class="fa fa-exchange-alt space-right" aria-hidden="true"></i> Port mappings </uib-tab-heading>
-              <kubernetes-applications-ports-datatable dataset="ctrl.ports" table-key="kubernetes.applications.ports" order-by="Name" refresh-callback="ctrl.getApplications">
+              <kubernetes-applications-ports-datatable dataset="ctrl.state.ports" table-key="kubernetes.applications.ports" order-by="Name" refresh-callback="ctrl.getApplications">
               </kubernetes-applications-ports-datatable>
             </uib-tab>
             <uib-tab index="2" classes="btn-sm" select="ctrl.selectTab(2)">
               <uib-tab-heading> <i class="fa fa-th-list space-right" aria-hidden="true"></i> Stacks </uib-tab-heading>
               <kubernetes-applications-stacks-datatable
-                dataset="ctrl.stacks"
+                dataset="ctrl.state.stacks"
                 table-key="kubernetes.applications.stacks"
                 order-by="Name"
                 refresh-callback="ctrl.getApplications"

--- a/app/kubernetes/views/applications/applicationsController.js
+++ b/app/kubernetes/views/applications/applicationsController.js
@@ -39,7 +39,7 @@ class KubernetesApplicationsController {
         const promises = _.map(stack.Applications, (app) => this.KubernetesApplicationService.delete(app));
         await Promise.all(promises);
         this.Notifications.success('Stack successfully removed', stack.Name);
-        _.remove(this.stacks, { Name: stack.Name });
+        _.remove(this.state.stacks, { Name: stack.Name });
       } catch (err) {
         this.Notifications.error('Failure', err, 'Unable to remove stack');
       } finally {
@@ -72,8 +72,8 @@ class KubernetesApplicationsController {
           await this.KubernetesApplicationService.delete(application);
         }
         this.Notifications.success('Application successfully removed', application.Name);
-        const index = this.applications.indexOf(application);
-        this.applications.splice(index, 1);
+        const index = this.state.applications.indexOf(application);
+        this.state.applications.splice(index, 1);
       } catch (err) {
         this.Notifications.error('Failure', err, 'Unable to remove application');
       } finally {
@@ -95,7 +95,7 @@ class KubernetesApplicationsController {
 
   onPublishingModeClick(application) {
     this.state.activeTab = 1;
-    _.forEach(this.ports, (item) => {
+    _.forEach(this.state.ports, (item) => {
       item.Expanded = false;
       item.Highlighted = false;
       if (item.Name === application.Name && item.Ports.length > 1) {
@@ -120,9 +120,9 @@ class KubernetesApplicationsController {
             .some((label) => helmAppNames.includes(label[PodKubernetesInstanceLabel])) // check if label key is in helmAppNames
       );
 
-      this.applications = [...nonHelmApps, ...helmApplications];
-      this.stacks = KubernetesStackHelper.stacksFromApplications(applications);
-      this.ports = KubernetesApplicationHelper.portMappingsFromApplications(applications);
+      this.state.applications = [...nonHelmApps, ...helmApplications];
+      this.state.stacks = KubernetesStackHelper.stacksFromApplications(applications);
+      this.state.ports = KubernetesApplicationHelper.portMappingsFromApplications(applications);
     } catch (err) {
       this.Notifications.error('Failure', err, 'Unable to retrieve applications');
     }
@@ -138,8 +138,10 @@ class KubernetesApplicationsController {
       currentName: this.$state.$current.name,
       isAdmin: this.Authentication.isAdmin(),
       viewReady: false,
+      applications: [],
+      stacks: [],
+      ports: [],
     };
-
     await this.getApplications();
 
     this.state.viewReady = true;

--- a/app/kubernetes/views/applications/helm/helm.controller.js
+++ b/app/kubernetes/views/applications/helm/helm.controller.js
@@ -16,7 +16,7 @@ export default class KubernetesHelmApplicationController {
   async getHelmApplication() {
     try {
       this.state.dataLoading = true;
-      const releases = await this.HelmService.listReleases(this.endpoint.Id, { selector: `name=${this.state.params.name}`, namespace: 'default' });
+      const releases = await this.HelmService.listReleases(this.endpoint.Id, { selector: `name=${this.state.params.name}`, namespace: this.state.params.namespace });
       if (releases.length > 0) {
         this.state.release = releases[0];
       } else {
@@ -36,6 +36,7 @@ export default class KubernetesHelmApplicationController {
         viewReady: false,
         params: {
           name: this.$state.params.name,
+          namespace: this.$state.params.namespace,
         },
         release: {
           name: undefined,


### PR DESCRIPTION
Closes [EE-1582](https://portainer.atlassian.net/browse/EE-1582), [EE-1593](https://portainer.atlassian.net/browse/EE-1593).

## Bugfixes

- trim trailing slash and lowercase before persisting helm repo
- browser helm templates url /kubernetes/templates/templates -> /kubernetes/templates/helm
- fix publish url
- fix helm repo add refresh
- semi-fix k8s app expansion
- fix swagger variable K8sNodesLimits in api/http/handler/kubernetes/kubernetes_nodes_limits.go
- change swagger helm section from helm_charts to helm and ensure user repo endpoints are listed under helm

## Additional features (EE-1593)
- fallback to loadbalancer url for published urls