### PR TITLE
EE-1749: prevent exception when showing stats on windows container

### DIFF
--- a/app/docker/models/container.js
+++ b/app/docker/models/container.js
@@ -100,7 +100,7 @@ export function ContainerStatsViewModel(data) {
     }
   }
   this.Networks = _.values(data.networks);
-  if (data.blkio_stats !== undefined) {
+  if (data.blkio_stats !== undefined && data.blkio_stats.io_service_bytes_recursive !== null) {
     //TODO: take care of multiple block devices
     var readData = data.blkio_stats.io_service_bytes_recursive.find((d) => d.op === 'Read');
     if (readData === undefined) {


### PR DESCRIPTION
see https://github.com/portainer/portainer/issues/5826

reproduced in 2.9.1 (develop) running with an agent on windows server 2019 using windows containers.

This only avoids the exception, which breaks the entire graphing page - but still leaves no data in the IO usage graph.