### PR TITLE
doc(readme) fix slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Portainer CE is an open source project and is supported by the community. You ca
 Learn more about Portainers community support channels [here.](https://www.portainer.io/help_about)
 
 - Issues: https://github.com/portainer/portainer/issues
-- Slack (chat): https://portainer.slack.com/
+- Slack (chat): [https://portainer.slack.com/](https://join.slack.com/t/portainer/shared_invite/zt-txh3ljab-52QHTyjCqbe5RibC2lcjKA)
 
 You can join the Portainer Community by visiting community.portainer.io. This will give you advance notice of events, content and other related Portainer content.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Portainer CE is an open source project and is supported by the community. You ca
 Learn more about Portainers community support channels [here.](https://www.portainer.io/help_about)
 
 - Issues: https://github.com/portainer/portainer/issues
-- Slack (chat): https://portainer.io/slack/
+- Slack (chat): https://portainer.slack.com/
 
 You can join the Portainer Community by visiting community.portainer.io. This will give you advance notice of events, content and other related Portainer content.
 
@@ -59,7 +59,7 @@ You can join the Portainer Community by visiting community.portainer.io. This wi
 
 ## WORK FOR US
 
-If you are a developer, and our code in this repo makes sense to you, we would love to hear from you. We are always on the hunt for awesome devs, either freelance or employed. Drop us a line to info@portainer.io with your details and we will be in touch. 
+If you are a developer, and our code in this repo makes sense to you, we would love to hear from you. We are always on the hunt for awesome devs, either freelance or employed. Drop us a line to info@portainer.io with your details and we will be in touch.
 
 ## Privacy
 


### PR DESCRIPTION
The slack link in the readme was wrong.  It's now portainer.slack.com