### PR TITLE
fix(swagger): double quotes in swagger param breaks parser

### DIFF
--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -27,7 +27,7 @@ type stackListOperationFilters struct {
 // @description **Access policy**: restricted
 // @tags stacks
 // @security jwt
-// @param filters query string false "Filters to process on the stack list. Encoded as JSON (a map[string]string). For example, {"SwarmID": "jpofkc0i9uo9wtx1zesuk649w"} will only return stacks that are part of the specified Swarm cluster. Available filters: EndpointID, SwarmID."
+// @param filters query string false "Filters to process on the stack list. Encoded as JSON (a map[string]string). For example, {'SwarmID': 'jpofkc0i9uo9wtx1zesuk649w'} will only return stacks that are part of the specified Swarm cluster. Available filters: EndpointID, SwarmID."
 // @success 200 {array} portainer.Stack "Success"
 // @success 204 "Success"
 // @failure 400 "Invalid request"


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <sven.dowideit@portainer.io>

yes, the fix to #5338 was exactly what @huib-portainer said - we should give him commit bit...