### PR TITLE
feat(api-key): user-access-token generation endpoint EE-1889 EE-1888 EE-1895

### DIFF
--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -6,7 +6,7 @@ import (
 
 // APIKeyService represents a service for managing API keys.
 type APIKeyService interface {
-	GenerateApiKey(userID portainer.UserID, description string) ([]byte, error)
+	GenerateApiKey(userID portainer.UserID, description string) ([]byte, *portainer.APIKey, error)
 	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
 	GetAPIKey(digest string) (*portainer.APIKey, error)
 	DeleteAPIKey(userID portainer.UserID, apiKeyID portainer.APIKeyID) error

--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -1,0 +1,13 @@
+package apikey
+
+import (
+	portainer "github.com/portainer/portainer/api"
+)
+
+// APIKeyService represents a service for managing API keys.
+type APIKeyService interface {
+	GenerateApiKey(userID portainer.UserID, description string) ([]byte, error)
+	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
+	GetAPIKey(digest string) (*portainer.APIKey, error)
+	DeleteAPIKey(userID portainer.UserID, apiKeyID portainer.APIKeyID) error
+}

--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -11,5 +11,5 @@ type APIKeyService interface {
 	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
 	GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error)
 	UpdateAPIKey(apiKey *portainer.APIKey) error
-	DeleteAPIKey(userID portainer.UserID, apiKeyID portainer.APIKeyID) error
+	DeleteAPIKey(apiKeyID portainer.APIKeyID) error
 }

--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -6,8 +6,10 @@ import (
 
 // APIKeyService represents a service for managing API keys.
 type APIKeyService interface {
-	GenerateApiKey(userID portainer.UserID, description string) ([]byte, *portainer.APIKey, error)
+	HashRaw(rawKey string) ([]byte, error)
+	GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error)
 	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
-	GetAPIKey(digest string) (*portainer.APIKey, error)
+	GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error)
+	UpdateAPIKey(apiKey *portainer.APIKey) error
 	DeleteAPIKey(userID portainer.UserID, apiKeyID portainer.APIKeyID) error
 }

--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -1,6 +1,9 @@
 package apikey
 
 import (
+	"crypto/rand"
+	"io"
+
 	portainer "github.com/portainer/portainer/api"
 )
 
@@ -12,4 +15,14 @@ type APIKeyService interface {
 	GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error)
 	UpdateAPIKey(apiKey *portainer.APIKey) error
 	DeleteAPIKey(apiKeyID portainer.APIKeyID) error
+}
+
+// generateRandomKey generates a random key of specified length
+// source: https://github.com/gorilla/securecookie/blob/master/securecookie.go#L515
+func generateRandomKey(length int) []byte {
+	k := make([]byte, length)
+	if _, err := io.ReadFull(rand.Reader, k); err != nil {
+		return nil
+	}
+	return k
 }

--- a/api/apikey/cache.go
+++ b/api/apikey/cache.go
@@ -1,0 +1,50 @@
+package apikey
+
+import (
+	"sync"
+
+	cmap "github.com/orcaman/concurrent-map"
+	portainer "github.com/portainer/portainer/api"
+)
+
+type apiKeyCache struct {
+	cache cmap.ConcurrentMap
+	mux   sync.RWMutex
+}
+
+// NewAPIKeyCache creates a new cache for API keys
+func NewAPIKeyCache() *apiKeyCache {
+	return &apiKeyCache{
+		cache: cmap.New(),
+	}
+}
+
+// GetAPIKey returns the api-key associated to an api-key digest
+// This is required because HTTP requests will contain the digest of the API key in header,
+// the digest value must be mapped to an api-key to map to a portainer user.
+func (c *apiKeyCache) GetAPIKey(digest string) (*portainer.APIKey, bool) {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	apiKey, ok := c.cache.Get(digest)
+	if !ok {
+		return nil, false
+	}
+	return apiKey.(*portainer.APIKey), true
+}
+
+// Set persists an API key to the cache
+func (c *apiKeyCache) Set(apikey *portainer.APIKey) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.cache.Set(string(apikey.Digest[:]), apikey)
+}
+
+// Delete removes an API key from the cache
+func (c *apiKeyCache) Delete(digest string) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.cache.Remove(digest)
+}

--- a/api/apikey/cache.go
+++ b/api/apikey/cache.go
@@ -1,6 +1,8 @@
 package apikey
 
 import (
+	"time"
+
 	cmap "github.com/orcaman/concurrent-map"
 	portainer "github.com/portainer/portainer/api"
 )
@@ -17,12 +19,13 @@ type entry struct {
 // digest value must be mapped to a portainer user (and respective key data) for validation.
 // This cache is used to avoid multiple database queries to retrieve these user/key associated to the digest.
 type apiKeyCache struct {
-	cache cmap.ConcurrentMap // map[string]entry
+	cache               cmap.ConcurrentMap // map[string]entry
+	keyEvictionDuration time.Duration      // duration after which an API key is automatically evicted from the cache
 }
 
 // NewAPIKeyCache creates a new cache for API keys
-func NewAPIKeyCache() *apiKeyCache {
-	return &apiKeyCache{cache: cmap.New()}
+func NewAPIKeyCache(keyEvictionDuration time.Duration) *apiKeyCache {
+	return &apiKeyCache{cache: cmap.New(), keyEvictionDuration: keyEvictionDuration}
 }
 
 // Get returns the user/key associated to an api-key's digest
@@ -44,6 +47,12 @@ func (c *apiKeyCache) Set(digest []byte, user portainer.User, apiKey portainer.A
 		user:   user,
 		apiKey: apiKey,
 	})
+
+	// automatically evict set key after keyEvictionDuration
+	go func() {
+		<-time.After(c.keyEvictionDuration)
+		c.cache.Remove(string(digest))
+	}()
 }
 
 // Delete evicts a digest's user/key entry key from the cache

--- a/api/apikey/cache.go
+++ b/api/apikey/cache.go
@@ -1,11 +1,11 @@
 package apikey
 
 import (
-	"time"
-
-	cmap "github.com/orcaman/concurrent-map"
+	lru "github.com/hashicorp/golang-lru"
 	portainer "github.com/portainer/portainer/api"
 )
+
+const defaultAPIKeyCacheSize = 1024
 
 // entry is a tuple containing the user and API key associated to an API key digest
 type entry struct {
@@ -19,13 +19,15 @@ type entry struct {
 // digest value must be mapped to a portainer user (and respective key data) for validation.
 // This cache is used to avoid multiple database queries to retrieve these user/key associated to the digest.
 type apiKeyCache struct {
-	cache               cmap.ConcurrentMap // map[string]entry
-	keyEvictionDuration time.Duration      // duration after which an API key is automatically evicted from the cache
+	// cache type [string]entry cache (key: string(digest), value: user/key entry)
+	// note: []byte keys are not supported by golang-lru Cache
+	cache *lru.Cache
 }
 
 // NewAPIKeyCache creates a new cache for API keys
-func NewAPIKeyCache(keyEvictionDuration time.Duration) *apiKeyCache {
-	return &apiKeyCache{cache: cmap.New(), keyEvictionDuration: keyEvictionDuration}
+func NewAPIKeyCache(cacheSize int) *apiKeyCache {
+	cache, _ := lru.New(cacheSize)
+	return &apiKeyCache{cache: cache}
 }
 
 // Get returns the user/key associated to an api-key's digest
@@ -43,16 +45,10 @@ func (c *apiKeyCache) Get(digest []byte) (portainer.User, portainer.APIKey, bool
 
 // Set persists a user/key entry to the cache
 func (c *apiKeyCache) Set(digest []byte, user portainer.User, apiKey portainer.APIKey) {
-	c.cache.Set(string(digest), entry{
+	c.cache.Add(string(digest), entry{
 		user:   user,
 		apiKey: apiKey,
 	})
-
-	// automatically evict set key after keyEvictionDuration
-	go func() {
-		<-time.After(c.keyEvictionDuration)
-		c.cache.Remove(string(digest))
-	}()
 }
 
 // Delete evicts a digest's user/key entry key from the cache

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -33,7 +33,7 @@ func (a *apiKeyService) HashRaw(rawKey string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to decode raw API key")
 	}
-	hashDigest := sha256.Sum256([]byte(decodedRawAPIKey))
+	hashDigest := sha256.Sum256(decodedRawAPIKey)
 	return hashDigest[:], nil
 }
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -110,6 +110,7 @@ func (a *apiKeyService) DeleteAPIKey(userID portainer.UserID, apiKeyID portainer
 	for _, key := range apiKeys {
 		if key.ID == apiKeyID {
 			apiKey = &key
+			break
 		}
 	}
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -23,7 +23,7 @@ func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository, userRepositor
 	return &apiKeyService{
 		apiKeyRepository: apiKeyRepository,
 		userRepository:   userRepository,
-		cache:            NewAPIKeyCache(),
+		cache:            NewAPIKeyCache(time.Hour),
 	}
 }
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -93,11 +93,13 @@ func (a *apiKeyService) GetDigestUserAndKey(digest []byte) (portainer.User, port
 	return *user, *apiKey, nil
 }
 
-// UpdateAPIKey updates an API key and clears the user/api-key cache entry for the digest.
+// UpdateAPIKey updates an API key and in cache and database.
 func (a *apiKeyService) UpdateAPIKey(apiKey *portainer.APIKey) error {
-	if user, _, ok := a.cache.Get(apiKey.Digest); ok {
-		a.cache.Set(apiKey.Digest, user, *apiKey)
+	user, _, err := a.GetDigestUserAndKey(apiKey.Digest)
+	if err != nil {
+		return errors.Wrap(err, "Unable to retrieve API key")
 	}
+	a.cache.Set(apiKey.Digest, user, *apiKey)
 	return a.apiKeyRepository.UpdateAPIKey(apiKey)
 }
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -23,7 +23,7 @@ func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository, userRepositor
 	return &apiKeyService{
 		apiKeyRepository: apiKeyRepository,
 		userRepository:   userRepository,
-		cache:            NewAPIKeyCache(time.Hour),
+		cache:            NewAPIKeyCache(defaultAPIKeyCacheSize),
 	}
 }
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -1,0 +1,94 @@
+package apikey
+
+import (
+	"crypto/sha256"
+	"time"
+
+	"github.com/gorilla/securecookie"
+	"github.com/pkg/errors"
+
+	portainer "github.com/portainer/portainer/api"
+)
+
+type apiKeyService struct {
+	apiKeyRepository portainer.APIKeyRepository
+	cache            *apiKeyCache
+}
+
+func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository) *apiKeyService {
+	return &apiKeyService{
+		apiKeyRepository: apiKeyRepository,
+		cache:            NewAPIKeyCache(),
+	}
+}
+
+// GenerateApiKey generates an API key for a user; returns rawApiKey (for one-time display).
+// The generated API key is stored in the database.
+func (a *apiKeyService) GenerateApiKey(userID portainer.UserID, description string) ([]byte, error) {
+	rawAPIKey := securecookie.GenerateRandomKey(32)
+	rawAPIKeyChars := []rune(string(rawAPIKey))
+	hashDigest := sha256.Sum256(rawAPIKey)
+
+	apiKey := &portainer.APIKey{
+		UserID:      userID,
+		Description: description,
+		Prefix:      [3]rune{rawAPIKeyChars[0], rawAPIKeyChars[1], rawAPIKeyChars[2]},
+		DateCreated: time.Now(),
+		Digest:      hashDigest,
+	}
+
+	err := a.apiKeyRepository.CreateAPIKey(apiKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create API key")
+	}
+
+	// persist api-key to cache
+	a.cache.Set(apiKey)
+
+	return rawAPIKey, nil
+}
+
+// GetAPIKeys returns all the API keys associated to a user.
+func (a *apiKeyService) GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error) {
+	return a.apiKeyRepository.GetAPIKeysByUserID(userID)
+}
+
+// GetAPIKey returns the api-key associated to a specified hash digest.
+func (a *apiKeyService) GetAPIKey(digest string) (*portainer.APIKey, error) {
+	// get api key from cache if possible
+	cachedKey, ok := a.cache.GetAPIKey(digest)
+	if ok {
+		return cachedKey, nil
+	}
+
+	apiKey, err := a.apiKeyRepository.GetAPIKeyByDigest(digest)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to retrieve API key")
+	}
+
+	return &apiKey, nil
+}
+
+// DeleteAPIKey deletes an API key and removes the digest/api-key entry from the cache.
+func (a *apiKeyService) DeleteAPIKey(userID portainer.UserID, apiKeyID portainer.APIKeyID) error {
+	apiKeys, err := a.GetAPIKeys(userID)
+	if err != nil {
+		return errors.Wrap(err, "Unable to retrieve API keys associated to the user")
+	}
+
+	var apiKey *portainer.APIKey
+	for _, key := range apiKeys {
+		if key.ID == apiKeyID {
+			apiKey = &key
+		}
+	}
+
+	if apiKey == nil {
+		return errors.New("Invalid API key ID")
+	}
+
+	// retrieve api-keys from cache
+	a.cache.Delete(string(apiKey.Digest[:]))
+
+	return a.apiKeyRepository.DeleteAPIKey(apiKeyID)
+}

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -15,40 +15,52 @@ var ErrInvalidAPIKey = errors.New("Invalid API key")
 
 type apiKeyService struct {
 	apiKeyRepository portainer.APIKeyRepository
+	userRepository   portainer.UserService
 	cache            *apiKeyCache
 }
 
-func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository) *apiKeyService {
+func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository, userRepository portainer.UserService) *apiKeyService {
 	return &apiKeyService{
 		apiKeyRepository: apiKeyRepository,
+		userRepository:   userRepository,
 		cache:            NewAPIKeyCache(),
 	}
 }
 
-// GenerateApiKey generates an API key for a user; also returns rawApiKey (for one-time display).
-// The generated API key is stored in the database.
-func (a *apiKeyService) GenerateApiKey(userID portainer.UserID, description string) ([]byte, *portainer.APIKey, error) {
+// HashRaw computes a hash digest of provided base64 encoded raw API key.
+func (a *apiKeyService) HashRaw(rawKey string) ([]byte, error) {
+	decodedRawAPIKey, err := base64.StdEncoding.DecodeString(rawKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to decode raw API key")
+	}
+	hashDigest := sha256.Sum256([]byte(decodedRawAPIKey))
+	return hashDigest[:], nil
+}
+
+// GenerateApiKey generates a base64 encoded raw API key for a user (for one-time display).
+// The generated API key is stored in the cache and database.
+func (a *apiKeyService) GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error) {
 	rawAPIKey := securecookie.GenerateRandomKey(32)
 	encodedRawAPIKey := base64.StdEncoding.EncodeToString(rawAPIKey)
 	hashDigest := sha256.Sum256(rawAPIKey)
 
 	apiKey := &portainer.APIKey{
-		UserID:      userID,
+		UserID:      user.ID,
 		Description: description,
 		Prefix:      encodedRawAPIKey[:3],
 		DateCreated: time.Now(),
-		Digest:      &hashDigest,
+		Digest:      hashDigest[:],
 	}
 
 	err := a.apiKeyRepository.CreateAPIKey(apiKey)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Unable to create API key")
+		return "", nil, errors.Wrap(err, "Unable to create API key")
 	}
 
 	// persist api-key to cache
-	a.cache.Set(apiKey)
+	a.cache.Set(apiKey.Digest, user, *apiKey)
 
-	return rawAPIKey, apiKey, nil
+	return encodedRawAPIKey, apiKey, nil
 }
 
 // GetAPIKeys returns all the API keys associated to a user.
@@ -56,20 +68,35 @@ func (a *apiKeyService) GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey,
 	return a.apiKeyRepository.GetAPIKeysByUserID(userID)
 }
 
-// GetAPIKey returns the api-key associated to a specified hash digest.
-func (a *apiKeyService) GetAPIKey(digest string) (*portainer.APIKey, error) {
+// GetDigestUserAndKey returns the user and api-key associated to a specified hash digest.
+// A cache lookup is performed first; if the user/api-key is not found in the cache, respective database lookups are performed.
+func (a *apiKeyService) GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error) {
 	// get api key from cache if possible
-	cachedKey, ok := a.cache.GetAPIKey(digest)
+	cachedUser, cachedKey, ok := a.cache.Get(digest)
 	if ok {
-		return cachedKey, nil
+		return cachedUser, cachedKey, nil
 	}
 
 	apiKey, err := a.apiKeyRepository.GetAPIKeyByDigest(digest)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to retrieve API key")
+		return portainer.User{}, portainer.APIKey{}, errors.Wrap(err, "Unable to retrieve API key")
 	}
 
-	return &apiKey, nil
+	user, err := a.userRepository.User(apiKey.UserID)
+	if err != nil {
+		return portainer.User{}, portainer.APIKey{}, errors.Wrap(err, "Unable to retrieve digest user")
+	}
+
+	// persist api-key to cache - for quicker future lookups
+	a.cache.Set(apiKey.Digest, *user, *apiKey)
+
+	return *user, *apiKey, nil
+}
+
+// UpdateAPIKey updates an API key and clears the user/api-key cache entry for the digest.
+func (a *apiKeyService) UpdateAPIKey(apiKey *portainer.APIKey) error {
+	a.cache.Delete(apiKey.Digest)
+	return a.apiKeyRepository.UpdateAPIKey(apiKey)
 }
 
 // DeleteAPIKey deletes an API key and removes the digest/api-key entry from the cache.
@@ -90,8 +117,8 @@ func (a *apiKeyService) DeleteAPIKey(userID portainer.UserID, apiKeyID portainer
 		return ErrInvalidAPIKey
 	}
 
-	// retrieve api-keys from cache
-	a.cache.Delete(string(apiKey.Digest[:]))
+	// delete the user/api-key from cache
+	a.cache.Delete(apiKey.Digest)
 
 	return a.apiKeyRepository.DeleteAPIKey(apiKeyID)
 }

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -95,7 +95,9 @@ func (a *apiKeyService) GetDigestUserAndKey(digest []byte) (portainer.User, port
 
 // UpdateAPIKey updates an API key and clears the user/api-key cache entry for the digest.
 func (a *apiKeyService) UpdateAPIKey(apiKey *portainer.APIKey) error {
-	a.cache.Delete(apiKey.Digest)
+	if user, _, ok := a.cache.Get(apiKey.Digest); ok {
+		a.cache.Set(apiKey.Digest, user, *apiKey)
+	}
 	return a.apiKeyRepository.UpdateAPIKey(apiKey)
 }
 

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -11,6 +11,8 @@ import (
 	portainer "github.com/portainer/portainer/api"
 )
 
+var ErrInvalidAPIKey = errors.New("Invalid API key")
+
 type apiKeyService struct {
 	apiKeyRepository portainer.APIKeyRepository
 	cache            *apiKeyCache
@@ -33,9 +35,9 @@ func (a *apiKeyService) GenerateApiKey(userID portainer.UserID, description stri
 	apiKey := &portainer.APIKey{
 		UserID:      userID,
 		Description: description,
-		Prefix:      [3]rune{rune(encodedRawAPIKey[0]), rune(encodedRawAPIKey[1]), rune(encodedRawAPIKey[2])},
+		Prefix:      encodedRawAPIKey[:3],
 		DateCreated: time.Now(),
-		Digest:      hashDigest,
+		Digest:      &hashDigest,
 	}
 
 	err := a.apiKeyRepository.CreateAPIKey(apiKey)
@@ -85,7 +87,7 @@ func (a *apiKeyService) DeleteAPIKey(userID portainer.UserID, apiKeyID portainer
 	}
 
 	if apiKey == nil {
-		return errors.New("Invalid API key ID")
+		return ErrInvalidAPIKey
 	}
 
 	// retrieve api-keys from cache

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gorilla/securecookie"
 	"github.com/pkg/errors"
 
 	portainer "github.com/portainer/portainer/api"
@@ -41,7 +40,7 @@ func (a *apiKeyService) HashRaw(rawKey string) ([]byte, error) {
 // GenerateApiKey generates a base64 encoded raw API key for a user (for one-time display).
 // The generated API key is stored in the cache and database.
 func (a *apiKeyService) GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error) {
-	rawAPIKey := securecookie.GenerateRandomKey(32)
+	rawAPIKey := generateRandomKey(32)
 	encodedRawAPIKey := base64.StdEncoding.EncodeToString(rawAPIKey)
 	hashDigest := sha256.Sum256(rawAPIKey)
 

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -1,12 +1,61 @@
 package apikey
 
 import (
+	"encoding/base64"
 	"testing"
 
+	"github.com/portainer/portainer/api/bolt"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_SatisfiesAPIKeyServiceInterface(t *testing.T) {
 	is := assert.New(t)
 	is.Implements((*APIKeyService)(nil), NewAPIKeyService(nil))
+}
+
+func Test_GenerateApiKey(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository())
+
+	t.Run("Successfully generates API key", func(t *testing.T) {
+		desc := "test-1"
+		rawKey, apiKey, err := service.GenerateApiKey(1, desc)
+		is.NoError(err)
+		is.NotEmpty(rawKey)
+		is.NotEmpty(apiKey)
+		is.Equal(desc, apiKey.Description)
+	})
+
+	t.Run("Prefix matches encoded key prefix", func(t *testing.T) {
+		rawKey, apiKey, err := service.GenerateApiKey(1, "test-2")
+		is.NoError(err)
+
+		encodedKey := base64.StdEncoding.EncodeToString(rawKey)
+		is.Equal(encodedKey[:3], string(apiKey.Prefix[:]))
+	})
+
+	t.Run("Successfully caches API key", func(t *testing.T) {
+		_, apiKey, err := service.GenerateApiKey(1, "test-3")
+		is.NoError(err)
+
+		apiKeyFromCache, ok := service.cache.GetAPIKey(string(apiKey.Digest[:]))
+		is.True(ok)
+		is.Equal(apiKey, apiKeyFromCache)
+	})
+}
+
+func Test_GetAPIKeys(t *testing.T) {
+	// TODO: implement
+}
+
+func Test_GetAPIKey(t *testing.T) {
+	// TODO: implement
+}
+
+func Test_DeleteAPIKey(t *testing.T) {
+	// TODO: implement
 }

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -1,6 +1,7 @@
 package apikey
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"testing"
 
@@ -45,6 +46,19 @@ func Test_GenerateApiKey(t *testing.T) {
 		apiKeyFromCache, ok := service.cache.GetAPIKey(string(apiKey.Digest[:]))
 		is.True(ok)
 		is.Equal(apiKey, apiKeyFromCache)
+	})
+
+	t.Run("Decoded raw api-key digest matches generated digest", func(t *testing.T) {
+		rawKey, apiKey, err := service.GenerateApiKey(1, "test-4")
+		is.NoError(err)
+
+		encodedKey := base64.StdEncoding.EncodeToString(rawKey) // this will be provided by the user
+		decodedKey, err := base64.StdEncoding.DecodeString(encodedKey)
+		is.NoError(err)
+
+		generatedDigest := sha256.Sum256(decodedKey)
+
+		is.Equal(apiKey.Digest, generatedDigest)
 	})
 }
 

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -1,0 +1,12 @@
+package apikey
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SatisfiesAPIKeyServiceInterface(t *testing.T) {
+	is := assert.New(t)
+	is.Implements((*APIKeyService)(nil), NewAPIKeyService(nil))
+}

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -203,7 +203,7 @@ func Test_DeleteAPIKey(t *testing.T) {
 		is.NoError(err)
 		is.Equal(*apiKey, apiKeyGot)
 
-		err = service.DeleteAPIKey(user.ID, apiKey.ID)
+		err = service.DeleteAPIKey(apiKey.ID)
 		is.NoError(err)
 
 		_, _, err = service.GetDigestUserAndKey(apiKey.Digest)
@@ -219,7 +219,7 @@ func Test_DeleteAPIKey(t *testing.T) {
 		is.True(ok)
 		is.Equal(*apiKey, apiKeyFromCache)
 
-		err = service.DeleteAPIKey(user.ID, apiKey.ID)
+		err = service.DeleteAPIKey(apiKey.ID)
 		is.NoError(err)
 
 		_, _, ok = service.cache.Get(apiKey.Digest)

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -3,15 +3,37 @@ package apikey
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"log"
 	"testing"
+	"time"
 
+	"github.com/gorilla/securecookie"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_SatisfiesAPIKeyServiceInterface(t *testing.T) {
 	is := assert.New(t)
-	is.Implements((*APIKeyService)(nil), NewAPIKeyService(nil))
+	is.Implements((*APIKeyService)(nil), NewAPIKeyService(nil, nil))
+}
+
+func Test_HashRaw(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully decodes base64 encoded string and generates hash digest", func(t *testing.T) {
+		rawAPIKey := securecookie.GenerateRandomKey(32)
+		encodedRawAPIKey := base64.StdEncoding.EncodeToString(rawAPIKey)
+		digest, err := service.HashRaw(encodedRawAPIKey)
+		is.NoError(err)
+		is.NotEmpty(digest)
+		is.Len(digest, 32)
+	})
 }
 
 func Test_GenerateApiKey(t *testing.T) {
@@ -20,11 +42,11 @@ func Test_GenerateApiKey(t *testing.T) {
 	store, teardown := bolt.MustNewTestStore(true)
 	defer teardown()
 
-	service := NewAPIKeyService(store.APIKeyRepository())
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
 
 	t.Run("Successfully generates API key", func(t *testing.T) {
 		desc := "test-1"
-		rawKey, apiKey, err := service.GenerateApiKey(1, desc)
+		rawKey, apiKey, err := service.GenerateApiKey(portainer.User{ID: 1}, desc)
 		is.NoError(err)
 		is.NotEmpty(rawKey)
 		is.NotEmpty(apiKey)
@@ -32,45 +54,175 @@ func Test_GenerateApiKey(t *testing.T) {
 	})
 
 	t.Run("Prefix matches encoded key prefix", func(t *testing.T) {
-		rawKey, apiKey, err := service.GenerateApiKey(1, "test-2")
+		rawKey, apiKey, err := service.GenerateApiKey(portainer.User{ID: 1}, "test-2")
 		is.NoError(err)
 
-		encodedKey := base64.StdEncoding.EncodeToString(rawKey)
-		is.Equal(encodedKey[:3], apiKey.Prefix)
+		is.Equal(rawKey[:3], apiKey.Prefix)
 		is.Len(apiKey.Prefix, 3)
 	})
 
 	t.Run("Successfully caches API key", func(t *testing.T) {
-		_, apiKey, err := service.GenerateApiKey(1, "test-3")
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-3")
 		is.NoError(err)
 
-		apiKeyFromCache, ok := service.cache.GetAPIKey(string(apiKey.Digest[:]))
+		userFromCache, apiKeyFromCache, ok := service.cache.Get(apiKey.Digest)
 		is.True(ok)
-		is.Equal(apiKey, apiKeyFromCache)
+		is.Equal(user, userFromCache)
+		is.Equal(apiKey, &apiKeyFromCache)
 	})
 
 	t.Run("Decoded raw api-key digest matches generated digest", func(t *testing.T) {
-		rawKey, apiKey, err := service.GenerateApiKey(1, "test-4")
+		rawKey, apiKey, err := service.GenerateApiKey(portainer.User{ID: 1}, "test-4")
 		is.NoError(err)
 
-		encodedKey := base64.StdEncoding.EncodeToString(rawKey) // this will be provided by the user
-		decodedKey, err := base64.StdEncoding.DecodeString(encodedKey)
+		decodedKey, err := base64.StdEncoding.DecodeString(rawKey)
 		is.NoError(err)
 
 		generatedDigest := sha256.Sum256(decodedKey)
 
-		is.Equal(apiKey.Digest, generatedDigest)
+		is.Equal(apiKey.Digest, generatedDigest[:])
 	})
 }
 
 func Test_GetAPIKeys(t *testing.T) {
-	// TODO: implement
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully returns all API keys", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, _, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+		_, _, err = service.GenerateApiKey(user, "test-2")
+		is.NoError(err)
+
+		keys, err := service.GetAPIKeys(user.ID)
+		is.NoError(err)
+		is.Len(keys, 2)
+	})
 }
 
-func Test_GetAPIKey(t *testing.T) {
-	// TODO: implement
+func Test_GetDigestUserAndKey(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully returns user and api key associated to digest", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+
+		userGot, apiKeyGot, err := service.GetDigestUserAndKey(apiKey.Digest)
+		is.NoError(err)
+		is.Equal(user, userGot)
+		is.Equal(*apiKey, apiKeyGot)
+	})
+
+	t.Run("Successfully caches user and api key associated to digest", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+
+		userGot, apiKeyGot, err := service.GetDigestUserAndKey(apiKey.Digest)
+		is.NoError(err)
+		is.Equal(user, userGot)
+		is.Equal(*apiKey, apiKeyGot)
+
+		userFromCache, apiKeyFromCache, ok := service.cache.Get(apiKey.Digest)
+		is.True(ok)
+		is.Equal(userGot, userFromCache)
+		is.Equal(apiKeyGot, apiKeyFromCache)
+	})
+}
+
+func Test_UpdateAPIKey(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully updates the api-key LastUsed time", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		store.User().CreateUser(&user)
+		_, apiKey, err := service.GenerateApiKey(user, "test-x")
+		is.NoError(err)
+
+		apiKey.LastUsed = time.Now().UTC()
+		err = service.UpdateAPIKey(apiKey)
+		is.NoError(err)
+
+		_, apiKeyGot, err := service.GetDigestUserAndKey(apiKey.Digest)
+		is.NoError(err)
+
+		log.Println(apiKey)
+		log.Println(apiKeyGot)
+
+		is.Equal(apiKey.LastUsed, apiKeyGot.LastUsed)
+
+	})
+
+	t.Run("Successfully removes api-key from cache upon update", func(t *testing.T) {
+		_, apiKey, err := service.GenerateApiKey(portainer.User{ID: 1}, "test-x2")
+		is.NoError(err)
+
+		_, apiKeyFromCache, ok := service.cache.Get(apiKey.Digest)
+		is.True(ok)
+		is.Equal(*apiKey, apiKeyFromCache)
+
+		err = service.UpdateAPIKey(apiKey)
+		is.NoError(err)
+
+		_, _, ok = service.cache.Get(apiKey.Digest)
+		is.False(ok)
+	})
 }
 
 func Test_DeleteAPIKey(t *testing.T) {
-	// TODO: implement
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully updates the api-key", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+
+		_, apiKeyGot, err := service.GetDigestUserAndKey(apiKey.Digest)
+		is.NoError(err)
+		is.Equal(*apiKey, apiKeyGot)
+
+		err = service.DeleteAPIKey(user.ID, apiKey.ID)
+		is.NoError(err)
+
+		_, _, err = service.GetDigestUserAndKey(apiKey.Digest)
+		is.Error(err)
+	})
+
+	t.Run("Successfully removes api-key from cache upon deletion", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+
+		_, apiKeyFromCache, ok := service.cache.Get(apiKey.Digest)
+		is.True(ok)
+		is.Equal(*apiKey, apiKeyFromCache)
+
+		err = service.DeleteAPIKey(user.ID, apiKey.ID)
+		is.NoError(err)
+
+		_, _, ok = service.cache.Get(apiKey.Digest)
+		is.False(ok)
+	})
 }

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -36,7 +36,8 @@ func Test_GenerateApiKey(t *testing.T) {
 		is.NoError(err)
 
 		encodedKey := base64.StdEncoding.EncodeToString(rawKey)
-		is.Equal(encodedKey[:3], string(apiKey.Prefix[:]))
+		is.Equal(encodedKey[:3], apiKey.Prefix)
+		is.Len(apiKey.Prefix, 3)
 	})
 
 	t.Run("Successfully caches API key", func(t *testing.T) {

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -170,7 +170,7 @@ func Test_UpdateAPIKey(t *testing.T) {
 
 	})
 
-	t.Run("Successfully removes api-key from cache upon update", func(t *testing.T) {
+	t.Run("Successfully updates api-key in cache upon api-key update", func(t *testing.T) {
 		_, apiKey, err := service.GenerateApiKey(portainer.User{ID: 1}, "test-x2")
 		is.NoError(err)
 
@@ -178,11 +178,15 @@ func Test_UpdateAPIKey(t *testing.T) {
 		is.True(ok)
 		is.Equal(*apiKey, apiKeyFromCache)
 
+		apiKey.LastUsed = time.Now().UTC()
+		is.NotEqual(*apiKey, apiKeyFromCache)
+
 		err = service.UpdateAPIKey(apiKey)
 		is.NoError(err)
 
-		_, _, ok = service.cache.Get(apiKey.Digest)
-		is.False(ok)
+		_, updatedAPIKeyFromCache, ok := service.cache.Get(apiKey.Digest)
+		is.True(ok)
+		is.Equal(*apiKey, updatedAPIKeyFromCache)
 	})
 }
 

--- a/api/bolt/apikey/apikey.go
+++ b/api/bolt/apikey/apikey.go
@@ -1,0 +1,73 @@
+package apikey
+
+import (
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/internal"
+
+	"github.com/boltdb/bolt"
+)
+
+const (
+	// BucketName represents the name of the bucket where this service stores data.
+	BucketName = "api_key"
+)
+
+// Service represents a service for managing environment(endpoint) data.
+type Service struct {
+	connection *internal.DbConnection
+}
+
+// NewService creates a new instance of a service.
+func NewService(connection *internal.DbConnection) (*Service, error) {
+	err := internal.CreateBucket(connection, BucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{
+		connection: connection,
+	}, nil
+}
+
+// GetAPIKeysByUserID return an slice containing all the APIKeys a user has access to.
+func (service *Service) GetAPIKeysByUserID(userID portainer.UserID) ([]portainer.APIKey, error) {
+	var result = make([]portainer.APIKey, 0)
+
+	err := service.connection.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			var record portainer.APIKey
+			err := internal.UnmarshalObject(v, &record)
+			if err != nil {
+				return err
+			}
+
+			if record.UserID == userID {
+				result = append(result, record)
+			}
+		}
+
+		return nil
+	})
+
+	return result, err
+}
+
+// CreateKey creates a new APIKey object.
+func (service *Service) CreateKey(record *portainer.APIKey) error {
+	return service.connection.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+
+		id, _ := bucket.NextSequence()
+		record.ID = portainer.APIKeyID(id)
+
+		data, err := internal.MarshalObject(record)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(internal.Itob(int(record.ID)), data)
+	})
+}

--- a/api/bolt/apikey/apikey.go
+++ b/api/bolt/apikey/apikey.go
@@ -29,7 +29,7 @@ func NewService(connection *internal.DbConnection) (*Service, error) {
 	}, nil
 }
 
-// GetAPIKeysByUserID return an slice containing all the APIKeys a user has access to.
+// GetAPIKeysByUserID returns a slice containing all the APIKeys a user has access to.
 func (service *Service) GetAPIKeysByUserID(userID portainer.UserID) ([]portainer.APIKey, error) {
 	var result = make([]portainer.APIKey, 0)
 

--- a/api/bolt/apikeyrepository/apikeyrepository.go
+++ b/api/bolt/apikeyrepository/apikeyrepository.go
@@ -14,7 +14,7 @@ const (
 	BucketName = "api_key"
 )
 
-// Service represents a service for managing environment(endpoint) data.
+// Service represents a service for managing api-key data.
 type Service struct {
 	connection *internal.DbConnection
 }

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/portainer/portainer/api/bolt/apikey"
 	"github.com/portainer/portainer/api/bolt/helmuserrepository"
 
 	"github.com/boltdb/bolt"
@@ -60,6 +61,7 @@ type Store struct {
 	RegistryService           *registry.Service
 	ResourceControlService    *resourcecontrol.Service
 	RoleService               *role.Service
+	APIKeyRepositoryService   *apikey.Service
 	ScheduleService           *schedule.Service
 	SettingsService           *settings.Service
 	SSLSettingsService        *ssl.Service

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/portainer/portainer/api/bolt/apikey"
+	"github.com/portainer/portainer/api/bolt/apikeyrepository"
 	"github.com/portainer/portainer/api/bolt/helmuserrepository"
 
 	"github.com/boltdb/bolt"
@@ -61,7 +61,7 @@ type Store struct {
 	RegistryService           *registry.Service
 	ResourceControlService    *resourcecontrol.Service
 	RoleService               *role.Service
-	APIKeyRepositoryService   *apikey.Service
+	APIKeyRepositoryService   *apikeyrepository.Service
 	ScheduleService           *schedule.Service
 	SettingsService           *settings.Service
 	SSLSettingsService        *ssl.Service

--- a/api/bolt/services.go
+++ b/api/bolt/services.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt/apikey"
 	"github.com/portainer/portainer/api/bolt/customtemplate"
 	"github.com/portainer/portainer/api/bolt/dockerhub"
 	"github.com/portainer/portainer/api/bolt/edgegroup"
@@ -155,6 +156,12 @@ func (store *Store) initServices() error {
 	}
 	store.UserService = userService
 
+	apiKeyService, err := apikey.NewService(store.connection)
+	if err != nil {
+		return err
+	}
+	store.APIKeyRepositoryService = apiKeyService
+
 	versionService, err := version.NewService(store.connection)
 	if err != nil {
 		return err
@@ -229,6 +236,11 @@ func (store *Store) ResourceControl() portainer.ResourceControlService {
 // Role gives access to the Role data management layer
 func (store *Store) Role() portainer.RoleService {
 	return store.RoleService
+}
+
+// APIKeyRepository gives access to the api-key data management layer
+func (store *Store) APIKeyRepository() portainer.APIKeyRepositoryService {
+	return store.APIKeyRepositoryService
 }
 
 // Settings gives access to the Settings data management layer

--- a/api/bolt/services.go
+++ b/api/bolt/services.go
@@ -2,7 +2,7 @@ package bolt
 
 import (
 	portainer "github.com/portainer/portainer/api"
-	"github.com/portainer/portainer/api/bolt/apikey"
+	"github.com/portainer/portainer/api/bolt/apikeyrepository"
 	"github.com/portainer/portainer/api/bolt/customtemplate"
 	"github.com/portainer/portainer/api/bolt/dockerhub"
 	"github.com/portainer/portainer/api/bolt/edgegroup"
@@ -156,7 +156,7 @@ func (store *Store) initServices() error {
 	}
 	store.UserService = userService
 
-	apiKeyService, err := apikey.NewService(store.connection)
+	apiKeyService, err := apikeyrepository.NewService(store.connection)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (store *Store) Role() portainer.RoleService {
 }
 
 // APIKeyRepository gives access to the api-key data management layer
-func (store *Store) APIKeyRepository() portainer.APIKeyRepositoryService {
+func (store *Store) APIKeyRepository() portainer.APIKeyRepository {
 	return store.APIKeyRepositoryService
 }
 

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
 	"github.com/portainer/portainer/api/bolt"
 	"github.com/portainer/portainer/api/chisel"
 	"github.com/portainer/portainer/api/cli"
@@ -112,6 +113,10 @@ func initKubernetesDeployer(kubernetesTokenCacheManager *kubeproxy.TokenCacheMan
 
 func initHelmPackageManager(assetsPath string) (libhelm.HelmPackageManager, error) {
 	return libhelm.NewHelmPackageManager(libhelm.HelmConfig{BinaryPath: assetsPath})
+}
+
+func initAPIKeyService(datastore portainer.DataStore) apikey.APIKeyService {
+	return apikey.NewAPIKeyService(datastore.APIKeyRepository())
 }
 
 func initJWTService(dataStore portainer.DataStore) (portainer.JWTService, error) {
@@ -412,6 +417,8 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 		log.Fatal(err)
 	}
 
+	apiKeyService := initAPIKeyService(dataStore)
+
 	jwtService, err := initJWTService(dataStore)
 	if err != nil {
 		log.Fatalf("failed initializing JWT service: %v", err)
@@ -568,6 +575,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 		KubernetesDeployer:          kubernetesDeployer,
 		HelmPackageManager:          helmPackageManager,
 		CryptoService:               cryptoService,
+		APIKeyService:               apiKeyService,
 		JWTService:                  jwtService,
 		FileService:                 fileService,
 		LDAPService:                 ldapService,

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -116,7 +116,7 @@ func initHelmPackageManager(assetsPath string) (libhelm.HelmPackageManager, erro
 }
 
 func initAPIKeyService(datastore portainer.DataStore) apikey.APIKeyService {
-	return apikey.NewAPIKeyService(datastore.APIKeyRepository())
+	return apikey.NewAPIKeyService(datastore.APIKeyRepository(), datastore.User())
 }
 
 func initJWTService(dataStore portainer.DataStore) (portainer.JWTService, error) {

--- a/api/go.mod
+++ b/api/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/websocket v1.4.2
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/joho/godotenv v1.3.0
 	github.com/jpillora/chisel v0.0.0-20190724232113-f3a8df20e389
 	github.com/json-iterator/go v1.1.11

--- a/api/go.sum
+++ b/api/go.sum
@@ -437,6 +437,8 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/api/http/handler/users/handler.go
+++ b/api/http/handler/users/handler.go
@@ -52,7 +52,11 @@ func NewHandler(bouncer *security.RequestBouncer, rateLimiter *security.RateLimi
 	h.Handle("/users/{id}",
 		bouncer.AdminAccess(httperror.LoggerHandler(h.userDelete))).Methods(http.MethodDelete)
 	h.Handle("/users/{id}/tokens",
+		bouncer.RestrictedAccess(httperror.LoggerHandler(h.userGetAccessTokens))).Methods(http.MethodGet)
+	h.Handle("/users/{id}/tokens",
 		rateLimiter.LimitAccess(bouncer.RestrictedAccess(httperror.LoggerHandler(h.userCreateAccessToken)))).Methods(http.MethodPost)
+	h.Handle("/users/{id}/tokens/{keyID}",
+		bouncer.RestrictedAccess(httperror.LoggerHandler(h.userRemoveAccessToken))).Methods(http.MethodDelete)
 	h.Handle("/users/{id}/memberships",
 		bouncer.RestrictedAccess(httperror.LoggerHandler(h.userMemberships))).Methods(http.MethodGet)
 	h.Handle("/users/{id}/passwd",

--- a/api/http/handler/users/handler.go
+++ b/api/http/handler/users/handler.go
@@ -5,6 +5,7 @@ import (
 
 	httperror "github.com/portainer/libhttp/error"
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
 	"github.com/portainer/portainer/api/http/security"
 
 	"net/http"
@@ -28,15 +29,17 @@ func hideFields(user *portainer.User) {
 type Handler struct {
 	*mux.Router
 	bouncer       *security.RequestBouncer
+	apiKeyService apikey.APIKeyService
 	DataStore     portainer.DataStore
 	CryptoService portainer.CryptoService
 }
 
 // NewHandler creates a handler to manage user operations.
-func NewHandler(bouncer *security.RequestBouncer, rateLimiter *security.RateLimiter) *Handler {
+func NewHandler(bouncer *security.RequestBouncer, rateLimiter *security.RateLimiter, apiKeyService apikey.APIKeyService) *Handler {
 	h := &Handler{
-		Router:  mux.NewRouter(),
-		bouncer: bouncer,
+		Router:        mux.NewRouter(),
+		bouncer:       bouncer,
+		apiKeyService: apiKeyService,
 	}
 	h.Handle("/users",
 		bouncer.AdminAccess(httperror.LoggerHandler(h.userCreate))).Methods(http.MethodPost)

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -20,7 +20,7 @@ type userAccessTokenCreatePayload struct {
 
 func (payload *userAccessTokenCreatePayload) Validate(r *http.Request) error {
 	if govalidator.IsNull(payload.Description) || govalidator.Contains(payload.Description, " ") {
-		return errors.New("Invalid description. Must not contain any whitespace")
+		return errors.New("invalid description. Must not contain any whitespace")
 	}
 	return nil
 }
@@ -51,7 +51,7 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 	// specifically require JWT auth for this endpoint since API-Key based auth is not supported
 	t := handler.bouncer.JWTAuthLookup(r)
 	if t == nil {
-		return &httperror.HandlerError{http.StatusUnauthorized, "", errors.New("JWT Authentication required")}
+		return &httperror.HandlerError{http.StatusUnauthorized, "Auth not supported", errors.New("JWT Authentication required")}
 	}
 
 	var payload userAccessTokenCreatePayload

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -80,7 +80,7 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
 	}
 
-	rawAPIKey, err := handler.apiKeyService.GenerateApiKey(portainer.UserID(userID), payload.Description)
+	rawAPIKey, _, err := handler.apiKeyService.GenerateApiKey(portainer.UserID(userID), payload.Description)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Internal Server Error", err}
 	}

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -1,0 +1,108 @@
+package users
+
+import (
+	"crypto/sha256"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/gorilla/securecookie"
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+type userAccessTokenCreatePayload struct {
+	Description string `validate:"required" example:"github-api-key" json:"description"`
+}
+
+func (payload *userAccessTokenCreatePayload) Validate(r *http.Request) error {
+	if govalidator.IsNull(payload.Description) || govalidator.Contains(payload.Description, " ") {
+		return errors.New("Invalid description. Must not contain any whitespace")
+	}
+	return nil
+}
+
+type accessTokenResponse struct {
+	APIKey []byte `json:"apiKey"`
+}
+
+// @id UserGenerateAPIKey
+// @summary Generate an API key for a user
+// @description Generates an API key for a user.
+// @description Only the calling user can generate a token for themselves.
+// @description **Access policy**: restricted
+// @tags users
+// @security jwt
+// @accept json
+// @produce json
+// @param body body userAccessTokenCreatePayload true "details"
+// @success 200 {object} accessTokenResponse "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 404 "User not found"
+// @failure 500 "Server error"
+// @router /users/{id}/tokens [post]
+func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	// specifically require JWT auth for this endpoint since API-Key based auth is not supported
+	t := handler.bouncer.JWTAuthLookup(r)
+	if t == nil {
+		return &httperror.HandlerError{http.StatusUnauthorized, "", errors.New("JWT Authentication required")}
+	}
+
+	var payload userAccessTokenCreatePayload
+	err := request.DecodeAndValidateJSONPayload(r, &payload)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid request payload", err}
+	}
+
+	userID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid user identifier route variable", err}
+	}
+
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+
+	if tokenData.ID != portainer.UserID(userID) {
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create user access token", httperrors.ErrUnauthorized}
+	}
+
+	user, err := handler.DataStore.User().User(portainer.UserID(userID))
+	if err != nil {
+		if err == bolterrors.ErrObjectNotFound {
+			return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
+		}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
+	}
+
+	rawAPIKey, apiKey := generateApiKey(user.ID, payload)
+	err = handler.DataStore.APIKeyRepository().CreateKey(&apiKey)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to persist api-key to the database", err}
+	}
+
+	return response.JSON(w, accessTokenResponse{rawAPIKey})
+}
+
+// generateApiKey generates an API key for a user; returns rawApiKey (for one-time display) - along with the APIKey struct.
+func generateApiKey(userID portainer.UserID, payload userAccessTokenCreatePayload) ([]byte, portainer.APIKey) {
+	rawAPIKey := securecookie.GenerateRandomKey(32)
+	rawAPIKeyChars := []rune(string(rawAPIKey))
+	hashDigest := sha256.Sum256(rawAPIKey)
+	apiKey := portainer.APIKey{
+		UserID:      userID,
+		Description: payload.Description,
+		Prefix:      [3]rune{rawAPIKeyChars[0], rawAPIKeyChars[1], rawAPIKeyChars[2]},
+		DateCreated: time.Now(),
+		Digest:      hashDigest,
+	}
+	return rawAPIKey, apiKey
+}

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -9,7 +9,6 @@ import (
 	"github.com/portainer/libhttp/request"
 	"github.com/portainer/libhttp/response"
 	portainer "github.com/portainer/portainer/api"
-	bolterrors "github.com/portainer/portainer/api/bolt/errors"
 	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/security"
 )
@@ -76,10 +75,7 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 
 	user, err := handler.DataStore.User().User(portainer.UserID(userID))
 	if err != nil {
-		if err == bolterrors.ErrObjectNotFound {
-			return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
-		}
-		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
+		return &httperror.HandlerError{http.StatusBadRequest, "Unable to find a user", err}
 	}
 
 	rawAPIKey, apiKey, err := handler.apiKeyService.GenerateApiKey(*user, payload.Description)

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -48,8 +48,7 @@ type accessTokenResponse struct {
 // @router /users/{id}/tokens [post]
 func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
 	// specifically require JWT auth for this endpoint since API-Key based auth is not supported
-	t := handler.bouncer.JWTAuthLookup(r)
-	if t == nil {
+	if jwt := handler.bouncer.JWTAuthLookup(r); jwt == nil {
 		return &httperror.HandlerError{http.StatusUnauthorized, "Auth not supported", errors.New("JWT Authentication required")}
 	}
 

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -41,6 +41,7 @@ type accessTokenResponse struct {
 // @param body body userAccessTokenCreatePayload true "details"
 // @success 200 {object} accessTokenResponse "Success"
 // @failure 400 "Invalid request"
+// @failure 401 "Unauthorized"
 // @failure 403 "Permission denied"
 // @failure 404 "User not found"
 // @failure 500 "Server error"

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -26,7 +26,8 @@ func (payload *userAccessTokenCreatePayload) Validate(r *http.Request) error {
 }
 
 type accessTokenResponse struct {
-	APIKey []byte `json:"apiKey"`
+	RawAPIKey []byte           `json:"rawAPIKey"`
+	APIKey    portainer.APIKey `json:"apiKey"`
 }
 
 // @id UserGenerateAPIKey
@@ -81,10 +82,10 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
 	}
 
-	rawAPIKey, _, err := handler.apiKeyService.GenerateApiKey(portainer.UserID(userID), payload.Description)
+	rawAPIKey, apiKey, err := handler.apiKeyService.GenerateApiKey(portainer.UserID(userID), payload.Description)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Internal Server Error", err}
 	}
 
-	return response.JSON(w, accessTokenResponse{rawAPIKey})
+	return response.JSON(w, accessTokenResponse{rawAPIKey, *apiKey})
 }

--- a/api/http/handler/users/user_create_access_token.go
+++ b/api/http/handler/users/user_create_access_token.go
@@ -26,7 +26,7 @@ func (payload *userAccessTokenCreatePayload) Validate(r *http.Request) error {
 }
 
 type accessTokenResponse struct {
-	RawAPIKey []byte           `json:"rawAPIKey"`
+	RawAPIKey string           `json:"rawAPIKey"`
 	APIKey    portainer.APIKey `json:"apiKey"`
 }
 
@@ -74,7 +74,7 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to create user access token", httperrors.ErrUnauthorized}
 	}
 
-	_, err = handler.DataStore.User().User(portainer.UserID(userID))
+	user, err := handler.DataStore.User().User(portainer.UserID(userID))
 	if err != nil {
 		if err == bolterrors.ErrObjectNotFound {
 			return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
@@ -82,7 +82,7 @@ func (handler *Handler) userCreateAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
 	}
 
-	rawAPIKey, apiKey, err := handler.apiKeyService.GenerateApiKey(portainer.UserID(userID), payload.Description)
+	rawAPIKey, apiKey, err := handler.apiKeyService.GenerateApiKey(*user, payload.Description)
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Internal Server Error", err}
 	}

--- a/api/http/handler/users/user_create_access_token_test.go
+++ b/api/http/handler/users/user_create_access_token_test.go
@@ -1,0 +1,145 @@
+package users
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
+	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_userCreateAccessToken(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	// create admin and standard user(s)
+	adminUser := &portainer.User{ID: 1, Username: "admin", Role: portainer.AdministratorRole}
+	err := store.User().CreateUser(adminUser)
+	is.NoError(err, "error creating admin user")
+
+	user := &portainer.User{ID: 2, Username: "standard", Role: portainer.StandardUserRole}
+	err = store.User().CreateUser(user)
+	is.NoError(err, "error creating user")
+
+	// setup services
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+	apiKeyService := apikey.NewAPIKeyService(store.APIKeyRepository(), store.User())
+	requestBouncer := security.NewRequestBouncer(store, jwtService, apiKeyService)
+	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
+
+	h := NewHandler(requestBouncer, rateLimiter, apiKeyService)
+	h.DataStore = store
+
+	// generate standard and admin user tokens
+	adminJWT, _ := jwtService.GenerateToken(&portainer.TokenData{ID: adminUser.ID, Username: adminUser.Username, Role: adminUser.Role})
+	jwt, _ := jwtService.GenerateToken(&portainer.TokenData{ID: user.ID, Username: user.Username, Role: user.Role})
+
+	t.Run("standard user successfully generates API key", func(t *testing.T) {
+		data := userAccessTokenCreatePayload{Description: "test-token"}
+		payload, err := json.Marshal(data)
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodPost, "/users/2/tokens", bytes.NewBuffer(payload))
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusOK, rr.Code)
+
+		body, err := io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+
+		var resp accessTokenResponse
+		err = json.Unmarshal(body, &resp)
+		is.NoError(err, "response should be json")
+		is.EqualValues(data.Description, resp.APIKey.Description)
+		is.NotEmpty(resp.RawAPIKey)
+	})
+
+	t.Run("admin cannot generate API key for standard user", func(t *testing.T) {
+		data := userAccessTokenCreatePayload{Description: "test-token-admin"}
+		payload, err := json.Marshal(data)
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodPost, "/users/2/tokens", bytes.NewBuffer(payload))
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminJWT))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusForbidden, rr.Code)
+
+		_, err = io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+	})
+
+	t.Run("endpoint cannot generate api-key using api-key auth", func(t *testing.T) {
+		rawAPIKey, _, err := apiKeyService.GenerateApiKey(*user, "test-api-key")
+		is.NoError(err)
+
+		data := userAccessTokenCreatePayload{Description: "test-token-fails"}
+		payload, err := json.Marshal(data)
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodPost, "/users/2/tokens", bytes.NewBuffer(payload))
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusUnauthorized, rr.Code)
+
+		body, err := io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+		is.Equal("{\"message\":\"Auth not supported\",\"details\":\"JWT Authentication required\"}\n", string(body))
+	})
+}
+
+func Test_userAccessTokenCreatePayload(t *testing.T) {
+	is := assert.New(t)
+
+	tests := []struct {
+		payload    userAccessTokenCreatePayload
+		shouldFail bool
+	}{
+		{
+			payload:    userAccessTokenCreatePayload{Description: "test-token"},
+			shouldFail: false,
+		},
+		{
+			payload:    userAccessTokenCreatePayload{Description: ""},
+			shouldFail: true,
+		},
+		{
+			payload:    userAccessTokenCreatePayload{Description: "test token"},
+			shouldFail: true,
+		},
+		{
+			payload:    userAccessTokenCreatePayload{Description: "test-token "},
+			shouldFail: true,
+		},
+	}
+
+	for _, test := range tests {
+		err := test.payload.Validate(nil)
+		if test.shouldFail {
+			is.Error(err)
+		} else {
+			is.NoError(err)
+		}
+	}
+}

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -100,7 +100,7 @@ func (handler *Handler) deleteUser(w http.ResponseWriter, user *portainer.User) 
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user API keys from the database", err}
 	}
 	for _, k := range apiKeys {
-		err = handler.apiKeyService.DeleteAPIKey(k.UserID, k.ID)
+		err = handler.apiKeyService.DeleteAPIKey(k.ID)
 		if err != nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user API key from the database", err}
 		}

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -94,5 +94,17 @@ func (handler *Handler) deleteUser(w http.ResponseWriter, user *portainer.User) 
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user memberships from the database", err}
 	}
 
+	// Remove all of the users persisted API keys
+	apiKeys, err := handler.apiKeyService.GetAPIKeys(user.ID)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user API keys from the database", err}
+	}
+	for _, k := range apiKeys {
+		err = handler.apiKeyService.DeleteAPIKey(k.UserID, k.ID)
+		if err != nil {
+			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove user API key from the database", err}
+		}
+	}
+
 	return response.Empty(w)
 }

--- a/api/http/handler/users/user_delete_test.go
+++ b/api/http/handler/users/user_delete_test.go
@@ -1,0 +1,59 @@
+package users
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
+	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_deleteUserRemovesAccessTokens(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	// create standard user
+	user := &portainer.User{ID: 2, Username: "standard", Role: portainer.StandardUserRole}
+	err := store.User().CreateUser(user)
+	is.NoError(err, "error creating user")
+
+	// setup services
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+	apiKeyService := apikey.NewAPIKeyService(store.APIKeyRepository(), store.User())
+	requestBouncer := security.NewRequestBouncer(store, jwtService, apiKeyService)
+	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
+
+	h := NewHandler(requestBouncer, rateLimiter, apiKeyService)
+	h.DataStore = store
+
+	// generate standard and admin user tokens
+	// jwt, _ := jwtService.GenerateToken(&portainer.TokenData{ID: user.ID, Username: user.Username, Role: user.Role})
+
+	t.Run("standard user deletion removes all associated access tokens", func(t *testing.T) {
+		_, _, err := apiKeyService.GenerateApiKey(*user, "test-user-token")
+		is.NoError(err)
+
+		keys, err := apiKeyService.GetAPIKeys(user.ID)
+		is.NoError(err)
+		is.Len(keys, 1)
+
+		rr := httptest.NewRecorder()
+		h.deleteUser(httptest.NewRecorder(), user)
+
+		is.Equal(http.StatusOK, rr.Code)
+
+		keys, err = apiKeyService.GetAPIKeys(user.ID)
+		is.NoError(err)
+		is.Equal(0, len(keys))
+	})
+
+}

--- a/api/http/handler/users/user_get_access_tokens.go
+++ b/api/http/handler/users/user_get_access_tokens.go
@@ -1,0 +1,68 @@
+package users
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	portainer "github.com/portainer/portainer/api"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+// @id UserGetAPIKeys
+// @summary Get all API keys for a user
+// @description Gets all API keys for a user.
+// @description Only the calling user or admin can retrieve api-keys.
+// @description **Access policy**: authenticated
+// @tags users
+// @security jwt
+// @security ApiKeyAuth
+// @produce json
+// @success 200 {array} portainer.APIKey "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 404 "User not found"
+// @failure 500 "Server error"
+// @router /users/{id}/tokens [get]
+func (handler *Handler) userGetAccessTokens(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	userID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid user identifier route variable", err}
+	}
+
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+
+	if tokenData.Role != portainer.AdministratorRole && tokenData.ID != portainer.UserID(userID) {
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to get user access tokens", httperrors.ErrUnauthorized}
+	}
+
+	_, err = handler.DataStore.User().User(portainer.UserID(userID))
+	if err != nil {
+		if err == bolterrors.ErrObjectNotFound {
+			return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
+		}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
+	}
+
+	apiKeys, err := handler.apiKeyService.GetAPIKeys(portainer.UserID(userID))
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Internal Server Error", err}
+	}
+
+	for idx := range apiKeys {
+		hideAPIKeyFields(&apiKeys[idx])
+	}
+
+	return response.JSON(w, apiKeys)
+}
+
+// hideAPIKeyFields remove the digest from the API key (it is not needed in the response)
+func hideAPIKeyFields(apiKey *portainer.APIKey) {
+	apiKey.Digest = nil
+}

--- a/api/http/handler/users/user_get_access_tokens_test.go
+++ b/api/http/handler/users/user_get_access_tokens_test.go
@@ -1,0 +1,135 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
+	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_userGetAccessTokens(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	// create admin and standard user(s)
+	adminUser := &portainer.User{ID: 1, Username: "admin", Role: portainer.AdministratorRole}
+	err := store.User().CreateUser(adminUser)
+	is.NoError(err, "error creating admin user")
+
+	user := &portainer.User{ID: 2, Username: "standard", Role: portainer.StandardUserRole}
+	err = store.User().CreateUser(user)
+	is.NoError(err, "error creating user")
+
+	// setup services
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+	apiKeyService := apikey.NewAPIKeyService(store.APIKeyRepository(), store.User())
+	requestBouncer := security.NewRequestBouncer(store, jwtService, apiKeyService)
+	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
+
+	h := NewHandler(requestBouncer, rateLimiter, apiKeyService)
+	h.DataStore = store
+
+	// generate standard and admin user tokens
+	adminJWT, _ := jwtService.GenerateToken(&portainer.TokenData{ID: adminUser.ID, Username: adminUser.Username, Role: adminUser.Role})
+	jwt, _ := jwtService.GenerateToken(&portainer.TokenData{ID: user.ID, Username: user.Username, Role: user.Role})
+
+	t.Run("standard user can successfully retrieve API key", func(t *testing.T) {
+		_, apiKey, err := apiKeyService.GenerateApiKey(*user, "test-get-token")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/2/tokens", nil)
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusOK, rr.Code)
+
+		body, err := io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+
+		var resp []portainer.APIKey
+		err = json.Unmarshal(body, &resp)
+		is.NoError(err, "response should be list json")
+
+		is.Len(resp, 1)
+		is.Nil(resp[0].Digest)
+		is.Equal(apiKey.ID, resp[0].ID)
+		is.Equal(apiKey.UserID, resp[0].UserID)
+		is.Equal(apiKey.Prefix, resp[0].Prefix)
+		is.Equal(apiKey.Description, resp[0].Description)
+	})
+
+	t.Run("admin can retrieve standard user API Key", func(t *testing.T) {
+		_, _, err := apiKeyService.GenerateApiKey(*user, "test-get-admin-token")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/2/tokens", nil)
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminJWT))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusOK, rr.Code)
+
+		body, err := io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+
+		var resp []portainer.APIKey
+		err = json.Unmarshal(body, &resp)
+		is.NoError(err, "response should be list json")
+
+		is.True(len(resp) > 0)
+	})
+
+	t.Run("user can retrieve API Key using api-key auth", func(t *testing.T) {
+		rawAPIKey, _, err := apiKeyService.GenerateApiKey(*user, "test-api-key")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodGet, "/users/2/tokens", nil)
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusOK, rr.Code)
+
+		body, err := io.ReadAll(rr.Body)
+		is.NoError(err, "ReadAll should not return error")
+
+		var resp []portainer.APIKey
+		err = json.Unmarshal(body, &resp)
+		is.NoError(err, "response should be list json")
+
+		is.True(len(resp) > 0)
+	})
+}
+
+func Test_hideAPIKeyFields(t *testing.T) {
+	is := assert.New(t)
+
+	apiKey := &portainer.APIKey{
+		ID:          1,
+		UserID:      2,
+		Prefix:      "abc",
+		Description: "test",
+		Digest:      nil,
+	}
+
+	hideAPIKeyFields(apiKey)
+
+	is.Nil(apiKey.Digest, "digest should be cleared when hiding api key fields")
+}

--- a/api/http/handler/users/user_remove_access_token.go
+++ b/api/http/handler/users/user_remove_access_token.go
@@ -1,0 +1,66 @@
+package users
+
+import (
+	"net/http"
+
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	"github.com/portainer/libhttp/response"
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
+	bolterrors "github.com/portainer/portainer/api/bolt/errors"
+	httperrors "github.com/portainer/portainer/api/http/errors"
+	"github.com/portainer/portainer/api/http/security"
+)
+
+// @id UserRemoveAPIKey
+// @summary Remove an api-key associated to a user
+// @description Remove an api-key associated to a user..
+// @description Only the calling user or admin can remove api-key.
+// @description **Access policy**: authenticated
+// @tags users
+// @security jwt
+// @security ApiKeyAuth
+// @success 204 "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 404 "Not found"
+// @failure 500 "Server error"
+// @router /users/{id}/tokens/{keyID} [delete]
+func (handler *Handler) userRemoveAccessToken(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	userID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid user identifier route variable", err}
+	}
+
+	apiKeyID, err := request.RetrieveNumericRouteVariableValue(r, "keyID")
+	if err != nil {
+		return &httperror.HandlerError{http.StatusBadRequest, "Invalid api-key identifier route variable", err}
+	}
+
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve user authentication token", err}
+	}
+	if tokenData.Role != portainer.AdministratorRole && tokenData.ID != portainer.UserID(userID) {
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to get user access tokens", httperrors.ErrUnauthorized}
+	}
+
+	_, err = handler.DataStore.User().User(portainer.UserID(userID))
+	if err != nil {
+		if err == bolterrors.ErrObjectNotFound {
+			return &httperror.HandlerError{http.StatusNotFound, "Unable to find a user with the specified identifier inside the database", err}
+		}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
+	}
+
+	err = handler.apiKeyService.DeleteAPIKey(portainer.UserID(userID), portainer.APIKeyID(apiKeyID))
+	if err != nil {
+		if err == apikey.ErrInvalidAPIKey {
+			return &httperror.HandlerError{http.StatusNotFound, "Unable to find an api-key with the specified identifier inside the database", err}
+		}
+		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to remove the api-key from the user", err}
+	}
+
+	return response.Empty(w)
+}

--- a/api/http/handler/users/user_remove_access_token.go
+++ b/api/http/handler/users/user_remove_access_token.go
@@ -54,7 +54,7 @@ func (handler *Handler) userRemoveAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
 	}
 
-	err = handler.apiKeyService.DeleteAPIKey(portainer.UserID(userID), portainer.APIKeyID(apiKeyID))
+	err = handler.apiKeyService.DeleteAPIKey(portainer.APIKeyID(apiKeyID))
 	if err != nil {
 		if err == apikey.ErrInvalidAPIKey {
 			return &httperror.HandlerError{http.StatusNotFound, "Unable to find an api-key with the specified identifier inside the database", err}

--- a/api/http/handler/users/user_remove_access_token_test.go
+++ b/api/http/handler/users/user_remove_access_token_test.go
@@ -1,0 +1,100 @@
+package users
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
+	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/jwt"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_userRemoveAccessToken(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	// create admin and standard user(s)
+	adminUser := &portainer.User{ID: 1, Username: "admin", Role: portainer.AdministratorRole}
+	err := store.User().CreateUser(adminUser)
+	is.NoError(err, "error creating admin user")
+
+	user := &portainer.User{ID: 2, Username: "standard", Role: portainer.StandardUserRole}
+	err = store.User().CreateUser(user)
+	is.NoError(err, "error creating user")
+
+	// setup services
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+	apiKeyService := apikey.NewAPIKeyService(store.APIKeyRepository(), store.User())
+	requestBouncer := security.NewRequestBouncer(store, jwtService, apiKeyService)
+	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
+
+	h := NewHandler(requestBouncer, rateLimiter, apiKeyService)
+	h.DataStore = store
+
+	// generate standard and admin user tokens
+	adminJWT, _ := jwtService.GenerateToken(&portainer.TokenData{ID: adminUser.ID, Username: adminUser.Username, Role: adminUser.Role})
+	jwt, _ := jwtService.GenerateToken(&portainer.TokenData{ID: user.ID, Username: user.Username, Role: user.Role})
+
+	t.Run("standard user can successfully delete API key", func(t *testing.T) {
+		_, apiKey, err := apiKeyService.GenerateApiKey(*user, "test-delete-token")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%d", "/users/2/tokens", apiKey.ID), nil)
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusNoContent, rr.Code)
+
+		keys, err := apiKeyService.GetAPIKeys(user.ID)
+		is.NoError(err)
+
+		is.Equal(0, len(keys))
+	})
+
+	t.Run("admin can delete a standard user API Key", func(t *testing.T) {
+		_, apiKey, err := apiKeyService.GenerateApiKey(*user, "test-admin-delete-token")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%d", "/users/2/tokens", apiKey.ID), nil)
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminJWT))
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusNoContent, rr.Code)
+
+		keys, err := apiKeyService.GetAPIKeys(user.ID)
+		is.NoError(err)
+
+		is.Equal(0, len(keys))
+	})
+
+	t.Run("user can delete API Key using api-key auth", func(t *testing.T) {
+		rawAPIKey, apiKey, err := apiKeyService.GenerateApiKey(*user, "test-api-key-auth-deletion")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%d", "/users/2/tokens", apiKey.ID), nil)
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		is.Equal(http.StatusNoContent, rr.Code)
+
+		keys, err := apiKeyService.GetAPIKeys(user.ID)
+		is.NoError(err)
+
+		is.Equal(0, len(keys))
+	})
+}

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -3,7 +3,6 @@ package security
 import (
 	"errors"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -318,7 +317,7 @@ func extractAPIKey(r *http.Request) (apikey string, ok bool) {
 
 	// extract the API key from query params.
 	// Case-insensitive check for the "X-API-KEY" query param.
-	var query url.Values = r.URL.Query()
+	query := r.URL.Query()
 	for k, v := range query {
 		if strings.EqualFold(k, apiKeyHeader) {
 			return v[0], true

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -138,7 +138,7 @@ func (bouncer *RequestBouncer) AuthorizedEdgeEndpointOperation(r *http.Request, 
 // - authenticating the request with a valid token
 func (bouncer *RequestBouncer) mwAuthenticatedUser(h http.Handler) http.Handler {
 	h = bouncer.mwAuthenticateFirst([]tokenLookup{
-		bouncer.jwtAuthLookup,
+		bouncer.JWTAuthLookup,
 		bouncer.apiKeyLookup,
 	}, h)
 	h = mwSecureHeaders(h)
@@ -231,8 +231,8 @@ func (bouncer *RequestBouncer) mwAuthenticateFirst(tokenLookups []tokenLookup, n
 	})
 }
 
-// jwtAuthLookup looks up a valid bearer in the request.
-func (bouncer *RequestBouncer) jwtAuthLookup(r *http.Request) *portainer.TokenData {
+// JWTAuthLookup looks up a valid bearer in the request.
+func (bouncer *RequestBouncer) JWTAuthLookup(r *http.Request) *portainer.TokenData {
 	// get token from the Authorization header or query parameter
 	token, err := extractBearerToken(r)
 	if err != nil {

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -317,11 +317,10 @@ func extractAPIKey(r *http.Request) (apikey string, ok bool) {
 	}
 
 	// extract the API key from query params.
-	// Since there is no way to case-insensitive extract query parameters,
-	// we need upper-case the query params to check for presence of the "X-API-KEY" param.
+	// Case-insensitive check for the "X-API-KEY" query param.
 	var query url.Values = r.URL.Query()
 	for k, v := range query {
-		if strings.ToUpper(k) == apiKeyHeader {
+		if strings.EqualFold(k, apiKeyHeader) {
 			return v[0], true
 		}
 	}

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -260,6 +260,7 @@ func (bouncer *RequestBouncer) apiKeyLookup(r *http.Request) *portainer.TokenDat
 	// TODO: retrieve user associated to the API-Key
 	// TODO: generate a new token for the user
 	// TODO: return generated token
+	// TODO: update apiKey last accessed time
 
 	var tokenData *portainer.TokenData
 

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/apikey"
 	"github.com/portainer/portainer/api/bolt"
 	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/jwt"
@@ -40,7 +41,9 @@ func Test_mwAuthenticateFirst(t *testing.T) {
 	jwtService, err := jwt.NewService("1h", nil)
 	assert.NoError(t, err, "failed to create a copy of service")
 
-	bouncer := NewRequestBouncer(store, jwtService)
+	apiKeyService := apikey.NewAPIKeyService(nil, nil)
+
+	bouncer := NewRequestBouncer(store, jwtService, apiKeyService)
 
 	tests := []struct {
 		name                   string

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -302,7 +302,7 @@ func Test_apiKeyLookup(t *testing.T) {
 	t.Run("valid x-api-key header succeeds api-key lookup", func(t *testing.T) {
 		rawAPIKey, apiKey, err := apiKeyService.GenerateApiKey(*user, "test")
 		is.NoError(err)
-		defer apiKeyService.DeleteAPIKey(user.ID, apiKey.ID)
+		defer apiKeyService.DeleteAPIKey(apiKey.ID)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Add("x-api-key", rawAPIKey)
@@ -316,7 +316,7 @@ func Test_apiKeyLookup(t *testing.T) {
 	t.Run("successful api-key lookup updates token last used time", func(t *testing.T) {
 		rawAPIKey, apiKey, err := apiKeyService.GenerateApiKey(*user, "test")
 		is.NoError(err)
-		defer apiKeyService.DeleteAPIKey(user.ID, apiKey.ID)
+		defer apiKeyService.DeleteAPIKey(apiKey.ID)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Add("x-api-key", rawAPIKey)

--- a/api/http/security/bouncer_test.go
+++ b/api/http/security/bouncer_test.go
@@ -108,35 +108,35 @@ func Test_extractBearerToken(t *testing.T) {
 		requestHeader      string
 		requestHeaderValue string
 		wantToken          string
-		doesError          bool
+		succeeds           bool
 	}{
 		{
 			name:               "missing request header",
 			requestHeader:      "",
 			requestHeaderValue: "",
 			wantToken:          "",
-			doesError:          true,
+			succeeds:           false,
 		},
 		{
 			name:               "invalid authorization request header",
 			requestHeader:      "authorisation", // note: `s`
 			requestHeaderValue: "abc",
 			wantToken:          "",
-			doesError:          true,
+			succeeds:           false,
 		},
 		{
 			name:               "valid authorization request header",
 			requestHeader:      "AUTHORIZATION",
 			requestHeaderValue: "abc",
 			wantToken:          "abc",
-			doesError:          false,
+			succeeds:           true,
 		},
 		{
 			name:               "valid authorization request header case-insensitive canonical check",
 			requestHeader:      "authorization",
 			requestHeaderValue: "def",
 			wantToken:          "def",
-			doesError:          false,
+			succeeds:           true,
 		},
 	}
 
@@ -145,7 +145,7 @@ func Test_extractBearerToken(t *testing.T) {
 		req.Header.Set(test.requestHeader, test.requestHeaderValue)
 		apiKey, err := extractBearerToken(req)
 		is.Equal(test.wantToken, apiKey)
-		if test.doesError {
+		if !test.succeeds {
 			is.Error(err, "Should return error")
 			is.ErrorIs(err, httperrors.ErrUnauthorized)
 		} else {
@@ -154,7 +154,7 @@ func Test_extractBearerToken(t *testing.T) {
 	}
 }
 
-func Test_extractAPIKey(t *testing.T) {
+func Test_extractAPIKeyHeader(t *testing.T) {
 	is := assert.New(t)
 
 	tt := []struct {
@@ -201,4 +201,134 @@ func Test_extractAPIKey(t *testing.T) {
 		is.Equal(test.wantApiKey, apiKey)
 		is.Equal(test.succeeds, ok)
 	}
+}
+
+func Test_extractAPIKeyQueryParam(t *testing.T) {
+	is := assert.New(t)
+
+	tt := []struct {
+		name            string
+		queryParam      string
+		queryParamValue string
+		wantApiKey      string
+		succeeds        bool
+	}{
+		{
+			name:            "missing request header",
+			queryParam:      "",
+			queryParamValue: "",
+			wantApiKey:      "",
+			succeeds:        false,
+		},
+		{
+			name:            "invalid api-key request header",
+			queryParam:      "api-key",
+			queryParamValue: "abc",
+			wantApiKey:      "",
+			succeeds:        false,
+		},
+		{
+			name:            "valid api-key request header",
+			queryParam:      apiKeyHeader,
+			queryParamValue: "abc",
+			wantApiKey:      "abc",
+			succeeds:        true,
+		},
+		{
+			name:            "valid api-key request header case-insensitive canonical check",
+			queryParam:      "x-api-key",
+			queryParamValue: "def",
+			wantApiKey:      "def",
+			succeeds:        true,
+		},
+	}
+
+	for _, test := range tt {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		q := req.URL.Query()
+		q.Add(test.queryParam, test.queryParamValue)
+		req.URL.RawQuery = q.Encode()
+
+		apiKey, ok := extractAPIKey(req)
+		is.Equal(test.wantApiKey, apiKey)
+		is.Equal(test.succeeds, ok)
+	}
+}
+
+func Test_apiKeyLookup(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	// create standard user
+	user := &portainer.User{ID: 2, Username: "standard", Role: portainer.StandardUserRole}
+	err := store.User().CreateUser(user)
+	is.NoError(err, "error creating user")
+
+	// setup services
+	jwtService, err := jwt.NewService("1h", store)
+	is.NoError(err, "Error initiating jwt service")
+	apiKeyService := apikey.NewAPIKeyService(store.APIKeyRepository(), store.User())
+	bouncer := NewRequestBouncer(store, jwtService, apiKeyService)
+
+	t.Run("missing x-api-key header fails api-key lookup", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		// req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+		token := bouncer.apiKeyLookup(req)
+		is.Nil(token)
+	})
+
+	t.Run("invalid x-api-key header fails api-key lookup", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add("x-api-key", "random-failing-api-key")
+		token := bouncer.apiKeyLookup(req)
+		is.Nil(token)
+	})
+
+	t.Run("valid x-api-key header succeeds api-key lookup", func(t *testing.T) {
+		rawAPIKey, _, err := apiKeyService.GenerateApiKey(*user, "test")
+		is.NoError(err)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		token := bouncer.apiKeyLookup(req)
+
+		expectedToken := &portainer.TokenData{ID: user.ID, Username: user.Username, Role: portainer.StandardUserRole}
+		is.Equal(expectedToken, token)
+	})
+
+	t.Run("valid x-api-key header succeeds api-key lookup", func(t *testing.T) {
+		rawAPIKey, apiKey, err := apiKeyService.GenerateApiKey(*user, "test")
+		is.NoError(err)
+		defer apiKeyService.DeleteAPIKey(user.ID, apiKey.ID)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		token := bouncer.apiKeyLookup(req)
+
+		expectedToken := &portainer.TokenData{ID: user.ID, Username: user.Username, Role: portainer.StandardUserRole}
+		is.Equal(expectedToken, token)
+	})
+
+	t.Run("successful api-key lookup updates token last used time", func(t *testing.T) {
+		rawAPIKey, apiKey, err := apiKeyService.GenerateApiKey(*user, "test")
+		is.NoError(err)
+		defer apiKeyService.DeleteAPIKey(user.ID, apiKey.ID)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add("x-api-key", rawAPIKey)
+
+		token := bouncer.apiKeyLookup(req)
+
+		expectedToken := &portainer.TokenData{ID: user.ID, Username: user.Username, Role: portainer.StandardUserRole}
+		is.Equal(expectedToken, token)
+
+		_, apiKeyUpdated, err := apiKeyService.GetDigestUserAndKey(apiKey.Digest)
+		is.NoError(err)
+
+		is.True(apiKeyUpdated.LastUsed.After(apiKey.LastUsed))
+	})
 }

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -99,7 +99,7 @@ type Server struct {
 func (server *Server) Start() error {
 	kubernetesTokenCacheManager := server.KubernetesTokenCacheManager
 
-	requestBouncer := security.NewRequestBouncer(server.DataStore, server.JWTService)
+	requestBouncer := security.NewRequestBouncer(server.DataStore, server.JWTService, server.APIKeyService)
 
 	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
 	offlineGate := offlinegate.NewOfflineGate()

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portainer/libhelm"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/adminmonitor"
+	"github.com/portainer/portainer/api/apikey"
 	"github.com/portainer/portainer/api/crypto"
 	"github.com/portainer/portainer/api/docker"
 	"github.com/portainer/portainer/api/http/handler"
@@ -74,6 +75,7 @@ type Server struct {
 	FileService                 portainer.FileService
 	DataStore                   portainer.DataStore
 	GitService                  portainer.GitService
+	APIKeyService               apikey.APIKeyService
 	JWTService                  portainer.JWTService
 	LDAPService                 portainer.LDAPService
 	OAuthService                portainer.OAuthService
@@ -232,7 +234,7 @@ func (server *Server) Start() error {
 	var uploadHandler = upload.NewHandler(requestBouncer)
 	uploadHandler.FileService = server.FileService
 
-	var userHandler = users.NewHandler(requestBouncer, rateLimiter)
+	var userHandler = users.NewHandler(requestBouncer, rateLimiter, server.APIKeyService)
 	userHandler.DataStore = server.DataStore
 	userHandler.CryptoService = server.CryptoService
 

--- a/api/internal/testhelpers/datastore.go
+++ b/api/internal/testhelpers/datastore.go
@@ -8,27 +8,28 @@ import (
 )
 
 type datastore struct {
-	customTemplate     portainer.CustomTemplateService
-	edgeGroup          portainer.EdgeGroupService
-	edgeJob            portainer.EdgeJobService
-	edgeStack          portainer.EdgeStackService
-	endpoint           portainer.EndpointService
-	endpointGroup      portainer.EndpointGroupService
-	endpointRelation   portainer.EndpointRelationService
-	helmUserRepository portainer.HelmUserRepositoryService
-	registry           portainer.RegistryService
-	resourceControl    portainer.ResourceControlService
-	role               portainer.RoleService
-	sslSettings        portainer.SSLSettingsService
-	settings           portainer.SettingsService
-	stack              portainer.StackService
-	tag                portainer.TagService
-	teamMembership     portainer.TeamMembershipService
-	team               portainer.TeamService
-	tunnelServer       portainer.TunnelServerService
-	user               portainer.UserService
-	version            portainer.VersionService
-	webhook            portainer.WebhookService
+	customTemplate          portainer.CustomTemplateService
+	edgeGroup               portainer.EdgeGroupService
+	edgeJob                 portainer.EdgeJobService
+	edgeStack               portainer.EdgeStackService
+	endpoint                portainer.EndpointService
+	endpointGroup           portainer.EndpointGroupService
+	endpointRelation        portainer.EndpointRelationService
+	helmUserRepository      portainer.HelmUserRepositoryService
+	registry                portainer.RegistryService
+	resourceControl         portainer.ResourceControlService
+	apiKeyRepositoryService portainer.APIKeyRepositoryService
+	role                    portainer.RoleService
+	sslSettings             portainer.SSLSettingsService
+	settings                portainer.SettingsService
+	stack                   portainer.StackService
+	tag                     portainer.TagService
+	teamMembership          portainer.TeamMembershipService
+	team                    portainer.TeamService
+	tunnelServer            portainer.TunnelServerService
+	user                    portainer.UserService
+	version                 portainer.VersionService
+	webhook                 portainer.WebhookService
 }
 
 func (d *datastore) BackupTo(io.Writer) error                            { return nil }
@@ -52,16 +53,19 @@ func (d *datastore) HelmUserRepository() portainer.HelmUserRepositoryService {
 func (d *datastore) Registry() portainer.RegistryService               { return d.registry }
 func (d *datastore) ResourceControl() portainer.ResourceControlService { return d.resourceControl }
 func (d *datastore) Role() portainer.RoleService                       { return d.role }
-func (d *datastore) Settings() portainer.SettingsService               { return d.settings }
-func (d *datastore) SSLSettings() portainer.SSLSettingsService         { return d.sslSettings }
-func (d *datastore) Stack() portainer.StackService                     { return d.stack }
-func (d *datastore) Tag() portainer.TagService                         { return d.tag }
-func (d *datastore) TeamMembership() portainer.TeamMembershipService   { return d.teamMembership }
-func (d *datastore) Team() portainer.TeamService                       { return d.team }
-func (d *datastore) TunnelServer() portainer.TunnelServerService       { return d.tunnelServer }
-func (d *datastore) User() portainer.UserService                       { return d.user }
-func (d *datastore) Version() portainer.VersionService                 { return d.version }
-func (d *datastore) Webhook() portainer.WebhookService                 { return d.webhook }
+func (d *datastore) APIKeyRepository() portainer.APIKeyRepositoryService {
+	return d.apiKeyRepositoryService
+}
+func (d *datastore) Settings() portainer.SettingsService             { return d.settings }
+func (d *datastore) SSLSettings() portainer.SSLSettingsService       { return d.sslSettings }
+func (d *datastore) Stack() portainer.StackService                   { return d.stack }
+func (d *datastore) Tag() portainer.TagService                       { return d.tag }
+func (d *datastore) TeamMembership() portainer.TeamMembershipService { return d.teamMembership }
+func (d *datastore) Team() portainer.TeamService                     { return d.team }
+func (d *datastore) TunnelServer() portainer.TunnelServerService     { return d.tunnelServer }
+func (d *datastore) User() portainer.UserService                     { return d.user }
+func (d *datastore) Version() portainer.VersionService               { return d.version }
+func (d *datastore) Webhook() portainer.WebhookService               { return d.webhook }
 
 type datastoreOption = func(d *datastore)
 

--- a/api/internal/testhelpers/datastore.go
+++ b/api/internal/testhelpers/datastore.go
@@ -18,7 +18,7 @@ type datastore struct {
 	helmUserRepository      portainer.HelmUserRepositoryService
 	registry                portainer.RegistryService
 	resourceControl         portainer.ResourceControlService
-	apiKeyRepositoryService portainer.APIKeyRepositoryService
+	apiKeyRepositoryService portainer.APIKeyRepository
 	role                    portainer.RoleService
 	sslSettings             portainer.SSLSettingsService
 	settings                portainer.SettingsService
@@ -53,7 +53,7 @@ func (d *datastore) HelmUserRepository() portainer.HelmUserRepositoryService {
 func (d *datastore) Registry() portainer.RegistryService               { return d.registry }
 func (d *datastore) ResourceControl() portainer.ResourceControlService { return d.resourceControl }
 func (d *datastore) Role() portainer.RoleService                       { return d.role }
-func (d *datastore) APIKeyRepository() portainer.APIKeyRepositoryService {
+func (d *datastore) APIKeyRepository() portainer.APIKeyRepository {
 	return d.apiKeyRepositoryService
 }
 func (d *datastore) Settings() portainer.SettingsService             { return d.settings }

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -672,10 +672,10 @@ type (
 		ID          APIKeyID `json:"Id" example:"1"`
 		UserID      UserID   `json:"UserId" example:"1"`
 		Description string
-		Prefix      [3]rune   `json:"prefix"`      // API key identifier (3 char prefix)
-		DateCreated time.Time `json:"dateCreated"` // Date when the API key was created (UTC)
-		LastUsed    time.Time `json:"lastUsed"`    // Date when the API key was last used (UTC)
-		Digest      [32]byte  `json:"digest"`      // Digest represents the hash of the raw API key
+		Prefix      string    `json:"prefix"`           // API key identifier (3 char prefix)
+		DateCreated time.Time `json:"dateCreated"`      // Date when the API key was created (UTC)
+		LastUsed    time.Time `json:"lastUsed"`         // Date when the API key was last used (UTC)
+		Digest      *[32]byte `json:"digest,omitempty"` // Digest represents the hash of the raw API key
 	}
 
 	// Schedule represents a scheduled job.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -675,7 +675,7 @@ type (
 		Prefix      string    `json:"prefix"`           // API key identifier (3 char prefix)
 		DateCreated time.Time `json:"dateCreated"`      // Date when the API key was created (UTC)
 		LastUsed    time.Time `json:"lastUsed"`         // Date when the API key was last used (UTC)
-		Digest      *[32]byte `json:"digest,omitempty"` // Digest represents the hash of the raw API key
+		Digest      []byte    `json:"digest,omitempty"` // Digest represents the hash of the raw API key
 	}
 
 	// Schedule represents a scheduled job.
@@ -1371,7 +1371,8 @@ type (
 	APIKeyRepository interface {
 		GetAPIKeysByUserID(userID UserID) ([]APIKey, error)
 		CreateAPIKey(key *APIKey) error
-		GetAPIKeyByDigest(digest string) (APIKey, error)
+		GetAPIKeyByDigest(digest []byte) (*APIKey, error)
+		UpdateAPIKey(key *APIKey) error
 		DeleteAPIKey(ID APIKeyID) error
 	}
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -669,13 +669,13 @@ type (
 
 	// APIKey represents an API key
 	APIKey struct {
-		ID          APIKeyID `json:"Id" example:"1"`
-		UserID      UserID   `json:"UserId" example:"1"`
-		Description string
+		ID          APIKeyID  `json:"id" example:"1"`
+		UserID      UserID    `json:"userId" example:"1"`
+		Description string    `json:"description" example:"portainer-api-key"`
 		Prefix      string    `json:"prefix"`           // API key identifier (3 char prefix)
 		DateCreated time.Time `json:"dateCreated"`      // Date when the API key was created (UTC)
 		LastUsed    time.Time `json:"lastUsed"`         // Date when the API key was last used (UTC)
-		Digest      []byte    `json:"digest,omitempty"` // Digest represents the hash of the raw API key
+		Digest      []byte    `json:"digest,omitempty"` // Digest represents SHA256 hash of the raw API key
 	}
 
 	// Schedule represents a scheduled job.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -664,7 +664,7 @@ type (
 	// RoleID represents a role identifier
 	RoleID int
 
-	// RoleID represents a role identifier
+	// APIKeyID represents an API key identifier
 	APIKeyID int
 
 	// APIKey represents an API key
@@ -1140,7 +1140,7 @@ type (
 		Registry() RegistryService
 		ResourceControl() ResourceControlService
 		Role() RoleService
-		APIKeyRepository() APIKeyRepositoryService
+		APIKeyRepository() APIKeyRepository
 		Settings() SettingsService
 		SSLSettings() SSLSettingsService
 		Stack() StackService
@@ -1368,9 +1368,11 @@ type (
 	}
 
 	// APIKeyRepositoryService
-	APIKeyRepositoryService interface {
+	APIKeyRepository interface {
 		GetAPIKeysByUserID(userID UserID) ([]APIKey, error)
-		CreateKey(key *APIKey) error
+		CreateAPIKey(key *APIKey) error
+		GetAPIKeyByDigest(digest string) (APIKey, error)
+		DeleteAPIKey(ID APIKeyID) error
 	}
 
 	// SettingsService represents a service for managing application settings

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1369,11 +1369,12 @@ type (
 
 	// APIKeyRepositoryService
 	APIKeyRepository interface {
-		GetAPIKeysByUserID(userID UserID) ([]APIKey, error)
 		CreateAPIKey(key *APIKey) error
-		GetAPIKeyByDigest(digest []byte) (*APIKey, error)
+		GetAPIKey(keyID APIKeyID) (*APIKey, error)
 		UpdateAPIKey(key *APIKey) error
 		DeleteAPIKey(ID APIKeyID) error
+		GetAPIKeysByUserID(userID UserID) ([]APIKey, error)
+		GetAPIKeyByDigest(digest []byte) (*APIKey, error)
 	}
 
 	// SettingsService represents a service for managing application settings

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -664,6 +664,20 @@ type (
 	// RoleID represents a role identifier
 	RoleID int
 
+	// RoleID represents a role identifier
+	APIKeyID int
+
+	// APIKey represents an API key
+	APIKey struct {
+		ID          APIKeyID `json:"Id" example:"1"`
+		UserID      UserID   `json:"UserId" example:"1"`
+		Description string
+		Prefix      [3]rune   `json:"prefix"`      // API key identifier (3 char prefix)
+		DateCreated time.Time `json:"dateCreated"` // Date when the API key was created (UTC)
+		LastUsed    time.Time `json:"lastUsed"`    // Date when the API key was last used (UTC)
+		Digest      [32]byte  `json:"digest"`      // Digest represents the hash of the raw API key
+	}
+
 	// Schedule represents a scheduled job.
 	// It only contains a pointer to one of the JobRunner implementations
 	// based on the JobType.
@@ -1126,6 +1140,7 @@ type (
 		Registry() RegistryService
 		ResourceControl() ResourceControlService
 		Role() RoleService
+		APIKeyRepository() APIKeyRepositoryService
 		Settings() SettingsService
 		SSLSettings() SSLSettingsService
 		Stack() StackService
@@ -1350,6 +1365,12 @@ type (
 		Roles() ([]Role, error)
 		CreateRole(role *Role) error
 		UpdateRole(ID RoleID, role *Role) error
+	}
+
+	// APIKeyRepositoryService
+	APIKeyRepositoryService interface {
+		GetAPIKeysByUserID(userID UserID) ([]APIKey, error)
+		CreateKey(key *APIKey) error
 	}
 
 	// SettingsService represents a service for managing application settings


### PR DESCRIPTION
Closes [EE-1889](https://portainer.atlassian.net/browse/EE-1889),  [EE-1888](https://portainer.atlassian.net/browse/EE-1888),  [EE-1895](https://portainer.atlassian.net/browse/EE-1895)

## Feature
- Endpoint to generate user access token (api-key)
  - This endpoint requires JWT auth (api-key auth cannot be used to create more api-keys)
  - An admin user cannot generate api-keys for other users
- Endpoint to retrieve all user access tokens
- Endpoint to revoke existing user access token
- Tests for all the functionality above
- APIKey middleware to authenticate and authorise `x-api-key` based requests
  - note: the key can be present in request header or as query param (similar to JWT auth)
- APIKey caching to improve middleware performance (api-key -> user mapping lookups)

## Example

```sh
# generate user api access token (api-key)
curl -X POST \
  -H "Authorization: Bearer $(curl 'http://localhost:9000/api/auth' -d'{"username":"admin","password":"admin123"}' --compressed | jq -r '.jwt')" \
  -d '{"description": "github-api-key"}' \
  http://localhost:9000/api/users/1/tokens
```

```sh
# get user api access tokens (api-keys)
curl \
  -H "Authorization: Bearer $(curl 'http://localhost:9000/api/auth' -d'{"username":"admin","password":"admin123"}' --compressed | jq -r '.jwt')" \
  http://localhost:9000/api/users/1/tokens
```

```sh
# remove a user's api access token (api-key)
curl -X DELETE \
  -H "Authorization: Bearer $(curl 'http://localhost:9000/api/auth' -d'{"username":"admin","password":"admin123"}' --compressed | jq -r '.jwt')" \
  http://localhost:9000/api/users/1/tokens/1
```

---

```sh
# use api-key auth (generated access token) to get all user access tokens
curl \
  -H "x-api-key: vEMa4rwbWWL308KJG1D9NWe/h03tVUQsk78+ubwEr4k=" \
  http://localhost:9000/api/users/1/tokens
```
