### PR TITLE
fix(swagger) the params for /restore are subtly different

### DIFF
--- a/api/http/handler/backup/restore.go
+++ b/api/http/handler/backup/restore.go
@@ -12,9 +12,9 @@ import (
 )
 
 type restorePayload struct {
-	FileContent []byte
-	FileName    string
-	Password    string
+	FileContent []byte `json:"file"`
+	FileName    string `json:"filename"`
+	Password    string `json:"password,omitempty"`
 }
 
 // @id Restore


### PR DESCRIPTION
@yi-portainer I need help wrt testing https://github.com/portainer/portainer-ee/pull/769/files

the usage that works for me in my store-tests is

```
curl -v -X POST \
	-F file=@./portainer-ce/portainer-ce-latest-testbackup.tar.gz \
	-F filename=portainer-ce-latest-testbackup.tar.gz \
	http://localhost:9000/api/restore
```

And I don't feel that lines up with what is in https://app.swaggerhub.com/apis/portainer/portainer-ee/2.10.0#/backup/Restore

its more like https://app.swaggerhub.com/apis/portainer/portainer-ce/2.9.2#/backup/Restore but with spelling changes to the params.