### PR TITLE
fix(roles): Missing manage access button in user roles [EE-1875] 

### DIFF
--- a/app/portainer/rbac/components/access-viewer/access-viewer-datatable/access-viewer-datatable.html
+++ b/app/portainer/rbac/components/access-viewer/access-viewer-datatable/access-viewer-datatable.html
@@ -33,10 +33,10 @@
           <td
             >{{ item.TeamName ? 'Team' : 'User' }} <code ng-if="item.TeamName">{{ item.TeamName }}</code> access defined on {{ item.AccessLocation }}
             <code ng-if="item.GroupName">{{ item.GroupName }}</code>
-            <a ng-if="item.AccessLocation === 'environment'" ui-sref="portainer.endpoints.endpoint.access({id: item.EndpointId})"
+            <a ng-if="!item.GroupName" ui-sref="portainer.endpoints.endpoint.access({id: item.EndpointId})"
               ><i style="margin-left: 5px;" class="fa fa-users" aria-hidden="true"></i> Manage access
             </a>
-            <a ng-if="item.AccessLocation === 'environment group'" ui-sref="portainer.groups.group.access({id: item.GroupId})"
+            <a ng-if="item.GroupName" ui-sref="portainer.groups.group.access({id: item.GroupId})"
               ><i style="margin-left: 5px;" class="fa fa-users" aria-hidden="true"></i> Manage access
             </a>
           </td>


### PR DESCRIPTION
Closes [EE-1875](https://portainer.atlassian.net/browse/EE-1875)

Note: This doesn't actually affect CE given that the user roles list doesn't get populated in this edition, but it still makes sense to fix the typo and keep both codes in sync.

![image](https://user-images.githubusercontent.com/16310914/137139520-89223d46-9abc-400b-8642-36d6f62d2bef.png)
