### PR TITLE
feat(configurations): portainer k8s configurations lingo update for explicitness EE-1626

### DIFF
--- a/app/assets/css/vendor-override.css
+++ b/app/assets/css/vendor-override.css
@@ -287,7 +287,7 @@ json-tree .branch-preview {
   margin-top: 15px;
 }
 
-.summary {
+.bold {
   color: var(--text-summary-color);
   font-weight: 700;
 }

--- a/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
@@ -125,7 +125,7 @@
               <td>
                 <!-- LB -->
                 <span ng-if="item.ServiceType === $ctrl.KubernetesServiceTypes.LOAD_BALANCER">
-                  <span> <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i> Load balancer </span>
+                  <span> <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i> LoadBalancer </span>
                   <span class="text-muted small" style="margin-left: 5px;">
                     <span ng-if="item.LoadBalancerIPAddress">{{ item.LoadBalancerIPAddress }}</span>
                     <span ng-if="!item.LoadBalancerIPAddress">pending</span>
@@ -133,10 +133,10 @@
                 </span>
                 <!-- Internal -->
                 <span ng-if="item.ServiceType === $ctrl.KubernetesServiceTypes.CLUSTER_IP">
-                  <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i> Internal
+                  <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i> ClusterIP
                 </span>
                 <!-- Cluster -->
-                <span ng-if="item.ServiceType === $ctrl.KubernetesServiceTypes.NODE_PORT"> <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i> Cluster </span>
+                <span ng-if="item.ServiceType === $ctrl.KubernetesServiceTypes.NODE_PORT"> <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i> NodePort </span>
               </td>
               <!-- Exposed port -->
               <td>

--- a/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
+++ b/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
@@ -67,7 +67,7 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
         <button type="button" class="btn btn-sm btn-primary" ui-sref="kubernetes.configurations.new" data-cy="k8sConfig-addConfigWithFormButton">
-          <i class="fa fa-plus space-right" aria-hidden="true"></i>Add ConfigMaps and Secrets with form
+          <i class="fa fa-plus space-right" aria-hidden="true"></i>Add with form
         </button>
         <button type="button" class="btn btn-sm btn-primary" ui-sref="kubernetes.deploy" data-cy="k8sConfig-deployFromManifestButton">
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Create from manifest

--- a/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
+++ b/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
@@ -67,7 +67,7 @@
           <i class="fa fa-trash-alt space-right" aria-hidden="true"></i>Remove
         </button>
         <button type="button" class="btn btn-sm btn-primary" ui-sref="kubernetes.configurations.new" data-cy="k8sConfig-addConfigWithFormButton">
-          <i class="fa fa-plus space-right" aria-hidden="true"></i>Add configuration with form
+          <i class="fa fa-plus space-right" aria-hidden="true"></i>Add ConfigMaps and Secrets with form
         </button>
         <button type="button" class="btn btn-sm btn-primary" ui-sref="kubernetes.deploy" data-cy="k8sConfig-deployFromManifestButton">
           <i class="fa fa-plus space-right" aria-hidden="true"></i>Create from manifest

--- a/app/kubernetes/components/kubernetes-sidebar/kubernetes-sidebar.html
+++ b/app/kubernetes/components/kubernetes-sidebar/kubernetes-sidebar.html
@@ -49,7 +49,7 @@
   class-name="sidebar-list"
   data-cy="k8sSidebar-configurations"
 >
-  Configurations
+  ConfigMaps & Secrets
 </sidebar-menu-item>
 
 <sidebar-menu-item path="kubernetes.volumes" path-params="{ endpointId: $ctrl.endpointId }" icon-class="fa-database fa-fw" class-name="sidebar-list" data-cy="k8sSidebar-volumes">

--- a/app/kubernetes/converters/application.js
+++ b/app/kubernetes/converters/application.js
@@ -299,11 +299,11 @@ class KubernetesApplicationConverter {
     if (app.ServiceType === KubernetesServiceTypes.LOAD_BALANCER) {
       res.PublishingType = KubernetesApplicationPublishingTypes.LOAD_BALANCER;
     } else if (app.ServiceType === KubernetesServiceTypes.NODE_PORT) {
-      res.PublishingType = KubernetesApplicationPublishingTypes.CLUSTER;
+      res.PublishingType = KubernetesApplicationPublishingTypes.NODE_PORT;
     } else if (app.ServiceType === KubernetesServiceTypes.CLUSTER_IP && isIngress) {
       res.PublishingType = KubernetesApplicationPublishingTypes.INGRESS;
     } else {
-      res.PublishingType = KubernetesApplicationPublishingTypes.INTERNAL;
+      res.PublishingType = KubernetesApplicationPublishingTypes.CLUSTER_IP;
     }
 
     if (app.Pods && app.Pods.length) {

--- a/app/kubernetes/converters/service.js
+++ b/app/kubernetes/converters/service.js
@@ -42,7 +42,7 @@ class KubernetesServiceConverter {
     res.StackName = formValues.StackName ? formValues.StackName : formValues.Name;
     res.ApplicationOwner = formValues.ApplicationOwner;
     res.ApplicationName = formValues.Name;
-    if (formValues.PublishingType === KubernetesApplicationPublishingTypes.CLUSTER) {
+    if (formValues.PublishingType === KubernetesApplicationPublishingTypes.NODE_PORT) {
       res.Type = KubernetesServiceTypes.NODE_PORT;
     } else if (formValues.PublishingType === KubernetesApplicationPublishingTypes.LOAD_BALANCER) {
       res.Type = KubernetesServiceTypes.LOAD_BALANCER;

--- a/app/kubernetes/filters/applicationFilters.js
+++ b/app/kubernetes/filters/applicationFilters.js
@@ -26,11 +26,11 @@ angular
       var status = _.toLower(text);
       switch (status) {
         case 'loadbalancer':
-          return 'Load balancer';
+          return 'LoadBalancer';
         case 'clusterip':
-          return 'Internal';
+          return 'ClusterIP';
         case 'nodeport':
-          return 'Cluster';
+          return 'NodePort';
       }
     };
   })

--- a/app/kubernetes/filters/applicationFilters.js
+++ b/app/kubernetes/filters/applicationFilters.js
@@ -1,6 +1,5 @@
 import _ from 'lodash-es';
 import { KubernetesApplicationDataAccessPolicies } from 'Kubernetes/models/application/models';
-import { KubernetesServiceTypes } from 'Kubernetes/models/service/models';
 import { KubernetesApplicationTypes, KubernetesApplicationTypeStrings } from 'Kubernetes/models/application/models';
 import { KubernetesPodNodeAffinityNodeSelectorRequirementOperators } from 'Kubernetes/pod/models';
 
@@ -31,19 +30,6 @@ angular
           return 'ClusterIP';
         case 'nodeport':
           return 'NodePort';
-      }
-    };
-  })
-  .filter('kubernetesApplicationPortsTableHeaderText', function () {
-    'use strict';
-    return function (serviceType) {
-      switch (serviceType) {
-        case KubernetesServiceTypes.LOAD_BALANCER:
-          return 'Load balancer';
-        case KubernetesServiceTypes.CLUSTER_IP:
-          return 'Application';
-        case KubernetesServiceTypes.NODE_PORT:
-          return 'Cluster node';
       }
     };
   })

--- a/app/kubernetes/filters/configurationFilters.js
+++ b/app/kubernetes/filters/configurationFilters.js
@@ -5,9 +5,9 @@ angular.module('portainer.kubernetes').filter('kubernetesConfigurationTypeText',
   return function (type) {
     switch (type) {
       case KubernetesConfigurationTypes.SECRET:
-        return 'Sensitive';
+        return 'Secret';
       case KubernetesConfigurationTypes.CONFIGMAP:
-        return 'Non-sensitive';
+        return 'ConfigMap';
     }
   };
 });

--- a/app/kubernetes/models/application/formValues.js
+++ b/app/kubernetes/models/application/formValues.js
@@ -22,7 +22,7 @@ export function KubernetesApplicationFormValues() {
   this.DataAccessPolicy = KubernetesApplicationDataAccessPolicies.SHARED;
   this.PersistedFolders = []; // KubernetesApplicationPersistedFolderFormValue lis;
   this.Configurations = []; // KubernetesApplicationConfigurationFormValue lis;
-  this.PublishingType = KubernetesApplicationPublishingTypes.INTERNAL;
+  this.PublishingType = KubernetesApplicationPublishingTypes.CLUSTER_IP;
   this.PublishedPorts = []; // KubernetesApplicationPublishedPortFormValue lis;
   this.PlacementType = KubernetesApplicationPlacementTypes.PREFERRED;
   this.Placements = []; // KubernetesApplicationPlacementFormValue lis;

--- a/app/kubernetes/models/application/models/constants.js
+++ b/app/kubernetes/models/application/models/constants.js
@@ -25,8 +25,8 @@ export const KubernetesApplicationTypeStrings = Object.freeze({
 });
 
 export const KubernetesApplicationPublishingTypes = Object.freeze({
-  INTERNAL: 1,
-  CLUSTER: 2,
+  CLUSTER_IP: 1,
+  NODE_PORT: 2,
   LOAD_BALANCER: 3,
   INGRESS: 4,
 });

--- a/app/kubernetes/views/applications/create/createApplication.html
+++ b/app/kubernetes/views/applications/create/createApplication.html
@@ -1239,498 +1239,515 @@
                 </div>
                 <!-- #region PUBLISHING OPTIONS -->
                 <div class="form-group">
-                  <div class="col-sm-12 small text-muted">
-                    Select how you want to publish your application.
+                  <div class="col-sm-12">
+                    <label for="enable_port_publishing" class="control-label text-left">
+                      Enable publishing for this application
+                    </label>
+                    <label class="switch" style="margin-left: 20px;">
+                      <input type="checkbox" class="form-control" name="enable_port_publishing" ng-model="ctrl.formValues.IsPublishingService" />
+                      <i></i>
+                    </label>
                   </div>
                 </div>
 
-                <!-- publishing options -->
-                <div class="form-group" style="margin-bottom: 0;">
-                  <div class="boxselector_wrapper">
-                    <div ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
-                      <input
-                        type="radio"
-                        id="publishing_internal"
-                        ng-value="ctrl.ApplicationPublishingTypes.INTERNAL"
-                        ng-model="ctrl.formValues.PublishingType"
-                        ng-change="ctrl.onChangePublishedPorts()"
-                        ng-disabled="ctrl.isPublishingTypeEditDisabled()"
-                        data-cy="k8sAppCreate-internalPublishButton"
-                      />
-                      <label
-                        for="publishing_internal"
-                        ng-if="
-                          !ctrl.isPublishingTypeEditDisabled() ||
-                          (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INTERNAL)
-                        "
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Internal
-                        </div>
-                        <p>Internal communications inside the cluster only</p>
-                      </label>
-                      <label
-                        for="publishing_internal"
-                        ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INTERNAL"
-                        tooltip-append-to-body="true"
-                        tooltip-placement="bottom"
-                        tooltip-class="portainer-tooltip"
-                        uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
-                        style="cursor: pointer; border-color: #767676;"
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Internal
-                        </div>
-                        <p>Internal communications inside the cluster only</p>
-                      </label>
-                    </div>
-
-                    <div ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
-                      <input
-                        type="radio"
-                        id="publishing_cluster"
-                        ng-value="ctrl.ApplicationPublishingTypes.CLUSTER"
-                        ng-model="ctrl.formValues.PublishingType"
-                        ng-change="ctrl.onChangePublishedPorts()"
-                        ng-disabled="ctrl.isPublishingTypeEditDisabled()"
-                        data-cy="k8sAppCreate-clusterPublishButton"
-                      />
-                      <label
-                        for="publishing_cluster"
-                        ng-if="
-                          !ctrl.isPublishingTypeEditDisabled() ||
-                          (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
-                        "
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Cluster
-                        </div>
-                        <p>Publish this application via a port on all nodes of the cluster</p>
-                      </label>
-                      <label
-                        for="publishing_cluster"
-                        ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.CLUSTER"
-                        tooltip-append-to-body="true"
-                        tooltip-placement="bottom"
-                        tooltip-class="portainer-tooltip"
-                        uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
-                        style="cursor: pointer; border-color: #767676;"
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Cluster
-                        </div>
-                        <p>Publish this application via a port on all nodes of the cluster</p>
-                      </label>
-                    </div>
-                    <div ng-if="ctrl.publishViaIngressEnabled()" ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
-                      <input
-                        type="radio"
-                        id="publishing_ingress"
-                        ng-value="ctrl.ApplicationPublishingTypes.INGRESS"
-                        ng-model="ctrl.formValues.PublishingType"
-                        ng-change="ctrl.onChangePublishedPorts()"
-                        ng-disabled="ctrl.isPublishingTypeEditDisabled()"
-                        data-cy="k8sAppCreate-ingressPublishButton"
-                      />
-                      <label
-                        for="publishing_ingress"
-                        ng-if="
-                          !ctrl.isPublishingTypeEditDisabled() ||
-                          (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
-                        "
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-route" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Ingress
-                        </div>
-                        <p>Publish this application via a HTTP route</p>
-                      </label>
-                      <label
-                        for="publishing_ingress"
-                        ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INGRESS"
-                        tooltip-append-to-body="true"
-                        tooltip-placement="bottom"
-                        tooltip-class="portainer-tooltip"
-                        uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
-                        style="cursor: pointer; border-color: #767676;"
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-route" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Ingress
-                        </div>
-                        <p>Publish this application via a HTTP route</p>
-                      </label>
-                    </div>
-                    <div ng-if="ctrl.publishViaLoadBalancerEnabled()" ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
-                      <input
-                        type="radio"
-                        id="publishing_loadbalancer"
-                        ng-value="ctrl.ApplicationPublishingTypes.LOAD_BALANCER"
-                        ng-model="ctrl.formValues.PublishingType"
-                        ng-change="ctrl.onChangePublishedPorts()"
-                        ng-disabled="ctrl.isPublishingTypeEditDisabled()"
-                        data-cy="k8sAppCreate-lbPublichButton"
-                      />
-                      <label
-                        for="publishing_loadbalancer"
-                        ng-if="
-                          !ctrl.isPublishingTypeEditDisabled() ||
-                          (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER)
-                        "
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Load balancer
-                        </div>
-                        <p>Publish this application via a load balancer</p>
-                      </label>
-                      <label
-                        for="publishing_loadbalancer"
-                        ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.LOAD_BALANCER"
-                        tooltip-append-to-body="true"
-                        tooltip-placement="bottom"
-                        tooltip-class="portainer-tooltip"
-                        uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
-                        style="cursor: pointer; border-color: #767676;"
-                      >
-                        <div class="boxselector_header">
-                          <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i>
-                          Load balancer
-                        </div>
-                        <p>Publish this application via a load balancer</p>
-                      </label>
+                <span ng-if="ctrl.formValues.IsPublishingService">
+                  <div class="form-group">
+                    <div class="col-sm-12 small text-muted">
+                      Select how you want to publish your application.
                     </div>
                   </div>
-                </div>
-                <!-- #endregion -->
 
-                <!-- #region PUBLISHED PORTS -->
-                <div class="form-group">
-                  <div class="col-sm-12" style="margin-top: 5px;">
-                    <label class="control-label text-left">Published ports</label>
-                    <span class="label label-default interactive" style="margin-left: 10px;" ng-click="ctrl.addPublishedPort()" data-cy="k8sAppCreate-addNewPortButton">
-                      <i class="fa fa-plus-circle" aria-hidden="true"></i> publish a new port
-                    </span>
-                  </div>
-
-                  <div
-                    class="col-sm-12 small text-muted"
-                    style="margin-top: 15px;"
-                    ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER && ctrl.formValues.PublishedPorts.length > 0"
-                  >
-                    <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
-                    When publishing a port in cluster mode, the node port is optional. If left empty Kubernetes will use a random port number. If you wish to specify a port, use a
-                    port number inside the default range <code>30000-32767</code>.
-                  </div>
-                  <div ng-if="ctrl.isNotInternalAndHasNoPublishedPorts()" class="col-sm-12 small text-warning" style="margin-top: 12px;">
-                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> At least one published port must be defined.
-                  </div>
-
-                  <div class="col-sm-12 form-inline" style="margin-top: 10px;">
-                    <!-- #region INPUTS -->
-                    <div
-                      ng-repeat-start="publishedPort in ctrl.formValues.PublishedPorts"
-                      style="margin-top: 2px;"
-                      tooltip-append-to-body="true"
-                      tooltip-placement="bottom"
-                      tooltip-class="portainer-tooltip"
-                      tooltip-enable="ctrl.disableLoadBalancerEdit()"
-                      uib-tooltip="Edition is not allowed while the Load Balancer is in 'Pending' state"
-                    >
-                      <div
-                        class="input-group input-group-sm"
-                        ng-class="{
-                          striked: publishedPort.NeedsDeletion,
-                          'col-sm-2': ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS,
-                          'col-sm-3': ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INGRESS
-                        }"
-                      >
-                        <span class="input-group-addon">container port</span>
+                  <!-- publishing options -->
+                  <div class="form-group" style="margin-bottom: 0;">
+                    <div class="boxselector_wrapper">
+                      <div ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
                         <input
-                          type="number"
-                          class="form-control"
-                          name="container_port_{{ $index }}"
-                          ng-model="publishedPort.ContainerPort"
-                          placeholder="80"
-                          ng-min="1"
-                          ng-max="65535"
-                          ng-required="!publishedPort.NeedsDeletion"
-                          ng-change="ctrl.onChangePortMappingContainerPort()"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-containerPort_{{ $index }}"
-                        />
-                      </div>
-
-                      <div
-                        class="col-sm-3 input-group input-group-sm"
-                        ng-class="{ striked: publishedPort.NeedsDeletion }"
-                        ng-if="
-                          (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER) ||
-                          (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
-                        "
-                      >
-                        <span class="input-group-addon">node port</span>
-                        <input
-                          name="published_node_port_{{ $index }}"
-                          type="number"
-                          class="form-control"
-                          ng-model="publishedPort.NodePort"
-                          placeholder="30080"
-                          ng-min="30000"
-                          ng-max="32767"
-                          ng-change="ctrl.onChangePortMappingNodePort()"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-nodePort_{{ $index }}"
-                          />
-                      </div>
-
-                      <div
-                        class="col-sm-3 input-group input-group-sm"
-                        ng-class="{ striked: publishedPort.NeedsDeletion }"
-                        ng-if="
-                          (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER) ||
-                          (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER)
-                        "
-                      >
-                        <span class="input-group-addon">load balancer port</span>
-                        <input
-                          type="number"
-                          class="form-control"
-                          name="load_balancer_port_{{ $index }}"
-                          ng-model="publishedPort.LoadBalancerPort"
-                          placeholder="80"
-                          value="8080"
-                          ng-min="1"
-                          ng-max="65535"
-                          ng-required="!publishedPort.NeedsDeletion"
-                          ng-change="ctrl.onChangePortMappingLoadBalancer()"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-lbPortInput_{{ $index }}"
-                        />
-                      </div>
-
-                      <div
-                        class="col-sm-2 input-group input-group-sm"
-                        ng-class="{ striked: publishedPort.NeedsDeletion }"
-                        ng-if="
-                          (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
-                          (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
-                        "
-                      >
-                        <span class="input-group-addon">ingress</span>
-                        <select
-                          class="form-control"
-                          name="ingress_class_{{ $index }}"
-                          ng-model="publishedPort.IngressName"
-                          ng-options="ingress.Name as ingress.Name for ingress in ctrl.ingresses"
-                          ng-required="!publishedPort.NeedsDeletion"
-                          ng-change="ctrl.onChangePortMappingIngress($index)"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-ingressSelect_{{ $index }}"
-                        >
-                          <option selected disabled hidden value="">Select an ingress</option>
-                        </select>
-                      </div>
-
-                      <div
-                        class="col-sm-2 input-group input-group-sm"
-                        ng-class="{ striked: publishedPort.NeedsDeletion }"
-                        ng-if="
-                          (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
-                          (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
-                        "
-                      >
-                        <span class="input-group-addon">hostname</span>
-                        <select
-                          class="form-control"
-                          name="ingress_hostname_{{ $index }}"
-                          ng-model="publishedPort.IngressHost"
-                          ng-options="host as (host | kubernetesApplicationIngressEmptyHostname) for host in publishedPort.IngressHosts"
+                          type="radio"
+                          id="publishing_internal"
+                          ng-value="ctrl.ApplicationPublishingTypes.INTERNAL"
+                          ng-model="ctrl.formValues.PublishingType"
                           ng-change="ctrl.onChangePublishedPorts()"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-hostnameSelect_{{ $index }}"
-                        >
-                          <option selected disabled hidden value="">Select a hostname</option>
-                        </select>
-                      </div>
-
-                      <div
-                        class="col-sm-2 input-group input-group-sm"
-                        ng-class="{ striked: publishedPort.NeedsDeletion }"
-                        ng-if="
-                          (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
-                          (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
-                        "
-                      >
-                        <span class="input-group-addon">route</span>
-                        <input
-                          class="form-control"
-                          name="ingress_route_{{ $index }}"
-                          ng-model="publishedPort.IngressRoute"
-                          placeholder="route"
-                          ng-required="!publishedPort.NeedsDeletion"
-                          ng-change="ctrl.onChangePortMappingIngressRoute()"
-                          ng-pattern="/^(\/?[a-zA-Z0-9]+([a-zA-Z0-9-/_]*[a-zA-Z0-9])?|[a-zA-Z0-9]+)|(\/){1}$/"
-                          ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
-                          data-cy="k8sAppCreate-ingressRoute_{{ $index }}"
+                          ng-disabled="ctrl.isPublishingTypeEditDisabled()"
+                          data-cy="k8sAppCreate-internalPublishButton"
                         />
+                        <label
+                          for="publishing_internal"
+                          ng-if="
+                            !ctrl.isPublishingTypeEditDisabled() ||
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INTERNAL)
+                          "
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i>
+                            ClusterIP
+                          </div>
+                          <p>Internal communications inside the cluster only</p>
+                        </label>
+                        <label
+                          for="publishing_internal"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INTERNAL"
+                          tooltip-append-to-body="true"
+                          tooltip-placement="bottom"
+                          tooltip-class="portainer-tooltip"
+                          uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
+                          style="cursor: pointer; border-color: #767676;"
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-list-alt" aria-hidden="true" style="margin-right: 2px;"></i>
+                            ClusterIP
+                          </div>
+                          <p>Internal communications inside the cluster only</p>
+                        </label>
                       </div>
 
-                      <div class="input-group col-sm-2 input-group-sm">
-                        <div class="btn-group btn-group-sm" ng-class="{ striked: publishedPort.NeedsDeletion }">
-                          <label
-                            class="btn btn-primary"
-                            ng-model="publishedPort.Protocol"
-                            uib-btn-radio="'TCP'"
-                            ng-change="ctrl.onChangePortProtocol($index)"
-                            ng-disabled="ctrl.isProtocolOptionDisabled($index, 'TCP')"
-                            data-cy="k8sAppCreate-TCPButton_{{ $index }}"
-                            >TCP</label
-                          >
-                          <label
-                            class="btn btn-primary"
-                            ng-model="publishedPort.Protocol"
-                            uib-btn-radio="'UDP'"
-                            ng-change="ctrl.onChangePortProtocol($index)"
-                            ng-disabled="ctrl.isProtocolOptionDisabled($index, 'UDP')"
-                            data-cy="k8sAppCreate-UDPButton_{{ $index }}"
-                            >UDP</label
-                          >
-                        </div>
-                        <button
-                          ng-if="!ctrl.disableLoadBalancerEdit() && !publishedPort.NeedsDeletion"
-                          class="btn btn-sm btn-danger"
-                          type="button"
-                          ng-click="ctrl.removePublishedPort($index)"
-                          data-cy="k8sAppCreate-rmPortButton_{{ $index }}"
+                      <div ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
+                        <input
+                          type="radio"
+                          id="publishing_cluster"
+                          ng-value="ctrl.ApplicationPublishingTypes.CLUSTER"
+                          ng-model="ctrl.formValues.PublishingType"
+                          ng-change="ctrl.onChangePublishedPorts()"
+                          ng-disabled="ctrl.isPublishingTypeEditDisabled()"
+                          data-cy="k8sAppCreate-clusterPublishButton"
+                        />
+                        <label
+                          for="publishing_cluster"
+                          ng-if="
+                            !ctrl.isPublishingTypeEditDisabled() ||
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
+                          "
                         >
-                          <i class="fa fa-trash-alt" aria-hidden="true"></i>
-                        </button>
-                        <button
-                          ng-if="publishedPort.NeedsDeletion && ctrl.formValues.PublishingType === ctrl.savedFormValues.PublishingType"
-                          class="btn btn-sm btn-primary"
-                          type="button"
-                          ng-click="ctrl.restorePublishedPort($index)"
-                          data-cy="k8sAppCreate-restorePortButton_{{ $index }}"
+                          <div class="boxselector_header">
+                            <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i>
+                            NodePort
+                          </div>
+                          <p>Publish this application via a port on all nodes of the cluster</p>
+                        </label>
+                        <label
+                          for="publishing_cluster"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.CLUSTER"
+                          tooltip-append-to-body="true"
+                          tooltip-placement="bottom"
+                          tooltip-class="portainer-tooltip"
+                          uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
+                          style="cursor: pointer; border-color: #767676;"
                         >
-                          <i class="fa fa-trash-restore" aria-hidden="true"></i>
-                        </button>
+                          <div class="boxselector_header">
+                            <i class="fa fa-list" aria-hidden="true" style="margin-right: 2px;"></i>
+                            NodePort
+                          </div>
+                          <p>Publish this application via a port on all nodes of the cluster</p>
+                        </label>
+                      </div>
+                      <div ng-if="ctrl.publishViaIngressEnabled()" ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
+                        <input
+                          type="radio"
+                          id="publishing_ingress"
+                          ng-value="ctrl.ApplicationPublishingTypes.INGRESS"
+                          ng-model="ctrl.formValues.PublishingType"
+                          ng-change="ctrl.onChangePublishedPorts()"
+                          ng-disabled="ctrl.isPublishingTypeEditDisabled()"
+                          data-cy="k8sAppCreate-ingressPublishButton"
+                        />
+                        <label
+                          for="publishing_ingress"
+                          ng-if="
+                            !ctrl.isPublishingTypeEditDisabled() ||
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
+                          "
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-route" aria-hidden="true" style="margin-right: 2px;"></i>
+                            Ingress
+                          </div>
+                          <p>Publish this application via a HTTP route</p>
+                        </label>
+                        <label
+                          for="publishing_ingress"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INGRESS"
+                          tooltip-append-to-body="true"
+                          tooltip-placement="bottom"
+                          tooltip-class="portainer-tooltip"
+                          uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
+                          style="cursor: pointer; border-color: #767676;"
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-route" aria-hidden="true" style="margin-right: 2px;"></i>
+                            Ingress
+                          </div>
+                          <p>Publish this application via a HTTP route</p>
+                        </label>
+                      </div>
+                      <div ng-if="ctrl.publishViaLoadBalancerEnabled()" ng-style="{ color: ctrl.isPublishingTypeEditDisabled() ? '#767676' : '' }">
+                        <input
+                          type="radio"
+                          id="publishing_loadbalancer"
+                          ng-value="ctrl.ApplicationPublishingTypes.LOAD_BALANCER"
+                          ng-model="ctrl.formValues.PublishingType"
+                          ng-change="ctrl.onChangePublishedPorts()"
+                          ng-disabled="ctrl.isPublishingTypeEditDisabled()"
+                          data-cy="k8sAppCreate-lbPublichButton"
+                        />
+                        <label
+                          for="publishing_loadbalancer"
+                          ng-if="
+                            !ctrl.isPublishingTypeEditDisabled() ||
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER)
+                          "
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i>
+                            Load balancer
+                          </div>
+                          <p>Publish this application via a load balancer</p>
+                        </label>
+                        <label
+                          for="publishing_loadbalancer"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.LOAD_BALANCER"
+                          tooltip-append-to-body="true"
+                          tooltip-placement="bottom"
+                          tooltip-class="portainer-tooltip"
+                          uib-tooltip="Changing the publishing mode is not allowed until you delete all previously existing ports"
+                          style="cursor: pointer; border-color: #767676;"
+                        >
+                          <div class="boxselector_header">
+                            <i class="fa fa-project-diagram" aria-hidden="true" style="margin-right: 2px;"></i>
+                            Load balancer
+                          </div>
+                          <p>Publish this application via a load balancer</p>
+                        </label>
                       </div>
                     </div>
-                    <!-- #endregion -->
+                  </div>
+                  <!-- #endregion -->
 
-                    <!-- #region VALIDATION -->
+                  <!-- #region PUBLISHED PORTS -->
+                  <div class="form-group">
+                    <div class="col-sm-12" style="margin-top: 5px;">
+                      <label class="control-label text-left">Published ports</label>
+                      <span class="label label-default interactive" style="margin-left: 10px;" ng-click="ctrl.addPublishedPort()" data-cy="k8sAppCreate-addNewPortButton">
+                        <i class="fa fa-plus-circle" aria-hidden="true"></i> publish a new port
+                      </span>
+                    </div>
+
                     <div
-                      ng-repeat-end
-                      ng-show="
-                        kubernetesApplicationCreationForm['container_port_' + $index].$invalid ||
-                        kubernetesApplicationCreationForm['published_node_port_' + $index].$invalid ||
-                        kubernetesApplicationCreationForm['load_balancer_port_' + $index].$invalid ||
-                        kubernetesApplicationCreationForm['ingress_class_' + $index].$invalid ||
-                        kubernetesApplicationCreationForm['ingress_route_' + $index].$invalid ||
-                        ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined ||
-                        (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER && ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined) ||
-                        (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS &&
-                          ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined) ||
-                        (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER &&
-                          ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined)
-                      "
+                      class="col-sm-12 small text-muted"
+                      style="margin-top: 15px;"
+                      ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER && ctrl.formValues.PublishedPorts.length > 0"
                     >
-                      <div class="col-sm-3 input-group input-group-sm">
-                        <div
-                          class="small text-warning"
-                          style="margin-top: 5px;"
-                          ng-if="
-                            kubernetesApplicationCreationForm['container_port_' + $index].$invalid || ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined
-                          "
-                        >
-                          <div ng-messages="kubernetesApplicationCreationForm['container_port_'+$index].$error">
-                            <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number is required.</p>
-                            <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number must be inside the range 1-65535.</p>
-                            <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number must be inside the range 1-65535.</p>
-                          </div>
-                          <p ng-if="ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined">
-                            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This port is already used.
-                          </p>
-                        </div>
-                      </div>
+                      <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
+                      When publishing a port in cluster mode, the node port is optional. If left empty Kubernetes will use a random port number. If you wish to specify a port, use
+                      a port number inside the default range <code>30000-32767</code>.
+                    </div>
+                    <div ng-if="ctrl.hasNoPublishedPorts()" class="col-sm-12 small text-warning" style="margin-top: 12px;">
+                      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> At least one published port must be defined.
+                    </div>
 
-                      <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER">
+                    <div class="col-sm-12 form-inline" style="margin-top: 10px;">
+                      <!-- #region INPUTS -->
+                      <div
+                        ng-repeat-start="publishedPort in ctrl.formValues.PublishedPorts"
+                        style="margin-top: 2px;"
+                        tooltip-append-to-body="true"
+                        tooltip-placement="bottom"
+                        tooltip-class="portainer-tooltip"
+                        tooltip-enable="ctrl.disableLoadBalancerEdit()"
+                        uib-tooltip="Edition is not allowed while the Load Balancer is in 'Pending' state"
+                      >
                         <div
-                          class="small text-warning"
-                          style="margin-top: 5px;"
-                          ng-if="
-                            kubernetesApplicationCreationForm['published_node_port_' + $index].$invalid || ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined
-                          "
+                          class="input-group input-group-sm"
+                          ng-class="{
+                            striked: publishedPort.NeedsDeletion,
+                            'col-sm-2': ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS,
+                            'col-sm-3': ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INGRESS
+                          }"
                         >
-                          <div ng-messages="kubernetesApplicationCreationForm['published_node_port_'+$index].$error">
-                            <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Node port number must be inside the range 30000-32767.</p>
-                            <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Node port number must be inside the range 30000-32767.</p>
-                          </div>
-                          <p ng-if="ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined">
-                            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This port is already used.
-                          </p>
+                          <span class="input-group-addon">container port</span>
+                          <input
+                            type="number"
+                            class="form-control"
+                            name="container_port_{{ $index }}"
+                            ng-model="publishedPort.ContainerPort"
+                            placeholder="80"
+                            ng-min="1"
+                            ng-max="65535"
+                            ng-required="!publishedPort.NeedsDeletion"
+                            ng-change="ctrl.onChangePortMappingContainerPort()"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-containerPort_{{ $index }}"
+                          />
                         </div>
-                      </div>
 
-                      <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS">
-                        <div class="small text-warning" style="margin-top: 5px;" ng-if="kubernetesApplicationCreationForm['ingress_class_' + $index].$invalid">
-                          <div ng-messages="kubernetesApplicationCreationForm['ingress_class_'+$index].$error">
-                            <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Ingress selection is required.</p>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS">
                         <div
-                          class="small text-warning"
-                          style="margin-top: 5px;"
+                          class="col-sm-3 input-group input-group-sm"
+                          ng-class="{ striked: publishedPort.NeedsDeletion }"
                           ng-if="
-                            kubernetesApplicationCreationForm['ingress_route_' + $index].$invalid || ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
                           "
                         >
-                          <div ng-messages="kubernetesApplicationCreationForm['ingress_route_'+$index].$error">
-                            <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Route is required.</p>
-                            <p ng-message="pattern"
-                              ><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This field must consist of alphanumeric characters or the special characters: '-', '_'
-                              or '/'. It must start and end with an alphanumeric character (e.g. 'my-route', or 'route-123').</p
+                          <span class="input-group-addon">node port</span>
+                          <input
+                            name="published_node_port_{{ $index }}"
+                            type="number"
+                            class="form-control"
+                            ng-model="publishedPort.NodePort"
+                            placeholder="30080"
+                            ng-min="30000"
+                            ng-max="32767"
+                            ng-change="ctrl.onChangePortMappingNodePort()"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-nodePort_{{ $index }}"
+                          />
+                        </div>
+
+                        <div
+                          class="col-sm-3 input-group input-group-sm"
+                          ng-class="{ striked: publishedPort.NeedsDeletion }"
+                          ng-if="
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER)
+                          "
+                        >
+                          <span class="input-group-addon">load balancer port</span>
+                          <input
+                            type="number"
+                            class="form-control"
+                            name="load_balancer_port_{{ $index }}"
+                            ng-model="publishedPort.LoadBalancerPort"
+                            placeholder="80"
+                            value="8080"
+                            ng-min="1"
+                            ng-max="65535"
+                            ng-required="!publishedPort.NeedsDeletion"
+                            ng-change="ctrl.onChangePortMappingLoadBalancer()"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-lbPortInput_{{ $index }}"
+                          />
+                        </div>
+
+                        <div
+                          class="col-sm-2 input-group input-group-sm"
+                          ng-class="{ striked: publishedPort.NeedsDeletion }"
+                          ng-if="
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
+                          "
+                        >
+                          <span class="input-group-addon">ingress</span>
+                          <select
+                            class="form-control"
+                            name="ingress_class_{{ $index }}"
+                            ng-model="publishedPort.IngressName"
+                            ng-options="ingress.Name as ingress.Name for ingress in ctrl.ingresses"
+                            ng-required="!publishedPort.NeedsDeletion"
+                            ng-change="ctrl.onChangePortMappingIngress($index)"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-ingressSelect_{{ $index }}"
+                          >
+                            <option selected disabled hidden value="">Select an ingress</option>
+                          </select>
+                        </div>
+
+                        <div
+                          class="col-sm-2 input-group input-group-sm"
+                          ng-class="{ striked: publishedPort.NeedsDeletion }"
+                          ng-if="
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
+                          "
+                        >
+                          <span class="input-group-addon">hostname</span>
+                          <select
+                            class="form-control"
+                            name="ingress_hostname_{{ $index }}"
+                            ng-model="publishedPort.IngressHost"
+                            ng-options="host as (host | kubernetesApplicationIngressEmptyHostname) for host in publishedPort.IngressHosts"
+                            ng-change="ctrl.onChangePublishedPorts()"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-hostnameSelect_{{ $index }}"
+                          >
+                            <option selected disabled hidden value="">Select a hostname</option>
+                          </select>
+                        </div>
+
+                        <div
+                          class="col-sm-2 input-group input-group-sm"
+                          ng-class="{ striked: publishedPort.NeedsDeletion }"
+                          ng-if="
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS)
+                          "
+                        >
+                          <span class="input-group-addon">route</span>
+                          <input
+                            class="form-control"
+                            name="ingress_route_{{ $index }}"
+                            ng-model="publishedPort.IngressRoute"
+                            placeholder="route"
+                            ng-required="!publishedPort.NeedsDeletion"
+                            ng-change="ctrl.onChangePortMappingIngressRoute()"
+                            ng-pattern="/^(\/?[a-zA-Z0-9]+([a-zA-Z0-9-/_]*[a-zA-Z0-9])?|[a-zA-Z0-9]+)|(\/){1}$/"
+                            ng-disabled="ctrl.disableLoadBalancerEdit() || ctrl.isEditAndNotNewPublishedPort($index)"
+                            data-cy="k8sAppCreate-ingressRoute_{{ $index }}"
+                          />
+                        </div>
+
+                        <div class="input-group col-sm-2 input-group-sm">
+                          <div class="btn-group btn-group-sm" ng-class="{ striked: publishedPort.NeedsDeletion }">
+                            <label
+                              class="btn btn-primary"
+                              ng-model="publishedPort.Protocol"
+                              uib-btn-radio="'TCP'"
+                              ng-change="ctrl.onChangePortProtocol($index)"
+                              ng-disabled="ctrl.isProtocolOptionDisabled($index, 'TCP')"
+                              data-cy="k8sAppCreate-TCPButton_{{ $index }}"
+                              >TCP</label
+                            >
+                            <label
+                              class="btn btn-primary"
+                              ng-model="publishedPort.Protocol"
+                              uib-btn-radio="'UDP'"
+                              ng-change="ctrl.onChangePortProtocol($index)"
+                              ng-disabled="ctrl.isProtocolOptionDisabled($index, 'UDP')"
+                              data-cy="k8sAppCreate-UDPButton_{{ $index }}"
+                              >UDP</label
                             >
                           </div>
-                          <p ng-if="ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined">
-                            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This route is already used.
-                          </p>
+                          <button
+                            ng-if="!ctrl.disableLoadBalancerEdit() && !publishedPort.NeedsDeletion"
+                            class="btn btn-sm btn-danger"
+                            type="button"
+                            ng-click="ctrl.removePublishedPort($index)"
+                            data-cy="k8sAppCreate-rmPortButton_{{ $index }}"
+                          >
+                            <i class="fa fa-trash-alt" aria-hidden="true"></i>
+                          </button>
+                          <button
+                            ng-if="publishedPort.NeedsDeletion && ctrl.formValues.PublishingType === ctrl.savedFormValues.PublishingType"
+                            class="btn btn-sm btn-primary"
+                            type="button"
+                            ng-click="ctrl.restorePublishedPort($index)"
+                            data-cy="k8sAppCreate-restorePortButton_{{ $index }}"
+                          >
+                            <i class="fa fa-trash-restore" aria-hidden="true"></i>
+                          </button>
                         </div>
                       </div>
+                      <!-- #endregion -->
 
-                      <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER">
-                        <div
-                          class="small text-warning"
-                          style="margin-top: 5px;"
-                          ng-if="
-                            kubernetesApplicationCreationForm['load_balancer_port_' + $index].$invalid ||
-                            ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined
-                          "
-                        >
-                          <div ng-messages="kubernetesApplicationCreationForm['load_balancer_port_'+$index].$error">
-                            <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number is required.</p>
-                            <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number must be inside the range 1-65535.</p>
-                            <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number must be inside the range 1-65535.</p>
+                      <!-- #region VALIDATION -->
+                      <div
+                        ng-repeat-end
+                        ng-show="
+                          kubernetesApplicationCreationForm['container_port_' + $index].$invalid ||
+                          kubernetesApplicationCreationForm['published_node_port_' + $index].$invalid ||
+                          kubernetesApplicationCreationForm['load_balancer_port_' + $index].$invalid ||
+                          kubernetesApplicationCreationForm['ingress_class_' + $index].$invalid ||
+                          kubernetesApplicationCreationForm['ingress_route_' + $index].$invalid ||
+                          ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined ||
+                          (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER &&
+                            ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined) ||
+                          (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS &&
+                            ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined) ||
+                          (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER &&
+                            ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined)
+                        "
+                      >
+                        <div class="col-sm-3 input-group input-group-sm">
+                          <div
+                            class="small text-warning"
+                            style="margin-top: 5px;"
+                            ng-if="
+                              kubernetesApplicationCreationForm['container_port_' + $index].$invalid ||
+                              ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined
+                            "
+                          >
+                            <div ng-messages="kubernetesApplicationCreationForm['container_port_'+$index].$error">
+                              <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number is required.</p>
+                              <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number must be inside the range 1-65535.</p>
+                              <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Container port number must be inside the range 1-65535.</p>
+                            </div>
+                            <p ng-if="ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined">
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This port is already used.
+                            </p>
                           </div>
-                          <p ng-if="ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined">
-                            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                            This port is already used.
-                          </p>
                         </div>
-                      </div>
 
-                      <div class="input-group col-sm-1 input-group-sm"> </div>
+                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER">
+                          <div
+                            class="small text-warning"
+                            style="margin-top: 5px;"
+                            ng-if="
+                              kubernetesApplicationCreationForm['published_node_port_' + $index].$invalid ||
+                              ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined
+                            "
+                          >
+                            <div ng-messages="kubernetesApplicationCreationForm['published_node_port_'+$index].$error">
+                              <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Node port number must be inside the range 30000-32767.</p>
+                              <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Node port number must be inside the range 30000-32767.</p>
+                            </div>
+                            <p ng-if="ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined">
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This port is already used.
+                            </p>
+                          </div>
+                        </div>
+
+                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS">
+                          <div class="small text-warning" style="margin-top: 5px;" ng-if="kubernetesApplicationCreationForm['ingress_class_' + $index].$invalid">
+                            <div ng-messages="kubernetesApplicationCreationForm['ingress_class_'+$index].$error">
+                              <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Ingress selection is required.</p>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS">
+                          <div
+                            class="small text-warning"
+                            style="margin-top: 5px;"
+                            ng-if="
+                              kubernetesApplicationCreationForm['ingress_route_' + $index].$invalid || ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined
+                            "
+                          >
+                            <div ng-messages="kubernetesApplicationCreationForm['ingress_route_'+$index].$error">
+                              <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Route is required.</p>
+                              <p ng-message="pattern"
+                                ><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This field must consist of alphanumeric characters or the special characters: '-',
+                                '_' or '/'. It must start and end with an alphanumeric character (e.g. 'my-route', or 'route-123').</p
+                              >
+                            </div>
+                            <p ng-if="ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined">
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> This route is already used.
+                            </p>
+                          </div>
+                        </div>
+
+                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.LOAD_BALANCER">
+                          <div
+                            class="small text-warning"
+                            style="margin-top: 5px;"
+                            ng-if="
+                              kubernetesApplicationCreationForm['load_balancer_port_' + $index].$invalid ||
+                              ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined
+                            "
+                          >
+                            <div ng-messages="kubernetesApplicationCreationForm['load_balancer_port_'+$index].$error">
+                              <p ng-message="required"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number is required.</p>
+                              <p ng-message="min"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number must be inside the range 1-65535.</p>
+                              <p ng-message="max"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Load balancer port number must be inside the range 1-65535.</p>
+                            </div>
+                            <p ng-if="ctrl.state.duplicates.publishedPorts.loadBalancerPorts.refs[$index] !== undefined">
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                              This port is already used.
+                            </p>
+                          </div>
+                        </div>
+
+                        <div class="input-group col-sm-1 input-group-sm"> </div>
+                      </div>
+                      <!-- #endregion -->
                     </div>
-                    <!-- #endregion -->
                   </div>
-                </div>
+                </span>
                 <!-- #endregion -->
 
                 <!-- summary -->

--- a/app/kubernetes/views/applications/create/createApplication.html
+++ b/app/kubernetes/views/applications/create/createApplication.html
@@ -1264,7 +1264,7 @@
                         <input
                           type="radio"
                           id="publishing_internal"
-                          ng-value="ctrl.ApplicationPublishingTypes.INTERNAL"
+                          ng-value="ctrl.ApplicationPublishingTypes.CLUSTER_IP"
                           ng-model="ctrl.formValues.PublishingType"
                           ng-change="ctrl.onChangePublishedPorts()"
                           ng-disabled="ctrl.isPublishingTypeEditDisabled()"
@@ -1274,7 +1274,7 @@
                           for="publishing_internal"
                           ng-if="
                             !ctrl.isPublishingTypeEditDisabled() ||
-                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INTERNAL)
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER_IP)
                           "
                         >
                           <div class="boxselector_header">
@@ -1285,7 +1285,7 @@
                         </label>
                         <label
                           for="publishing_internal"
-                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.INTERNAL"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.CLUSTER_IP"
                           tooltip-append-to-body="true"
                           tooltip-placement="bottom"
                           tooltip-class="portainer-tooltip"
@@ -1304,7 +1304,7 @@
                         <input
                           type="radio"
                           id="publishing_cluster"
-                          ng-value="ctrl.ApplicationPublishingTypes.CLUSTER"
+                          ng-value="ctrl.ApplicationPublishingTypes.NODE_PORT"
                           ng-model="ctrl.formValues.PublishingType"
                           ng-change="ctrl.onChangePublishedPorts()"
                           ng-disabled="ctrl.isPublishingTypeEditDisabled()"
@@ -1314,7 +1314,7 @@
                           for="publishing_cluster"
                           ng-if="
                             !ctrl.isPublishingTypeEditDisabled() ||
-                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
+                            (ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT)
                           "
                         >
                           <div class="boxselector_header">
@@ -1325,7 +1325,7 @@
                         </label>
                         <label
                           for="publishing_cluster"
-                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.CLUSTER"
+                          ng-if="ctrl.isPublishingTypeEditDisabled() && ctrl.formValues.PublishingType !== ctrl.ApplicationPublishingTypes.NODE_PORT"
                           tooltip-append-to-body="true"
                           tooltip-placement="bottom"
                           tooltip-class="portainer-tooltip"
@@ -1433,7 +1433,7 @@
                     <div
                       class="col-sm-12 small text-muted"
                       style="margin-top: 15px;"
-                      ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER && ctrl.formValues.PublishedPorts.length > 0"
+                      ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT && ctrl.formValues.PublishedPorts.length > 0"
                     >
                       <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
                       When publishing a port in cluster mode, the node port is optional. If left empty Kubernetes will use a random port number. If you wish to specify a port, use
@@ -1482,8 +1482,8 @@
                           class="col-sm-3 input-group input-group-sm"
                           ng-class="{ striked: publishedPort.NeedsDeletion }"
                           ng-if="
-                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER) ||
-                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER)
+                            (publishedPort.IsNew && ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT) ||
+                            (!publishedPort.IsNew && ctrl.savedFormValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT)
                           "
                         >
                           <span class="input-group-addon">node port</span>
@@ -1646,7 +1646,7 @@
                           kubernetesApplicationCreationForm['ingress_class_' + $index].$invalid ||
                           kubernetesApplicationCreationForm['ingress_route_' + $index].$invalid ||
                           ctrl.state.duplicates.publishedPorts.containerPorts.refs[$index] !== undefined ||
-                          (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER &&
+                          (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT &&
                             ctrl.state.duplicates.publishedPorts.nodePorts.refs[$index] !== undefined) ||
                           (ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.INGRESS &&
                             ctrl.state.duplicates.publishedPorts.ingressRoutes.refs[$index] !== undefined) ||
@@ -1674,7 +1674,7 @@
                           </div>
                         </div>
 
-                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.CLUSTER">
+                        <div class="col-sm-3 input-group input-group-sm" ng-if="ctrl.formValues.PublishingType === ctrl.ApplicationPublishingTypes.NODE_PORT">
                           <div
                             class="small text-warning"
                             style="margin-top: 5px;"

--- a/app/kubernetes/views/applications/create/createApplicationController.js
+++ b/app/kubernetes/views/applications/create/createApplicationController.js
@@ -37,6 +37,7 @@ class KubernetesCreateApplicationController {
 
   /* @ngInject */
   constructor(
+    $scope,
     $async,
     $state,
     Notifications,
@@ -54,6 +55,7 @@ class KubernetesCreateApplicationController {
     StackService,
     KubernetesNodesLimitsService
   ) {
+    this.$scope = $scope;
     this.$async = $async;
     this.$state = $state;
     this.Notifications = Notifications;
@@ -140,6 +142,9 @@ class KubernetesCreateApplicationController {
     this.deployApplicationAsync = this.deployApplicationAsync.bind(this);
     this.setPullImageValidity = this.setPullImageValidity.bind(this);
     this.onChangeFileContent = this.onChangeFileContent.bind(this);
+    this.onServicePublishChange = this.onServicePublishChange.bind(this);
+
+    this.$scope.$watch(() => this.formValues.IsPublishingService, this.onServicePublishChange);
   }
   /* #endregion */
 
@@ -415,6 +420,27 @@ class KubernetesCreateApplicationController {
   }
 
   /* #endregion */
+
+  onServicePublishChange() {
+    // service creation
+    if (this.formValues.PublishedPorts.length === 0) {
+      if (this.formValues.IsPublishingService) {
+        // toggle enabled
+        this.addPublishedPort();
+      }
+      return;
+    }
+
+    // service update
+    if (this.formValues.IsPublishingService) {
+      // toggle enabled
+      this.formValues.PublishedPorts.forEach((port) => (port.NeedsDeletion = false));
+    } else {
+      // toggle disabled
+      // all new ports need to be deleted, existing ports need to be marked as needing deletion
+      this.formValues.PublishedPorts = this.formValues.PublishedPorts.filter((port) => !port.IsNew).map((port) => ({ ...port, NeedsDeletion: true }));
+    }
+  }
 
   /* #region  PUBLISHED PORTS UI MANAGEMENT */
   addPublishedPort() {
@@ -736,10 +762,8 @@ class KubernetesCreateApplicationController {
     return this.state.isEdit && !this.formValues.PublishedPorts[index].IsNew;
   }
 
-  isNotInternalAndHasNoPublishedPorts() {
-    const toDelPorts = _.filter(this.formValues.PublishedPorts, { NeedsDeletion: true });
-    const toKeepPorts = _.without(this.formValues.PublishedPorts, ...toDelPorts);
-    return this.formValues.PublishingType !== KubernetesApplicationPublishingTypes.INTERNAL && toKeepPorts.length === 0;
+  hasNoPublishedPorts() {
+    return this.formValues.PublishedPorts.filter((port) => !port.NeedsDeletion).length === 0;
   }
 
   isEditAndNotNewPlacement(index) {
@@ -771,8 +795,8 @@ class KubernetesCreateApplicationController {
     const invalid = !this.isValid();
     const hasNoChanges = this.isEditAndNoChangesMade();
     const nonScalable = this.isNonScalable();
-    const notInternalNoPorts = this.isNotInternalAndHasNoPublishedPorts();
-    return overflow || autoScalerOverflow || inProgress || invalid || hasNoChanges || nonScalable || notInternalNoPorts;
+    const isPublishingWithoutPorts = this.formValues.IsPublishingService && this.hasNoPublishedPorts();
+    return overflow || autoScalerOverflow || inProgress || invalid || hasNoChanges || nonScalable || isPublishingWithoutPorts;
   }
 
   disableLoadBalancerEdit() {
@@ -1113,6 +1137,8 @@ class KubernetesCreateApplicationController {
         if (this.state.isEdit) {
           this.nodesLimits.excludesPods(this.application.Pods, this.formValues.CpuLimit, KubernetesResourceReservationHelper.bytesValue(this.formValues.MemoryLimit));
         }
+
+        this.formValues.IsPublishingService = this.formValues.PublishedPorts.length > 0;
 
         this.updateNamespaceLimits();
         this.updateSliders();

--- a/app/kubernetes/views/applications/create/createApplicationController.js
+++ b/app/kubernetes/views/applications/create/createApplicationController.js
@@ -502,7 +502,7 @@ class KubernetesCreateApplicationController {
 
   onChangePortMappingNodePort() {
     const state = this.state.duplicates.publishedPorts.nodePorts;
-    if (this.formValues.PublishingType === KubernetesApplicationPublishingTypes.CLUSTER) {
+    if (this.formValues.PublishingType === KubernetesApplicationPublishingTypes.NODE_PORT) {
       const source = _.map(this.formValues.PublishedPorts, (p) => (p.NeedsDeletion ? undefined : p.NodePort));
       const duplicates = KubernetesFormValidationHelper.getDuplicates(source);
       state.refs = duplicates;
@@ -950,7 +950,7 @@ class KubernetesCreateApplicationController {
           if (this.savedFormValues) {
             this.formValues.PublishingType = this.savedFormValues.PublishingType;
           } else {
-            this.formValues.PublishingType = this.ApplicationPublishingTypes.INTERNAL;
+            this.formValues.PublishingType = this.ApplicationPublishingTypes.CLUSTER_IP;
           }
         }
         this.formValues.OriginalIngresses = this.ingresses;

--- a/app/kubernetes/views/applications/edit/application.html
+++ b/app/kubernetes/views/applications/edit/application.html
@@ -253,7 +253,8 @@
             <div ng-if="ctrl.application.ServiceType === ctrl.KubernetesServiceTypes.LOAD_BALANCER">
               <div class="small text-muted">
                 <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
-                This application is exposed through an external load balancer. Use the links below to access the different ports exposed.
+                This application is exposed through a service of type <span class="bold">{{ ctrl.application.ServiceType }}</span
+                >. Refer to the port configuration below to access it.
               </div>
               <div style="margin-top: 10px;" class="small text-muted">
                 <span ng-if="!ctrl.application.LoadBalancerIPAddress">
@@ -282,45 +283,41 @@
               </div>
             </div>
 
-            <!-- cluster notice -->
+            <!-- NodePort notice -->
             <div ng-if="ctrl.application.ServiceType === ctrl.KubernetesServiceTypes.NODE_PORT">
               <div class="small text-muted">
                 <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
-                This application is exposed globally on all nodes of your cluster. It can be reached using the IP address of any node in your cluster using the port configuration
-                below.
+                This application is exposed through a service of type <span class="bold">{{ ctrl.application.ServiceType }}</span
+                >. It can be reached using the IP address of any node in your cluster using the port configuration below.
               </div>
             </div>
 
-            <!-- internal notice -->
+            <!-- ClusterIP notice -->
             <div ng-if="ctrl.application.ServiceType === ctrl.KubernetesServiceTypes.CLUSTER_IP && !ctrl.state.useIngress">
               <div class="small text-muted">
                 <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
-                This application is only available for internal usage inside the cluster via the application name <code>{{ ctrl.application.ServiceName }}</code>
+                This application is exposed through a service of type <span class="bold">{{ ctrl.application.ServiceType }}</span
+                >. It can be reached via the application name <code>{{ ctrl.application.ServiceName }}</code> and the port configuration below.
                 <span class="btn btn-primary btn-xs" ng-click="ctrl.copyApplicationName()"><i class="fa fa-copy space-right" aria-hidden="true"></i>Copy</span>
                 <span id="copyNotificationApplicationName" style="margin-left: 7px; display: none; color: #23ae89;" class="small"
                   ><i class="fa fa-check" aria-hidden="true"></i> copied</span
                 >
               </div>
-              <div class="small text-muted" style="margin-top: 2px;">
-                <p>Refer to the below port configuration to access the application.</p>
-              </div>
             </div>
 
-            <!-- ingress notice -->
+            <!-- Ingress notice -->
             <div ng-if="ctrl.application.ServiceType === ctrl.KubernetesServiceTypes.CLUSTER_IP && ctrl.state.useIngress">
               <div class="small text-muted">
                 <p>
                   <i class="fa fa-info-circle blue-icon" aria-hidden="true" style="margin-right: 2px;"></i>
-                  This application is available for internal usage inside the cluster via the application name <code>{{ ctrl.application.ServiceName }}</code>
+                  This application is exposed through a service of type <span class="bold">{{ ctrl.application.ServiceType }}</span
+                  >. It can be reached via the application name <code>{{ ctrl.application.ServiceName }}</code> and the port configuration below.
                   <span class="btn btn-primary btn-xs" ng-click="ctrl.copyApplicationName()"><i class="fa fa-copy space-right" aria-hidden="true"></i>Copy</span>
                   <span id="copyNotificationApplicationName" style="margin-left: 7px; display: none; color: #23ae89;" class="small"
                     ><i class="fa fa-check" aria-hidden="true"></i> copied</span
                   >
                 </p>
-                <p>It can also be accessed via specific HTTP route(s).</p>
-              </div>
-              <div class="small text-muted" style="margin-top: 2px;">
-                <p>Refer to the below port configuration to access the application.</p>
+                <p>It is also associated to an <span class="bold">Ingress</span> and can be accessed via specific HTTP route(s).</p>
               </div>
             </div>
 
@@ -330,7 +327,7 @@
                 <tbody>
                   <tr class="text-muted">
                     <td style="width: 25%;">Container port</td>
-                    <td style="width: 25%;">{{ ctrl.application.ServiceType | kubernetesApplicationPortsTableHeaderText }} port</td>
+                    <td style="width: 25%;">Service port</td>
                     <td style="width: 50%;">HTTP route</td>
                   </tr>
                   <tr ng-repeat-start="port in ctrl.application.PublishedPorts">

--- a/app/kubernetes/views/configurations/configurations.html
+++ b/app/kubernetes/views/configurations/configurations.html
@@ -1,5 +1,5 @@
-<kubernetes-view-header title="Configuration list" state="kubernetes.configurations" view-ready="ctrl.state.viewReady">
-  Configurations
+<kubernetes-view-header title="ConfigMaps & Secrets list" state="kubernetes.configurations" view-ready="ctrl.state.viewReady">
+  ConfigMaps & Secrets
 </kubernetes-view-header>
 
 <kubernetes-view-loading view-ready="ctrl.state.viewReady"></kubernetes-view-loading>

--- a/app/kubernetes/views/configurations/create/createConfiguration.html
+++ b/app/kubernetes/views/configurations/create/createConfiguration.html
@@ -95,7 +95,7 @@
                     <label for="type_basic" data-cy="k8sConfigCreate-nonSensitiveButton">
                       <div class="boxselector_header">
                         <i class="fa fa-file-code" aria-hidden="true" style="margin-right: 2px;"></i>
-                        Non-sensitive
+                        ConfigMap
                       </div>
                       <p>This configuration holds non-sensitive information</p>
                     </label>
@@ -105,7 +105,7 @@
                     <label for="type_secret" data-cy="k8sConfigCreate-sensitiveButton">
                       <div class="boxselector_header">
                         <i class="fa fa-user-secret" aria-hidden="true" style="margin-right: 2px;"></i>
-                        Sensitive
+                        Secret
                       </div>
                       <p>This configuration holds sensitive information</p>
                     </label>
@@ -153,7 +153,7 @@
                   button-spinner="ctrl.state.actionInProgress"
                   data-cy="k8sConfigCreate-CreateConfigButton"
                 >
-                  <span ng-hide="ctrl.state.actionInProgress">Create configuration</span>
+                  <span ng-hide="ctrl.state.actionInProgress">Create {{ ctrl.formValues.Type | kubernetesConfigurationTypeText }}</span>
                   <span ng-show="ctrl.state.actionInProgress">Creation in progress...</span>
                 </button>
               </div>

--- a/app/kubernetes/views/configurations/create/createConfiguration.html
+++ b/app/kubernetes/views/configurations/create/createConfiguration.html
@@ -1,5 +1,5 @@
 <kubernetes-view-header title="Create configuration" state="kubernetes.configurations.new" view-ready="ctrl.state.viewReady">
-  <a ui-sref="kubernetes.configurations">Configurations</a> &gt; Create a configuration
+  <a ui-sref="kubernetes.configurations">ConfigMaps and Secrets</a> &gt; Create a configuration
 </kubernetes-view-header>
 
 <kubernetes-view-loading view-ready="ctrl.state.viewReady"></kubernetes-view-loading>

--- a/app/kubernetes/views/configurations/edit/configuration.html
+++ b/app/kubernetes/views/configurations/edit/configuration.html
@@ -1,7 +1,7 @@
 <kubernetes-view-header title="Configuration details" state="kubernetes.configurations.configuration" view-ready="ctrl.state.viewReady">
   <a ui-sref="kubernetes.resourcePools">Namespaces</a> &gt;
   <a ui-sref="kubernetes.resourcePools.resourcePool({ id: ctrl.configuration.Namespace })">{{ ctrl.configuration.Namespace }}</a> &gt;
-  <a ui-sref="kubernetes.configurations">Configurations</a> &gt; {{ ctrl.configuration.Name }}
+  <a ui-sref="kubernetes.configurations">ConfigMaps and Secrets</a> &gt; {{ ctrl.configuration.Name }}
 </kubernetes-view-header>
 
 <kubernetes-view-loading view-ready="ctrl.state.viewReady"></kubernetes-view-loading>
@@ -106,7 +106,7 @@
                   button-spinner="ctrl.state.actionInProgress"
                   data-cy="k8sConfigDetail-updateConfig"
                 >
-                  <span ng-hide="ctrl.state.actionInProgress">Update configuration</span>
+                  <span ng-hide="ctrl.state.actionInProgress">Update {{ ctrl.configuration.Type | kubernetesConfigurationTypeText }}</span>
                   <span ng-show="ctrl.state.actionInProgress">Update in progress...</span>
                 </button>
               </div>

--- a/app/kubernetes/views/summary/summary.html
+++ b/app/kubernetes/views/summary/summary.html
@@ -22,7 +22,7 @@
       <li ng-repeat="summary in $ctrl.state.resources" ng-if="summary.action && summary.kind && summary.name">
         {{ summary.action }}
         {{ $ctrl.getArticle(summary.kind, summary.action) }}
-        <span class="summary">{{ summary.kind }}</span> named <code>{{ summary.name }}</code>
+        <span class="bold">{{ summary.kind }}</span> named <code>{{ summary.name }}</code>
         <span ng-if="summary.type">
           of type <code>{{ summary.type }}</code></span
         >

--- a/app/portainer/components/sidebar/sidebar.css
+++ b/app/portainer/components/sidebar/sidebar.css
@@ -271,6 +271,7 @@ ul.sidebar .sidebar-title .form-control {
 ul.sidebar .sidebar-list a,
 ul.sidebar .sidebar-list .sidebar-sublist a {
   line-height: 36px;
+  letter-spacing: -0.03em;
 }
 
 ul.sidebar .sidebar-list .menu-icon {


### PR DESCRIPTION
Closes [EE-1626](https://portainer.atlassian.net/browse/EE-1626).

## Service UI changes
- We accurately reflect the underlying service type in the UI, this implied changing the following service type in the UI.
  - `Internal` -> `ClusterIP`
  - `Cluster` -> `NodePort`

---
<img width="1440" alt="Screen Shot 2021-09-28 at 2 41 30 PM" src="https://user-images.githubusercontent.com/63374656/135009145-5885b633-c10f-405d-bd50-03a6757d84fc.png">

- The description has been updated for all the service types to now also explicitly state the type of service for the application
- Table heading updated

---
<img width="1440" alt="Screen Shot 2021-09-28 at 2 42 03 PM" src="https://user-images.githubusercontent.com/63374656/135009227-de568051-9f84-4b89-8c87-a5992cfa6f7a.png">

- Create/Update application has an additional panel from which we can expose/deploy services

---
<img width="1440" alt="Screen Shot 2021-09-28 at 2 42 18 PM" src="https://user-images.githubusercontent.com/63374656/135009274-32b5d8fa-f2d4-421e-959c-c6d8ae2342af.png">

- portainer lingo for services translated to k8s service types (in both application create and update views)

---
<img width="1436" alt="Screen Shot 2021-09-28 at 2 42 49 PM" src="https://user-images.githubusercontent.com/63374656/135009335-ecce34a3-20f3-4be3-a8c7-d4d0d7e5ca5c.png">

- k8s application list view publishing mode column displays k8s service type
  - port mappings table publishing mode column also updated 

## Configuration UI changes

Configurations list view:
<img width="1440" alt="Screen Shot 2021-09-23 at 4 01 29 PM" src="https://user-images.githubusercontent.com/63374656/134453050-6d74059d-2b0e-4ab3-8c30-2e831e4cfe8b.png">

---

Configuration creation view:
<img width="1440" alt="Screen Shot 2021-09-23 at 2 53 44 PM" src="https://user-images.githubusercontent.com/63374656/134448584-96b4e7be-2d30-4637-9917-f71d2d4f25d9.png">

---

Configuration update view:
<img width="1439" alt="Screen Shot 2021-09-23 at 2 55 19 PM" src="https://user-images.githubusercontent.com/63374656/134448596-c751f6c4-7abe-455a-8aba-f555adcd3c7e.png">

---
