### PR TITLE
fix(swagger): swagger docs for websocketShellPodExec handler

### DIFF
--- a/api/http/handler/websocket/shell_pod.go
+++ b/api/http/handler/websocket/shell_pod.go
@@ -10,13 +10,21 @@ import (
 	"github.com/portainer/portainer/api/http/security"
 )
 
-// websocketShellPodExec handles GET requests on /websocket/pod?token=<token>&endpointId=<endpointID>
-// The request will be upgraded to the websocket protocol.
-// Authentication and access is controlled via the mandatory token query parameter.
-// The request will proxy input from the client to the pod via long-lived websocket connection.
-// The following query parameters are mandatory:
-// * token: JWT token used for authentication against this environment(endpoint)
-// * endpointId: environment(endpoint) ID of the environment(endpoint) where the resource is located
+// @summary Execute a websocket on kubectl shell pod
+// @description The request will be upgraded to the websocket protocol. The request will proxy input from the client to the pod via long-lived websocket connection.
+// @description **Access policy**: authenticated
+// @security jwt
+// @tags websocket
+// @accept json
+// @produce json
+// @param endpointId query int true "environment(endpoint) ID of the environment(endpoint) where the resource is located"
+// @param token query string true "JWT token used for authentication against this environment(endpoint)"
+// @success 200
+// @failure 400
+// @failure 403
+// @failure 404
+// @failure 500
+// @router /websocket/kubernetes-shell [get]
 func (handler *Handler) websocketShellPodExec(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
 	endpointID, err := request.RetrieveNumericQueryParameter(r, "endpointId", false)
 	if err != nil {


### PR DESCRIPTION
Closes [EE-1838](https://portainer.atlassian.net/browse/EE-1838).

## Changelog

Swagger docs for the `/websocket/kubernetes-shell` endpoint:

<img width="707" alt="Screen Shot 2021-10-07 at 10 44 06 AM" src="https://user-images.githubusercontent.com/63374656/136287672-049deccc-e75c-4d10-9675-798681fb3579.png">
