### PR TITLE
fix(helm): allow settings to be saved offline EE-1907

### DIFF
--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -113,7 +113,7 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 	if payload.HelmRepositoryURL != nil {
 		newHelmRepo := strings.TrimSuffix(strings.ToLower(*payload.HelmRepositoryURL), "/")
 
-		if newHelmRepo != settings.HelmRepositoryURL || newHelmRepo != portainer.DefaultHelmRepositoryURL {
+		if newHelmRepo != settings.HelmRepositoryURL && newHelmRepo != portainer.DefaultHelmRepositoryURL {
 			err := libhelm.ValidateHelmRepositoryURL(*payload.HelmRepositoryURL)
 			if err != nil {
 				return &httperror.HandlerError{http.StatusBadRequest, "Invalid Helm repository URL. Must correspond to a valid URL format", err}


### PR DESCRIPTION
When the global helm repo is the default one we should disable online checks.

Closes [EE-1907](https://portainer.atlassian.net/browse/EE-1907)