### PR TITLE
style(images): remove files filter from upload image task EE-1944

### DIFF
--- a/app/docker/views/images/import/importimage.html
+++ b/app/docker/views/images/import/importimage.html
@@ -19,7 +19,7 @@
           </div>
           <div class="form-group">
             <div class="col-sm-12">
-              <button type="button" class="btn btn-sm btn-primary" ngf-select ngf-min-size="10" ngf-accept="'application/x-tar,application/x-gzip'" ng-model="formValues.UploadFile"
+              <button type="button" class="btn btn-sm btn-primary" ngf-select ngf-min-size="10" ng-model="formValues.UploadFile"
                 >Select file</button
               >
               <span style="margin-left: 5px;">


### PR DESCRIPTION
The ngf-accept file filter has been removed as it erroneously hides accepted file types such as .tar.xz and .tar.bz2
(I raised that issue because I thought that those formats were not accepted by the front-end).

Attempts to add application/x-bzip2 and application/x-xz failed as they are not accepted MIME types.

Closes https://github.com/portainer/portainer/issues/5220