### PR TITLE
fix(migration): bubble up recovered panic in new error EE-1971

### DIFF
--- a/api/bolt/migrate_data.go
+++ b/api/bolt/migrate_data.go
@@ -26,8 +26,9 @@ func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) (err error) {
 		}
 	}()
 
-	err = migrator.Migrate()
-	return
+	// !Important: we must use a named return value in the function definition and not a local
+	// !variable referenced from the closure or else the return value will be incorrectly set
+	return migrator.Migrate()
 }
 
 // MigrateData automatically migrate the data based on the DBVersion.

--- a/api/bolt/migrate_data.go
+++ b/api/bolt/migrate_data.go
@@ -18,14 +18,16 @@ const beforePortainerVersionUpgradeBackup = "portainer.db.bak"
 var migrateLog = plog.NewScopedLog("bolt, migrate")
 
 // FailSafeMigrate backup and restore DB if migration fail
-func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) error {
+func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) (err error) {
 	defer func() {
-		if err := recover(); err != nil {
-			migrateLog.Info(fmt.Sprintf("Error during migration, recovering [%v]", err))
+		if e := recover(); e != nil {
 			store.Rollback(true)
+			err = fmt.Errorf("%v", e)
 		}
 	}()
-	return migrator.Migrate()
+
+	err = migrator.Migrate()
+	return
 }
 
 // MigrateData automatically migrate the data based on the DBVersion.


### PR DESCRIPTION
Fixes [EE-1971](https://portainer.atlassian.net/browse/EE-1971)

An error where a panic during db migration would cause an error like the following to show in the CE edition.

> level=info msg="2021/10/24 08:11:57 The Portainer database is set for Portainer Business Edition, please follow the instructions in our documentation to downgrade it: https://documentation.portainer.io/v2.0-be/downgrade/be-to-ce/"