### PR TITLE
fix(webhooks): support image names containing a port number [EE-493]

### DIFF
--- a/api/http/handler/webhooks/webhook_execute.go
+++ b/api/http/handler/webhooks/webhook_execute.go
@@ -73,11 +73,17 @@ func (handler *Handler) executeServiceWebhook(w http.ResponseWriter, endpoint *p
 	}
 
 	service.Spec.TaskTemplate.ForceUpdate++
+	
+	var imageName = strings.Split(service.Spec.TaskTemplate.ContainerSpec.Image, "@sha")[0]
 
 	if imageTag != "" {
-		service.Spec.TaskTemplate.ContainerSpec.Image = strings.Split(service.Spec.TaskTemplate.ContainerSpec.Image, ":")[0] + ":" + imageTag
+		var tagIndex = strings.LastIndex(imageName, ":")
+		if tagIndex == -1 {
+	  		tagIndex = len(imageName)
+		}
+		service.Spec.TaskTemplate.ContainerSpec.Image = imageName[:tagIndex] + ":" + imageTag
 	} else {
-		service.Spec.TaskTemplate.ContainerSpec.Image = strings.Split(service.Spec.TaskTemplate.ContainerSpec.Image, "@sha")[0]
+		service.Spec.TaskTemplate.ContainerSpec.Image = imageName
 	}
 
 	_, err = dockerClient.ServiceUpdate(context.Background(), resourceID, service.Version, service.Spec, dockertypes.ServiceUpdateOptions{QueryRegistry: true})


### PR DESCRIPTION
This fixes a bug where image names that contain a port number were inadvertently truncated (because port numbers are specified with a colon, just like the image tag).

For example, updating an image named `registry.example.com:5000/myimage:oldtag` with the new image tag `newtag` was incorrectly transformed into `registry.example.com:newtag`

---

I'm unfortunately unfamiliar with testing in Go, so I have not been able to add any automated tests. However, I have tested this fix manually, by performing the following steps:

1. Create a service in Portainer with the image `registry.example.com:5000/myimage:latest`
2. Enable the webhook in the Portainer UI
3. Make a request to the webhook _without_ specifying a new tag, e.g.:
  ` curl -X POST -k https://localhost:9443/api/webhooks/f9448502-a15d-47d5-9062-b2bf1ca7d0fb`
4. Reload the service page in Portainer and verify that the new image name is _unchanged_, but a new task is being deployed
5. Make a request to the webhook and _specify a new tag_, e.g.:
  ` curl -X POST -k https://localhost:9443/api/webhooks/f9448502-a15d-47d5-9062-b2bf1ca7d0fb?tag=newtag`
4. Reload the service page in Portainer and verify that the new image name is `registry.example.com:5000/myimage:newtag`

---
This fixes #4526