### PR TITLE
feat(access-token): Multi-auth middleware support EE-1891

### DIFF
--- a/api/http/handler/helm/handler.go
+++ b/api/http/handler/helm/handler.go
@@ -26,17 +26,19 @@ type Handler struct {
 	*mux.Router
 	requestBouncer     requestBouncer
 	dataStore          portainer.DataStore
+	jwtService         portainer.JWTService
 	kubeConfigService  kubernetes.KubeConfigService
 	kubernetesDeployer portainer.KubernetesDeployer
 	helmPackageManager libhelm.HelmPackageManager
 }
 
 // NewHandler creates a handler to manage endpoint group operations.
-func NewHandler(bouncer requestBouncer, dataStore portainer.DataStore, kubernetesDeployer portainer.KubernetesDeployer, helmPackageManager libhelm.HelmPackageManager, kubeConfigService kubernetes.KubeConfigService) *Handler {
+func NewHandler(bouncer requestBouncer, dataStore portainer.DataStore, jwtService portainer.JWTService, kubernetesDeployer portainer.KubernetesDeployer, helmPackageManager libhelm.HelmPackageManager, kubeConfigService kubernetes.KubeConfigService) *Handler {
 	h := &Handler{
 		Router:             mux.NewRouter(),
 		requestBouncer:     bouncer,
 		dataStore:          dataStore,
+		jwtService:         jwtService,
 		kubernetesDeployer: kubernetesDeployer,
 		helmPackageManager: helmPackageManager,
 		kubeConfigService:  kubeConfigService,
@@ -91,7 +93,12 @@ func (handler *Handler) getHelmClusterAccess(r *http.Request) (*options.Kubernet
 		return nil, &httperror.HandlerError{http.StatusNotFound, "Unable to find an environment on request context", err}
 	}
 
-	bearerToken, err := security.ExtractBearerToken(r)
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+
+	bearerToken, err := handler.jwtService.GenerateToken(tokenData)
 	if err != nil {
 		return nil, &httperror.HandlerError{http.StatusUnauthorized, "Unauthorized", err}
 	}

--- a/api/http/handler/helm/helm_delete_test.go
+++ b/api/http/handler/helm/helm_delete_test.go
@@ -11,6 +11,7 @@ import (
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/exec/exectest"
 	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
 	"github.com/portainer/portainer/api/kubernetes"
 	"github.com/stretchr/testify/assert"
 
@@ -30,10 +31,13 @@ func Test_helmDelete(t *testing.T) {
 	err = store.User().CreateUser(&portainer.User{Username: "admin", Role: portainer.AdministratorRole})
 	is.NoError(err, "Error creating a user")
 
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+
 	kubernetesDeployer := exectest.NewKubernetesDeployer()
 	helmPackageManager := test.NewMockHelmBinaryPackageManager("")
 	kubeConfigService := kubernetes.NewKubeConfigCAService("", "")
-	h := NewHandler(helper.NewTestRequestBouncer(), store, kubernetesDeployer, helmPackageManager, kubeConfigService)
+	h := NewHandler(helper.NewTestRequestBouncer(), store, jwtService, kubernetesDeployer, helmPackageManager, kubeConfigService)
 
 	is.NotNil(h, "Handler should not fail")
 

--- a/api/http/handler/helm/helm_install_test.go
+++ b/api/http/handler/helm/helm_install_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/portainer/portainer/api/exec/exectest"
 	"github.com/portainer/portainer/api/http/security"
 	helper "github.com/portainer/portainer/api/internal/testhelpers"
+	"github.com/portainer/portainer/api/jwt"
 	"github.com/portainer/portainer/api/kubernetes"
 	"github.com/stretchr/testify/assert"
 )
@@ -32,10 +33,13 @@ func Test_helmInstall(t *testing.T) {
 	err = store.User().CreateUser(&portainer.User{Username: "admin", Role: portainer.AdministratorRole})
 	is.NoError(err, "error creating a user")
 
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+
 	kubernetesDeployer := exectest.NewKubernetesDeployer()
 	helmPackageManager := test.NewMockHelmBinaryPackageManager("")
 	kubeConfigService := kubernetes.NewKubeConfigCAService("", "")
-	h := NewHandler(helper.NewTestRequestBouncer(), store, kubernetesDeployer, helmPackageManager, kubeConfigService)
+	h := NewHandler(helper.NewTestRequestBouncer(), store, jwtService, kubernetesDeployer, helmPackageManager, kubeConfigService)
 
 	is.NotNil(h, "Handler should not fail")
 

--- a/api/http/handler/helm/helm_list_test.go
+++ b/api/http/handler/helm/helm_list_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/portainer/libhelm/release"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/exec/exectest"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
 	"github.com/portainer/portainer/api/kubernetes"
 	"github.com/stretchr/testify/assert"
 
@@ -20,6 +22,8 @@ import (
 )
 
 func Test_helmList(t *testing.T) {
+	is := assert.New(t)
+
 	store, teardown := bolt.MustNewTestStore(true)
 	defer teardown()
 
@@ -29,19 +33,22 @@ func Test_helmList(t *testing.T) {
 	err = store.User().CreateUser(&portainer.User{Username: "admin", Role: portainer.AdministratorRole})
 	assert.NoError(t, err, "error creating a user")
 
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initialising jwt service")
+
 	kubernetesDeployer := exectest.NewKubernetesDeployer()
 	helmPackageManager := test.NewMockHelmBinaryPackageManager("")
 	kubeConfigService := kubernetes.NewKubeConfigCAService("", "")
-	h := NewHandler(helper.NewTestRequestBouncer(), store, kubernetesDeployer, helmPackageManager, kubeConfigService)
+	h := NewHandler(helper.NewTestRequestBouncer(), store, jwtService, kubernetesDeployer, helmPackageManager, kubeConfigService)
 
 	// Install a single chart.  We expect to get these values back
 	options := options.InstallOptions{Name: "nginx-1", Chart: "nginx", Namespace: "default"}
 	h.helmPackageManager.Install(options)
 
 	t.Run("helmList", func(t *testing.T) {
-		is := assert.New(t)
-
 		req := httptest.NewRequest(http.MethodGet, "/1/kubernetes/helm", nil)
+		ctx := security.StoreTokenData(req, &portainer.TokenData{ID: 1, Username: "admin", Role: 1})
+		req = req.WithContext(ctx)
 		req.Header.Add("Authorization", "Bearer dummytoken")
 
 		rr := httptest.NewRecorder()

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -183,7 +183,12 @@ func (bouncer *RequestBouncer) AuthorizedEdgeEndpointOperation(r *http.Request, 
 // - add secure handlers to the response
 // - parse the JWT token and put it into the http context.
 func (bouncer *RequestBouncer) mwAuthenticatedUser(h http.Handler) http.Handler {
-	h = bouncer.mwCheckJWTAuthentication(h)
+	// Use AnyAuth middleware to support multiple auth paradigms
+	// currently supported auth: JWT Auth, API-Key Auth
+	h = bouncer.AnyAuth([]mux.MiddlewareFunc{
+		bouncer.mwCheckJWTAuthentication,
+		bouncer.mwCheckAPIKeyAuthentication,
+	}, h)
 	h = mwSecureHeaders(h)
 	return h
 }

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -250,7 +250,7 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 		var tokenData *portainer.TokenData
 
 		// get token from the Authorization header or query parameter
-		token, err := ExtractBearerToken(r)
+		token, err := extractBearerToken(r)
 		if err != nil {
 			httperror.WriteError(w, http.StatusUnauthorized, "Unauthorized", err)
 			return
@@ -276,8 +276,8 @@ func (bouncer *RequestBouncer) mwCheckAuthentication(next http.Handler) http.Han
 	})
 }
 
-// ExtractBearerToken extracts the Bearer token from the request header or query parameter and returns the token.
-func ExtractBearerToken(r *http.Request) (string, error) {
+// extractBearerToken extracts the Bearer token from the request header or query parameter and returns the token.
+func extractBearerToken(r *http.Request) (string, error) {
 	// Optionally, token might be set via the "token" query parameter.
 	// For example, in websocket requests
 	token := r.URL.Query().Get("token")

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -50,15 +50,6 @@ var mwFailEveryRequest = mwFailAfterDuration(0, http.StatusBadRequest)
 func Test_middlewares(t *testing.T) {
 	is := assert.New(t)
 
-	// tests := []struct {
-	// 	name       string
-	// 	input      string
-	// 	wantOutput http.StatusCode
-	// }{
-
-	// 	}
-	// }
-	// dummy request
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	t.Run("mwPassEveryRequest passes with HTTP 302", func(t *testing.T) {

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -1,0 +1,179 @@
+package security
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testHandler200 is a simple handler which returns HTTP status 200 OK
+var testHandler200 = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+// mwSucceedAfterDuration is a simple middleware which succeeds after specified duration
+// for tests, we can specify desired HTTP status code to check for
+func mwSucceedAfterDuration(d time.Duration, httpStatusCode int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(d)
+
+			// override response code to signal that middleware has succeeded
+			w.WriteHeader(httpStatusCode)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// mwFailAfterDuration is a simple middleware which fails after specified duration with specified HTTP status code
+func mwFailAfterDuration(d time.Duration, httpStatusCode int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(d)
+			http.Error(w, "Malformed Content-Type header", httpStatusCode)
+		})
+	}
+}
+
+// define instantly succeeding and failing middlewares
+var mwPassEveryRequest = mwSucceedAfterDuration(0, http.StatusFound)
+var mwFailEveryRequest = mwFailAfterDuration(0, http.StatusBadRequest)
+
+// Test_middlewares is a set of simple tests to validate testing middlewares declared above so that they can be
+// utilised in more complex tests below.
+func Test_middlewares(t *testing.T) {
+	is := assert.New(t)
+
+	// tests := []struct {
+	// 	name       string
+	// 	input      string
+	// 	wantOutput http.StatusCode
+	// }{
+
+	// 	}
+	// }
+	// dummy request
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	t.Run("mwPassEveryRequest passes with HTTP 302", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+
+		h := mwPassEveryRequest(testHandler200)
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusFound, rr.Code, "Status should be 302 Found")
+	})
+
+	t.Run("mwFailEveryRequest fails with HTTP 400", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+
+		h := mwFailEveryRequest(testHandler200)
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusBadRequest, rr.Code, "Status should be 400 Bad Request")
+	})
+}
+
+func Test_AnyAuth(t *testing.T) {
+	is := assert.New(t)
+	bouncer := NewRequestBouncer(nil, nil)
+
+	tests := []struct {
+		name            string
+		inputMiddlwares []MiddlewareFunc
+		wantStatusCode  int
+	}{
+		{
+			name:            "AnyAuth middleware passes with no middleware",
+			inputMiddlwares: nil,
+			wantStatusCode:  http.StatusOK,
+		},
+		{
+			name:            "AnyAuth middleware succeeds with passing middleware",
+			inputMiddlwares: []MiddlewareFunc{mwPassEveryRequest},
+			wantStatusCode:  http.StatusFound,
+		},
+		{
+			name:            "AnyAuth fails with failing middleware",
+			inputMiddlwares: []MiddlewareFunc{mwFailEveryRequest},
+			wantStatusCode:  http.StatusBadRequest,
+		},
+		{
+			name: "AnyAuth succeeds if first middleware successfully handles request",
+			inputMiddlwares: []MiddlewareFunc{
+				mwPassEveryRequest,
+				mwFailEveryRequest,
+			},
+			wantStatusCode: http.StatusFound,
+		},
+		{
+			name: "AnyAuth succeeds if last middleware successfully handles request",
+			inputMiddlwares: []MiddlewareFunc{
+				mwFailEveryRequest,
+				mwPassEveryRequest,
+			},
+			wantStatusCode: http.StatusFound,
+		},
+		{
+			name: "AnyAuth succeeds if first middleware successfully handles request after a failing middleware",
+			inputMiddlwares: []MiddlewareFunc{
+				mwSucceedAfterDuration(time.Millisecond*50, http.StatusFound),
+				mwFailEveryRequest,
+			},
+			wantStatusCode: http.StatusFound,
+		},
+		{
+			name: "AnyAuth succeeds if last middleware successfully handles request after a failing middleware",
+			inputMiddlwares: []MiddlewareFunc{
+				mwFailEveryRequest,
+				mwSucceedAfterDuration(time.Millisecond*50, http.StatusFound),
+			},
+			wantStatusCode: http.StatusFound,
+		},
+		{
+			name: "AnyAuth succeeds if any middleware passes regardless of order and time",
+			inputMiddlwares: []MiddlewareFunc{
+				mwFailEveryRequest,
+				mwSucceedAfterDuration(time.Millisecond*25, http.StatusFound),
+				mwFailAfterDuration(time.Millisecond*50, http.StatusUnauthorized),
+			},
+			wantStatusCode: http.StatusFound,
+		},
+		{
+			name: "AnyAuth uses last succeeding middleware if multiple middlewares pass",
+			inputMiddlwares: []MiddlewareFunc{
+				mwFailEveryRequest,
+				mwPassEveryRequest,
+				mwSucceedAfterDuration(time.Millisecond*25, http.StatusOK),
+				mwSucceedAfterDuration(time.Millisecond*50, http.StatusAccepted), // is used since latest succeeding middleware
+			},
+			wantStatusCode: http.StatusAccepted,
+		},
+		{
+			name: "AnyAuth uses first failing middleware if all middlewares fail",
+			inputMiddlwares: []MiddlewareFunc{
+				mwFailEveryRequest, // is used since earliest failing middleware
+				mwFailAfterDuration(time.Millisecond*25, http.StatusUnauthorized),
+				mwFailAfterDuration(time.Millisecond*50, http.StatusForbidden),
+			},
+			wantStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rr := httptest.NewRecorder()
+
+			h := bouncer.AnyAuth(tt.inputMiddlwares, testHandler200)
+			h.ServeHTTP(rr, req)
+
+			is.Equal(tt.wantStatusCode, rr.Code, fmt.Sprintf("Status should be %d", tt.wantStatusCode))
+		})
+	}
+}

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,7 +86,7 @@ func Test_AnyAuth(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		inputMiddlwares []MiddlewareFunc
+		inputMiddlwares []mux.MiddlewareFunc
 		wantStatusCode  int
 	}{
 		{
@@ -95,17 +96,17 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name:            "AnyAuth middleware succeeds with passing middleware",
-			inputMiddlwares: []MiddlewareFunc{mwPassEveryRequest},
+			inputMiddlwares: []mux.MiddlewareFunc{mwPassEveryRequest},
 			wantStatusCode:  http.StatusFound,
 		},
 		{
 			name:            "AnyAuth fails with failing middleware",
-			inputMiddlwares: []MiddlewareFunc{mwFailEveryRequest},
+			inputMiddlwares: []mux.MiddlewareFunc{mwFailEveryRequest},
 			wantStatusCode:  http.StatusBadRequest,
 		},
 		{
 			name: "AnyAuth succeeds if first middleware successfully handles request",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwPassEveryRequest,
 				mwFailEveryRequest,
 			},
@@ -113,7 +114,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth succeeds if last middleware successfully handles request",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwFailEveryRequest,
 				mwPassEveryRequest,
 			},
@@ -121,7 +122,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth succeeds if first middleware successfully handles request after a failing middleware",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwSucceedAfterDuration(time.Millisecond*50, http.StatusFound),
 				mwFailEveryRequest,
 			},
@@ -129,7 +130,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth succeeds if last middleware successfully handles request after a failing middleware",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwFailEveryRequest,
 				mwSucceedAfterDuration(time.Millisecond*50, http.StatusFound),
 			},
@@ -137,7 +138,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth succeeds if any middleware passes regardless of order and time",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwFailEveryRequest,
 				mwSucceedAfterDuration(time.Millisecond*25, http.StatusFound),
 				mwFailAfterDuration(time.Millisecond*50, http.StatusUnauthorized),
@@ -146,7 +147,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth uses last succeeding middleware if multiple middlewares pass",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwFailEveryRequest,
 				mwPassEveryRequest,
 				mwSucceedAfterDuration(time.Millisecond*25, http.StatusOK),
@@ -156,7 +157,7 @@ func Test_AnyAuth(t *testing.T) {
 		},
 		{
 			name: "AnyAuth uses first failing middleware if all middlewares fail",
-			inputMiddlwares: []MiddlewareFunc{
+			inputMiddlwares: []mux.MiddlewareFunc{
 				mwFailEveryRequest, // is used since earliest failing middleware
 				mwFailAfterDuration(time.Millisecond*25, http.StatusUnauthorized),
 				mwFailAfterDuration(time.Millisecond*50, http.StatusForbidden),

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -172,7 +172,7 @@ func (server *Server) Start() error {
 
 	var fileHandler = file.NewHandler(filepath.Join(server.AssetsPath, "public"))
 
-	var endpointHelmHandler = helm.NewHandler(requestBouncer, server.DataStore, server.KubernetesDeployer, server.HelmPackageManager, server.KubeConfigService)
+	var endpointHelmHandler = helm.NewHandler(requestBouncer, server.DataStore, server.JWTService, server.KubernetesDeployer, server.HelmPackageManager, server.KubeConfigService)
 
 	var helmTemplatesHandler = helm.NewTemplateHandler(requestBouncer, server.HelmPackageManager)
 


### PR DESCRIPTION
Closes [EE-1891](https://portainer.atlassian.net/browse/EE-1891).

## Changelog

- Additional of `AnyAuth` middleware - into which one can pass in multiple auth middlewares and if any middlewares successfully process the request, then the successful middleware is used to process the actual request.
  - This allows us to support multiple auth paradigms
  - The API access token auth is in TODO as the backend implementation requires access to the datastore which will contain api access tokens - to be implemented by [EE-1889](https://portainer.atlassian.net/browse/EE-1889).  