### PR TITLE
feat(ui): fix error message not last long enough for user to copy error EE-1652

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -51,7 +51,12 @@ angular.module('portainer').config([
       },
     ]);
 
-    toastr.options.timeOut = 3000;
+    toastr.options = {
+      timeOut: 3000,
+      closeButton: true,
+      progressBar: true,
+      tapToDismiss: false,
+    }
 
     Terminal.applyAddon(fit);
 


### PR DESCRIPTION
This pr will introduce these changes:

1. close button for error toast
2. progress bar showing the timeout of message 
3. TapToDismiss is disabled, timeout counter will stop and message will stay as long as mouse on toast

close EE-1652