### PR TITLE
fix(stack): support removing duplicated stacks EE-1962

### DIFF
--- a/api/bolt/stack/stack.go
+++ b/api/bolt/stack/stack.go
@@ -77,6 +77,31 @@ func (service *Service) StackByName(name string) (*portainer.Stack, error) {
 	return stack, err
 }
 
+// Stacks returns an array containing all the stacks with same name
+func (service *Service) StacksByName(name string) ([]portainer.Stack, error) {
+	var stacks = make([]portainer.Stack, 0)
+
+	err := service.connection.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketName))
+		cursor := bucket.Cursor()
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			var t portainer.Stack
+			err := internal.UnmarshalObject(v, &t)
+			if err != nil {
+				return err
+			}
+
+			if t.Name == name {
+				stacks = append(stacks, t)
+			}
+		}
+
+		return nil
+	})
+
+	return stacks, err
+}
+
 // Stacks returns an array containing all the stacks.
 func (service *Service) Stacks() ([]portainer.Stack, error) {
 	var stacks = make([]portainer.Stack, 0)

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/portainer/portainer/api/filesystem"
 	gittypes "github.com/portainer/portainer/api/git/types"
 	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/internal/stackutils"
 )
 
 type composeStackFromFileContentPayload struct {
@@ -35,6 +36,36 @@ func (payload *composeStackFromFileContentPayload) Validate(r *http.Request) err
 	}
 	return nil
 }
+func (handler *Handler) checkAndCleanStackDupFromSwarm(w http.ResponseWriter, r *http.Request, endpoint *portainer.Endpoint, userID portainer.UserID, stack *portainer.Stack) error {
+	resourceControl, err := handler.DataStore.ResourceControl().ResourceControlByResourceIDAndType(stackutils.ResourceControlID(stack.EndpointID, stack.Name), portainer.StackResourceControl)
+	if err != nil {
+		return err
+	}
+	// stop scheduler updates of the stack before removal
+	if stack.AutoUpdate != nil {
+		stopAutoupdate(stack.ID, stack.AutoUpdate.JobID, *handler.Scheduler)
+	}
+
+	err = handler.DataStore.Stack().DeleteStack(stack.ID)
+	if err != nil {
+		return err
+	}
+
+	if resourceControl != nil {
+		err = handler.DataStore.ResourceControl().DeleteResourceControl(resourceControl.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if exists, _ := handler.FileService.FileExists(stack.ProjectPath); exists {
+		err = handler.FileService.RemoveDirectory(stack.ProjectPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter, r *http.Request, endpoint *portainer.Endpoint, userID portainer.UserID) *httperror.HandlerError {
 	var payload composeStackFromFileContentPayload
@@ -50,7 +81,19 @@ func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter,
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check for name collision", err}
 	}
 	if !isUnique {
-		return stackExistsError(payload.Name)
+		stack, err := handler.DataStore.Stack().StackByName(payload.Name)
+		if err != nil {
+			return stackExistsError(payload.Name)
+		}
+
+		if stack.Type != portainer.DockerComposeStack && stack.EndpointID == endpoint.ID {
+			err := handler.checkAndCleanStackDupFromSwarm(w, r, endpoint, userID, stack)
+			if err != nil {
+				return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Invalid request payload", Err: err}
+			}
+		} else {
+			return stackExistsError(payload.Name)
+		}
 	}
 
 	stackID := handler.DataStore.Stack().GetNextIdentifier()
@@ -155,7 +198,19 @@ func (handler *Handler) createComposeStackFromGitRepository(w http.ResponseWrite
 		return &httperror.HandlerError{StatusCode: http.StatusInternalServerError, Message: "Unable to check for name collision", Err: err}
 	}
 	if !isUnique {
-		return stackExistsError(payload.Name)
+		stack, err := handler.DataStore.Stack().StackByName(payload.Name)
+		if err != nil {
+			return stackExistsError(payload.Name)
+		}
+
+		if stack.Type != portainer.DockerComposeStack && stack.EndpointID == endpoint.ID {
+			err := handler.checkAndCleanStackDupFromSwarm(w, r, endpoint, userID, stack)
+			if err != nil {
+				return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Invalid request payload", Err: err}
+			}
+		} else {
+			return stackExistsError(payload.Name)
+		}
 	}
 
 	//make sure the webhook ID is unique
@@ -284,7 +339,19 @@ func (handler *Handler) createComposeStackFromFileUpload(w http.ResponseWriter, 
 		return &httperror.HandlerError{StatusCode: http.StatusInternalServerError, Message: "Unable to check for name collision", Err: err}
 	}
 	if !isUnique {
-		return stackExistsError(payload.Name)
+		stack, err := handler.DataStore.Stack().StackByName(payload.Name)
+		if err != nil {
+			return stackExistsError(payload.Name)
+		}
+
+		if stack.Type != portainer.DockerComposeStack && stack.EndpointID == endpoint.ID {
+			err := handler.checkAndCleanStackDupFromSwarm(w, r, endpoint, userID, stack)
+			if err != nil {
+				return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Invalid request payload", Err: err}
+			}
+		} else {
+			return stackExistsError(payload.Name)
+		}
 	}
 
 	stackID := handler.DataStore.Stack().GetNextIdentifier()

--- a/api/http/handler/stacks/create_compose_stack.go
+++ b/api/http/handler/stacks/create_compose_stack.go
@@ -80,6 +80,7 @@ func (handler *Handler) createComposeStackFromFileContent(w http.ResponseWriter,
 	if err != nil {
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to check for name collision", err}
 	}
+
 	if !isUnique {
 		stack, err := handler.DataStore.Stack().StackByName(payload.Name)
 		if err != nil {

--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -108,7 +108,7 @@ func filterStacks(stacks []portainer.Stack, filters *stackListOperationFilters, 
 		if stack.Type == portainer.DockerComposeStack && stack.EndpointID == portainer.EndpointID(filters.EndpointID) {
 			filteredStacks = append(filteredStacks, stack)
 		}
-		if stack.Type == portainer.DockerSwarmStack && (stack.SwarmID == filters.SwarmID || filters.SwarmID == "") {
+		if stack.Type == portainer.DockerSwarmStack && stack.SwarmID == filters.SwarmID {
 			filteredStacks = append(filteredStacks, stack)
 		}
 	}

--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -108,7 +108,7 @@ func filterStacks(stacks []portainer.Stack, filters *stackListOperationFilters, 
 		if stack.Type == portainer.DockerComposeStack && stack.EndpointID == portainer.EndpointID(filters.EndpointID) {
 			filteredStacks = append(filteredStacks, stack)
 		}
-		if stack.Type == portainer.DockerSwarmStack && stack.SwarmID == filters.SwarmID {
+		if stack.Type == portainer.DockerSwarmStack && (stack.SwarmID == filters.SwarmID || filters.SwarmID == "") {
 			filteredStacks = append(filteredStacks, stack)
 		}
 	}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1373,6 +1373,7 @@ type (
 	StackService interface {
 		Stack(ID StackID) (*Stack, error)
 		StackByName(name string) (*Stack, error)
+		StacksByName(name string) ([]Stack, error)
 		Stacks() ([]Stack, error)
 		CreateStack(stack *Stack) error
 		UpdateStack(ID StackID, stack *Stack) error


### PR DESCRIPTION
The delete func basically follows the process defined in stack_delete.go. 
It does not call the handler.deleteStack(), because I believe this is to handle the swarm stack removal via swarm command.