### PR TITLE
docs(versions): add new tool-versions json file

### DIFF
--- a/tool-versions.json
+++ b/tool-versions.json
@@ -1,0 +1,6 @@
+{
+    "description": "This file contains current tool versions",
+    "go_version": "v1.16.6",
+    "node_version": "12.x",
+    "yarn_version": "1.x"
+}


### PR DESCRIPTION
After discussion with Yi.  I'm adding a tool-versions.json file which allows reading/querying from documentation websites and so forth.   It means we can in theory, automate a lot of tool versions around this.  In the first instance I'm pulling this data into the new dev documentation which will show the versions of tools required to build portainer with.