### PR TITLE
chore(version): update version to 2.9.3 EE-1979

### DIFF
--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -74,7 +74,7 @@ type Handler struct {
 }
 
 // @title PortainerCE API
-// @version 2.9.2
+// @version 2.9.3
 // @description.markdown api-description.md
 // @termsOfService
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1470,7 +1470,7 @@ type (
 
 const (
 	// APIVersion is the version number of the Portainer API
-	APIVersion = "2.9.2"
+	APIVersion = "2.9.3"
 	// DBVersion is the version number of the Portainer database
 	DBVersion = 33
 	// ComposeSyntaxMaxVersion is a maximum supported version of the docker compose syntax

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Portainer.io",
   "name": "portainer",
   "homepage": "http://portainer.io",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "repository": {
     "type": "git",
     "url": "git@github.com:portainer/portainer.git"


### PR DESCRIPTION
Pre-release for 2.9.3

[EE-1979](https://portainer.atlassian.net/browse/EE-1979)

Branch release/2.9  is already done.  This is for develop