### PR TITLE
fix(endpoints): use the right command for windows agent EE-1877

### DIFF
--- a/app/portainer/views/endpoints/create/createEndpointController.js
+++ b/app/portainer/views/endpoints/create/createEndpointController.js
@@ -53,7 +53,7 @@ angular
       kubeLoadBalancer: `curl -L https://downloads.portainer.io/portainer-agent-ce${agentShortVersion}-k8s-lb.yaml -o portainer-agent-k8s.yaml; kubectl apply -f portainer-agent-k8s.yaml`,
       kubeNodePort: `curl -L https://downloads.portainer.io/portainer-agent-ce${agentShortVersion}-k8s-nodeport.yaml -o portainer-agent-k8s.yaml; kubectl apply -f portainer-agent-k8s.yaml`,
       agentLinux: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}.yml -o agent-stack.yml && docker stack deploy --compose-file=agent-stack.yml portainer-agent`,
-      agentWindows: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}-windows.yml -o agent-stack-windows.yml && docker stack deploy --compose-file=agent-stack-windows.yml portainer-agent`,
+      agentWindows: `curl https://downloads.portainer.io/agent-stack-ce${agentShortVersion}-windows.yml -o agent-stack-windows.yml ; docker stack deploy --compose-file=agent-stack-windows.yml portainer-agent`,
     };
     $scope.deployCommands = deployCommands;
 

--- a/app/portainer/views/wizard/wizard-endpoints/wizard-endpoint-docker/wizard-docker.controller.js
+++ b/app/portainer/views/wizard/wizard-endpoints/wizard-endpoint-docker/wizard-docker.controller.js
@@ -206,7 +206,7 @@ export default class WizardDockerController {
 
       this.command = {
         linuxCommand: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}.yml -o agent-stack.yml && docker stack deploy --compose-file=agent-stack.yml portainer-agent `,
-        winCommand: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}-windows.yml -o agent-stack-windows.yml && docker stack deploy --compose-file=agent-stack-windows.yml portainer-agent `,
+        winCommand: `curl https://downloads.portainer.io/agent-stack-ce${agentShortVersion}-windows.yml -o agent-stack-windows.yml ; docker stack deploy --compose-file=agent-stack-windows.yml portainer-agent `,
         linuxSocket: `-v "/var/run/docker.sock:/var/run/docker.sock" `,
         winSocket: `-v \.\pipe\docker_engine:\.\pipe\docker_engine `,
       };


### PR DESCRIPTION
Windows server 2019 doesn't have `-L` or `&&` in the powershell I was on (freshly installed for #5890)