### PR TITLE
fix(namespaces): remove the stacks from the data store when deleting their corresponding Kubernetes namespace EE-1872

### DIFF
--- a/api/http/proxy/factory/kubernetes/namespaces.go
+++ b/api/http/proxy/factory/kubernetes/namespaces.go
@@ -53,7 +53,7 @@ func (transport *baseTransport) proxyNamespaceDeleteOperation(request *http.Requ
 	}
 
 	for _, s := range stacks {
-		if s.Namespace == namespace {
+		if s.Namespace == namespace && s.EndpointID == transport.endpoint.ID {
 			if err := transport.dataStore.Stack().DeleteStack(s.ID); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Please review.