### PR TITLE
Prefix generated api-keys with `ptr_`

### DIFF
--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -9,7 +9,7 @@ import (
 
 // APIKeyService represents a service for managing API keys.
 type APIKeyService interface {
-	HashRaw(rawKey string) ([]byte, error)
+	HashRaw(rawKey string) []byte
 	GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error)
 	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
 	GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error)

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -29,27 +29,27 @@ func NewAPIKeyService(apiKeyRepository portainer.APIKeyRepository, userRepositor
 	}
 }
 
-// HashRaw computes a hash digest of provided base64 encoded raw API key.
+// HashRaw computes a hash digest of provided raw API key.
 func (a *apiKeyService) HashRaw(rawKey string) []byte {
 	hashDigest := sha256.Sum256([]byte(rawKey))
 	return hashDigest[:]
 }
 
-// GenerateApiKey generates a base64 encoded raw API key for a user (for one-time display).
+// GenerateApiKey generates a raw API key for a user (for one-time display).
 // The generated API key is stored in the cache and database.
 func (a *apiKeyService) GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error) {
 	randKey := generateRandomKey(32)
 	encodedRawAPIKey := base64.StdEncoding.EncodeToString(randKey)
 	prefixedAPIKey := portainerAPIKeyPrefix + encodedRawAPIKey
 
-	hashDigest := sha256.Sum256([]byte(prefixedAPIKey))
+	hashDigest := a.HashRaw(prefixedAPIKey)
 
 	apiKey := &portainer.APIKey{
 		UserID:      user.ID,
 		Description: description,
 		Prefix:      prefixedAPIKey[:7],
 		DateCreated: time.Now(),
-		Digest:      hashDigest[:],
+		Digest:      hashDigest,
 	}
 
 	err := a.apiKeyRepository.CreateAPIKey(apiKey)

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -264,10 +264,7 @@ func (bouncer *RequestBouncer) apiKeyLookup(r *http.Request) *portainer.TokenDat
 		return nil
 	}
 
-	digest, err := bouncer.apiKeyService.HashRaw(rawAPIKey)
-	if err != nil {
-		return nil
-	}
+	digest := bouncer.apiKeyService.HashRaw(rawAPIKey)
 
 	user, apiKey, err := bouncer.apiKeyService.GetDigestUserAndKey(digest)
 	if err != nil {

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -672,7 +672,7 @@ type (
 		ID          APIKeyID  `json:"id" example:"1"`
 		UserID      UserID    `json:"userId" example:"1"`
 		Description string    `json:"description" example:"portainer-api-key"`
-		Prefix      string    `json:"prefix"`           // API key identifier (3 char prefix)
+		Prefix      string    `json:"prefix"`           // API key identifier (7 char prefix)
 		DateCreated time.Time `json:"dateCreated"`      // Date when the API key was created (UTC)
 		LastUsed    time.Time `json:"lastUsed"`         // Date when the API key was last used (UTC)
 		Digest      []byte    `json:"digest,omitempty"` // Digest represents SHA256 hash of the raw API key


### PR DESCRIPTION
## changelog
- prefixing generated api-keys with `ptr_`
- updated tests accordingly