### PR TITLE
feat(api-key): open-api spec update to support api-key security scheme EE-2051

### DIFF
--- a/.vscode.example/portainer.code-snippets
+++ b/.vscode.example/portainer.code-snippets
@@ -150,6 +150,7 @@
       "// @description ",
       "// @description **Access policy**: ",
       "// @tags ",
+      "// @security ApiKeyAuth",
       "// @security jwt",
       "// @accept json",
       "// @produce json",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ When adding a new route to an existing handler use the following as a template (
 // @description
 // @description **Access policy**:
 // @tags
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/auth/logout.go
+++ b/api/http/handler/auth/logout.go
@@ -11,6 +11,7 @@ import (
 // @id Logout
 // @summary Logout
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags auth
 // @success 204 "Success"

--- a/api/http/handler/backup/backup.go
+++ b/api/http/handler/backup/backup.go
@@ -26,6 +26,7 @@ func (p *backupPayload) Validate(r *http.Request) error {
 // @description  Creates an archive with a system data snapshot that could be used to restore the system.
 // @description **Access policy**: admin
 // @tags backup
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce octet-stream

--- a/api/http/handler/customtemplates/customtemplate_create.go
+++ b/api/http/handler/customtemplates/customtemplate_create.go
@@ -22,6 +22,7 @@ import (
 // @description Create a custom template.
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @accept json,multipart/form-data
 // @produce json

--- a/api/http/handler/customtemplates/customtemplate_delete.go
+++ b/api/http/handler/customtemplates/customtemplate_delete.go
@@ -18,6 +18,7 @@ import (
 // @description Remove a template.
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Template identifier"
 // @success 204 "Success"

--- a/api/http/handler/customtemplates/customtemplate_file.go
+++ b/api/http/handler/customtemplates/customtemplate_file.go
@@ -19,6 +19,7 @@ type fileResponse struct {
 // @description Retrieve the content of the Stack file for the specified custom template
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Template identifier"

--- a/api/http/handler/customtemplates/customtemplate_inspect.go
+++ b/api/http/handler/customtemplates/customtemplate_inspect.go
@@ -18,6 +18,7 @@ import (
 // @description Retrieve details about a template.
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Template identifier"

--- a/api/http/handler/customtemplates/customtemplate_list.go
+++ b/api/http/handler/customtemplates/customtemplate_list.go
@@ -17,6 +17,7 @@ import (
 // @description List available custom templates.
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param type query []int true "Template types" Enums(1,2,3)

--- a/api/http/handler/customtemplates/customtemplate_update.go
+++ b/api/http/handler/customtemplates/customtemplate_update.go
@@ -62,6 +62,7 @@ func (payload *customTemplateUpdatePayload) Validate(r *http.Request) error {
 // @description Update a template.
 // @description **Access policy**: authenticated
 // @tags custom_templates
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/edgegroups/edgegroup_create.go
+++ b/api/http/handler/edgegroups/edgegroup_create.go
@@ -36,6 +36,7 @@ func (payload *edgeGroupCreatePayload) Validate(r *http.Request) error {
 // @summary Create an EdgeGroup
 // @description **Access policy**: administrator
 // @tags edge_groups
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/edgegroups/edgegroup_delete.go
+++ b/api/http/handler/edgegroups/edgegroup_delete.go
@@ -15,6 +15,7 @@ import (
 // @summary Deletes an EdgeGroup
 // @description **Access policy**: administrator
 // @tags edge_groups
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "EdgeGroup Id"
 // @success 204

--- a/api/http/handler/edgegroups/edgegroup_inspect.go
+++ b/api/http/handler/edgegroups/edgegroup_inspect.go
@@ -14,6 +14,7 @@ import (
 // @summary Inspects an EdgeGroup
 // @description **Access policy**: administrator
 // @tags edge_groups
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "EdgeGroup Id"

--- a/api/http/handler/edgegroups/edgegroup_list.go
+++ b/api/http/handler/edgegroups/edgegroup_list.go
@@ -19,6 +19,7 @@ type decoratedEdgeGroup struct {
 // @summary list EdgeGroups
 // @description **Access policy**: administrator
 // @tags edge_groups
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.EdgeGroup{HasEdgeStack=bool} "EdgeGroups"

--- a/api/http/handler/edgegroups/edgegroup_update.go
+++ b/api/http/handler/edgegroups/edgegroup_update.go
@@ -38,6 +38,7 @@ func (payload *edgeGroupUpdatePayload) Validate(r *http.Request) error {
 // @summary Updates an EdgeGroup
 // @description **Access policy**: administrator
 // @tags edge_groups
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/edgejobs/edgejob_create.go
+++ b/api/http/handler/edgejobs/edgejob_create.go
@@ -18,6 +18,7 @@ import (
 // @summary Create an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param method query string true "Creation Method" Enums(file, string)

--- a/api/http/handler/edgejobs/edgejob_delete.go
+++ b/api/http/handler/edgejobs/edgejob_delete.go
@@ -15,6 +15,7 @@ import (
 // @summary Delete an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @param id path string true "EdgeJob Id"
 // @success 204

--- a/api/http/handler/edgejobs/edgejob_file.go
+++ b/api/http/handler/edgejobs/edgejob_file.go
@@ -18,6 +18,7 @@ type edgeJobFileResponse struct {
 // @summary Fetch a file of an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_inspect.go
+++ b/api/http/handler/edgejobs/edgejob_inspect.go
@@ -19,6 +19,7 @@ type edgeJobInspectResponse struct {
 // @summary Inspect an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_list.go
+++ b/api/http/handler/edgejobs/edgejob_list.go
@@ -11,6 +11,7 @@ import (
 // @summary Fetch EdgeJobs list
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.EdgeJob

--- a/api/http/handler/edgejobs/edgejob_tasklogs_clear.go
+++ b/api/http/handler/edgejobs/edgejob_tasklogs_clear.go
@@ -15,6 +15,7 @@ import (
 // @summary Clear the log for a specifc task on an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_tasklogs_collect.go
+++ b/api/http/handler/edgejobs/edgejob_tasklogs_collect.go
@@ -14,6 +14,7 @@ import (
 // @summary Collect the log for a specifc task on an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_tasklogs_inspect.go
+++ b/api/http/handler/edgejobs/edgejob_tasklogs_inspect.go
@@ -17,6 +17,7 @@ type fileResponse struct {
 // @summary Fetch the log for a specifc task on an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_tasks_list.go
+++ b/api/http/handler/edgejobs/edgejob_tasks_list.go
@@ -21,6 +21,7 @@ type taskContainer struct {
 // @summary Fetch the list of tasks on an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeJob Id"

--- a/api/http/handler/edgejobs/edgejob_update.go
+++ b/api/http/handler/edgejobs/edgejob_update.go
@@ -32,6 +32,7 @@ func (payload *edgeJobUpdatePayload) Validate(r *http.Request) error {
 // @summary Update an EdgeJob
 // @description **Access policy**: administrator
 // @tags edge_jobs
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/edgestacks/edgestack_create.go
+++ b/api/http/handler/edgestacks/edgestack_create.go
@@ -21,6 +21,7 @@ import (
 // @summary Create an EdgeStack
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param method query string true "Creation Method" Enums(file,string,repository)

--- a/api/http/handler/edgestacks/edgestack_delete.go
+++ b/api/http/handler/edgestacks/edgestack_delete.go
@@ -15,6 +15,7 @@ import (
 // @summary Delete an EdgeStack
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @param id path string true "EdgeStack Id"
 // @success 204

--- a/api/http/handler/edgestacks/edgestack_file.go
+++ b/api/http/handler/edgestacks/edgestack_file.go
@@ -18,6 +18,7 @@ type stackFileResponse struct {
 // @summary Fetches the stack file for an EdgeStack
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeStack Id"

--- a/api/http/handler/edgestacks/edgestack_inspect.go
+++ b/api/http/handler/edgestacks/edgestack_inspect.go
@@ -14,6 +14,7 @@ import (
 // @summary Inspect an EdgeStack
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "EdgeStack Id"

--- a/api/http/handler/edgestacks/edgestack_list.go
+++ b/api/http/handler/edgestacks/edgestack_list.go
@@ -11,6 +11,7 @@ import (
 // @summary Fetches the list of EdgeStacks
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.EdgeStack

--- a/api/http/handler/edgestacks/edgestack_update.go
+++ b/api/http/handler/edgestacks/edgestack_update.go
@@ -35,6 +35,7 @@ func (payload *updateEdgeStackPayload) Validate(r *http.Request) error {
 // @summary Update an EdgeStack
 // @description **Access policy**: administrator
 // @tags edge_stacks
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/edgetemplates/edgetemplate_list.go
+++ b/api/http/handler/edgetemplates/edgetemplate_list.go
@@ -19,6 +19,7 @@ type templateFileFormat struct {
 // @summary Fetches the list of Edge Templates
 // @description **Access policy**: administrator
 // @tags edge_templates
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/endpointgroups/endpointgroup_create.go
+++ b/api/http/handler/endpointgroups/endpointgroup_create.go
@@ -36,6 +36,7 @@ func (payload *endpointGroupCreatePayload) Validate(r *http.Request) error {
 // @description Create a new environment(endpoint) group.
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/endpointgroups/endpointgroup_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_delete.go
@@ -16,6 +16,7 @@ import (
 // @description Remove an environment(endpoint) group.
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "EndpointGroup identifier"
 // @success 204 "Success"

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_add.go
@@ -15,6 +15,7 @@ import (
 // @description Add an environment(endpoint) to an environment(endpoint) group
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "EndpointGroup identifier"
 // @param endpointId path int true "Environment(Endpoint) identifier"

--- a/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
+++ b/api/http/handler/endpointgroups/endpointgroup_endpoint_delete.go
@@ -14,6 +14,7 @@ import (
 // @summary Removes environment(endpoint) from an environment(endpoint) group
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "EndpointGroup identifier"
 // @param endpointId path int true "Environment(Endpoint) identifier"

--- a/api/http/handler/endpointgroups/endpointgroup_inspect.go
+++ b/api/http/handler/endpointgroups/endpointgroup_inspect.go
@@ -14,6 +14,7 @@ import (
 // @description Retrieve details abont an environment(endpoint) group.
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/endpointgroups/endpointgroup_list.go
+++ b/api/http/handler/endpointgroups/endpointgroup_list.go
@@ -15,6 +15,7 @@ import (
 // @description only return authorized environment(endpoint) groups.
 // @description **Access policy**: restricted
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.EndpointGroup "Environment(Endpoint) group"

--- a/api/http/handler/endpointgroups/endpointgroup_update.go
+++ b/api/http/handler/endpointgroups/endpointgroup_update.go
@@ -32,6 +32,7 @@ func (payload *endpointGroupUpdatePayload) Validate(r *http.Request) error {
 // @description Update an environment(endpoint) group.
 // @description **Access policy**: administrator
 // @tags endpoint_groups
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/endpoints/endpoint_association_delete.go
+++ b/api/http/handler/endpoints/endpoint_association_delete.go
@@ -19,6 +19,7 @@ import (
 // @summary De-association an edge environment(endpoint)
 // @description De-association an edge environment(endpoint).
 // @description **Access policy**: administrator
+// @security ApiKeyAuth
 // @security jwt
 // @tags endpoints
 // @produce json

--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -152,6 +152,7 @@ func (payload *endpointCreatePayload) Validate(r *http.Request) error {
 // @description  Create a new environment(endpoint) that will be used to manage an environment(endpoint).
 // @description **Access policy**: administrator
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @accept multipart/form-data
 // @produce json

--- a/api/http/handler/endpoints/endpoint_delete.go
+++ b/api/http/handler/endpoints/endpoint_delete.go
@@ -16,6 +16,7 @@ import (
 // @description Remove an environment(endpoint).
 // @description **Access policy**: administrator
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Environment(Endpoint) identifier"
 // @success 204 "Success"

--- a/api/http/handler/endpoints/endpoint_dockerhub_status.go
+++ b/api/http/handler/endpoints/endpoint_dockerhub_status.go
@@ -29,6 +29,7 @@ type dockerhubStatusResponse struct {
 // @description get docker pull limits for a docker hub registry in the environment
 // @description **Access policy**:
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "endpoint ID"

--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -15,6 +15,7 @@ import (
 // @description Retrieve details about an environment(endpoint).
 // @description **Access policy**: restricted
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Environment(Endpoint) identifier"

--- a/api/http/handler/endpoints/endpoint_list.go
+++ b/api/http/handler/endpoints/endpoint_list.go
@@ -20,6 +20,7 @@ import (
 // @description only return authorized environments(endpoints).
 // @description **Access policy**: restricted
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param start query int false "Start searching from"

--- a/api/http/handler/endpoints/endpoint_registries_inspect.go
+++ b/api/http/handler/endpoints/endpoint_registries_inspect.go
@@ -16,6 +16,7 @@ import (
 // @summary get registry for environment
 // @description **Access policy**: authenticated
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "identifier"

--- a/api/http/handler/endpoints/endpoint_registries_list.go
+++ b/api/http/handler/endpoints/endpoint_registries_list.go
@@ -19,6 +19,7 @@ import (
 // @description **Access policy**: authenticated
 // @tags endpoints
 // @param namespace query string false "required if kubernetes environment, will show registries by namespace"
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Environment(Endpoint) identifier"

--- a/api/http/handler/endpoints/endpoint_registry_access.go
+++ b/api/http/handler/endpoints/endpoint_registry_access.go
@@ -25,6 +25,7 @@ func (payload *registryAccessPayload) Validate(r *http.Request) error {
 // @summary update registry access for environment
 // @description **Access policy**: authenticated
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/endpoints/endpoint_settings_update.go
+++ b/api/http/handler/endpoints/endpoint_settings_update.go
@@ -39,6 +39,7 @@ func (payload *endpointSettingsUpdatePayload) Validate(r *http.Request) error {
 // @summary Update settings for an environment(endpoint)
 // @description Update settings for an environment(endpoint).
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags endpoints
 // @accept json

--- a/api/http/handler/endpoints/endpoint_snapshot.go
+++ b/api/http/handler/endpoints/endpoint_snapshot.go
@@ -16,6 +16,7 @@ import (
 // @description Snapshots an environment(endpoint)
 // @description **Access policy**: administrator
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Environment(Endpoint) identifier"
 // @success 204 "Success"

--- a/api/http/handler/endpoints/endpoint_snapshots.go
+++ b/api/http/handler/endpoints/endpoint_snapshots.go
@@ -15,6 +15,7 @@ import (
 // @description Snapshot all environments(endpoints)
 // @description **Access policy**: administrator
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @success 204 "Success"
 // @failure 500 "Server Error"

--- a/api/http/handler/endpoints/endpoint_status_inspect.go
+++ b/api/http/handler/endpoints/endpoint_status_inspect.go
@@ -54,6 +54,7 @@ type endpointStatusInspectResponse struct {
 // @description Environment(Endpoint) for edge agent to check status of environment(endpoint)
 // @description **Access policy**: restricted only to Edge environments(endpoints)
 // @tags endpoints
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Environment(Endpoint) identifier"
 // @success 200 {object} endpointStatusInspectResponse "Success"

--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -57,6 +57,7 @@ func (payload *endpointUpdatePayload) Validate(r *http.Request) error {
 // @summary Update an environment(endpoint)
 // @description Update an environment(endpoint).
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags endpoints
 // @accept json

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -89,6 +89,10 @@ type Handler struct {
 // @BasePath /api
 // @schemes http https
 
+// @securitydefinitions.apikey ApiKeyAuth
+// @in header
+// @name Authorization
+
 // @securitydefinitions.apikey jwt
 // @in header
 // @name Authorization

--- a/api/http/handler/helm/helm_delete.go
+++ b/api/http/handler/helm/helm_delete.go
@@ -14,6 +14,7 @@ import (
 // @description
 // @description **Access policy**: authenticated
 // @tags helm
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Environment(Endpoint) identifier"
 // @param release path string true "The name of the release/application to uninstall"

--- a/api/http/handler/helm/helm_install.go
+++ b/api/http/handler/helm/helm_install.go
@@ -38,6 +38,7 @@ var errChartNameInvalid = errors.New("invalid chart name. " +
 // @description
 // @description **Access policy**: authenticated
 // @tags helm
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/helm/helm_list.go
+++ b/api/http/handler/helm/helm_list.go
@@ -14,6 +14,7 @@ import (
 // @description
 // @description **Access policy**: authenticated
 // @tags helm
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/helm/helm_repo_search.go
+++ b/api/http/handler/helm/helm_repo_search.go
@@ -16,6 +16,7 @@ import (
 // @description **Access policy**: authenticated
 // @tags helm
 // @param repo query string true "Helm repository URL"
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {object} string "Success"

--- a/api/http/handler/helm/helm_show.go
+++ b/api/http/handler/helm/helm_show.go
@@ -20,6 +20,7 @@ import (
 // @param repo query string true "Helm repository URL"
 // @param chart query string true "Chart name"
 // @param command path string true "chart/values/readme"
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce text/plain

--- a/api/http/handler/helm/user_helm_repos.go
+++ b/api/http/handler/helm/user_helm_repos.go
@@ -33,6 +33,7 @@ func (p *addHelmRepoUrlPayload) Validate(_ *http.Request) error {
 // @description Create a user helm repository.
 // @description **Access policy**: authenticated
 // @tags helm
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json
@@ -93,6 +94,7 @@ func (handler *Handler) userCreateHelmRepo(w http.ResponseWriter, r *http.Reques
 // @description Inspect a user helm repositories.
 // @description **Access policy**: authenticated
 // @tags helm
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "User identifier"

--- a/api/http/handler/kubernetes/kubernetes_config.go
+++ b/api/http/handler/kubernetes/kubernetes_config.go
@@ -19,6 +19,7 @@ import (
 // @description Generates kubeconfig file enabling client communication with k8s api server
 // @description **Access policy**: authenticated
 // @tags kubernetes
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/kubernetes/kubernetes_nodes_limits.go
+++ b/api/http/handler/kubernetes/kubernetes_nodes_limits.go
@@ -15,6 +15,7 @@ import (
 // @description Get CPU and memory limits of all nodes within k8s cluster
 // @description **Access policy**: authenticated
 // @tags kubernetes
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/kubernetes/namespaces_toggle_system.go
+++ b/api/http/handler/kubernetes/namespaces_toggle_system.go
@@ -22,6 +22,7 @@ func (payload *namespacesToggleSystemPayload) Validate(r *http.Request) error {
 // @summary Toggle the system state for a namespace
 // @description  Toggle the system state for a namespace
 // @description **Access policy**: administrator or environment(endpoint) admin
+// @security ApiKeyAuth
 // @security jwt
 // @tags kubernetes
 // @accept json

--- a/api/http/handler/ldap/ldap_check.go
+++ b/api/http/handler/ldap/ldap_check.go
@@ -22,6 +22,7 @@ func (payload *checkPayload) Validate(r *http.Request) error {
 // @description Test LDAP connectivity using LDAP details
 // @description **Access policy**: administrator
 // @tags ldap
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @param body body checkPayload true "details"

--- a/api/http/handler/motd/motd.go
+++ b/api/http/handler/motd/motd.go
@@ -30,6 +30,7 @@ type motdData struct {
 // @summary fetches the message of the day
 // @description **Access policy**: restricted
 // @tags motd
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {object} motdResponse

--- a/api/http/handler/registries/registry_configure.go
+++ b/api/http/handler/registries/registry_configure.go
@@ -83,6 +83,7 @@ func (payload *registryConfigurePayload) Validate(r *http.Request) error {
 // @description Configures a registry.
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/registries/registry_create.go
+++ b/api/http/handler/registries/registry_create.go
@@ -64,6 +64,7 @@ func (payload *registryCreatePayload) Validate(_ *http.Request) error {
 // @description Create a new registry.
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/registries/registry_delete.go
+++ b/api/http/handler/registries/registry_delete.go
@@ -17,6 +17,7 @@ import (
 // @description Remove a registry
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Registry identifier"
 // @success 204 "Success"

--- a/api/http/handler/registries/registry_inspect.go
+++ b/api/http/handler/registries/registry_inspect.go
@@ -16,6 +16,7 @@ import (
 // @description Retrieve details about a registry.
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Registry identifier"

--- a/api/http/handler/registries/registry_list.go
+++ b/api/http/handler/registries/registry_list.go
@@ -16,6 +16,7 @@ import (
 // @description will only return authorized registries.
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.Registry "Success"

--- a/api/http/handler/registries/registry_update.go
+++ b/api/http/handler/registries/registry_update.go
@@ -39,6 +39,7 @@ func (payload *registryUpdatePayload) Validate(r *http.Request) error {
 // @description Update a registry
 // @description **Access policy**: restricted
 // @tags registries
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/resourcecontrols/resourcecontrol_create.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_create.go
@@ -58,6 +58,7 @@ func (payload *resourceControlCreatePayload) Validate(r *http.Request) error {
 // @description Create a new resource control to restrict access to a Docker resource.
 // @description **Access policy**: administrator
 // @tags resource_controls
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/resourcecontrols/resourcecontrol_delete.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_delete.go
@@ -15,6 +15,7 @@ import (
 // @description Remove a resource control.
 // @description **Access policy**: administrator
 // @tags resource_controls
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Resource control identifier"
 // @success 204 "Success"

--- a/api/http/handler/resourcecontrols/resourcecontrol_update.go
+++ b/api/http/handler/resourcecontrols/resourcecontrol_update.go
@@ -40,6 +40,7 @@ func (payload *resourceControlUpdatePayload) Validate(r *http.Request) error {
 // @description Update a resource control
 // @description **Access policy**: authenticated
 // @tags resource_controls
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/roles/role_list.go
+++ b/api/http/handler/roles/role_list.go
@@ -12,6 +12,7 @@ import (
 // @description List all roles available for use
 // @description **Access policy**: administrator
 // @tags roles
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.Role "Success"

--- a/api/http/handler/settings/settings_inspect.go
+++ b/api/http/handler/settings/settings_inspect.go
@@ -12,6 +12,7 @@ import (
 // @description Retrieve Portainer settings.
 // @description **Access policy**: administrator
 // @tags settings
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {object} portainer.Settings "Success"

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -78,6 +78,7 @@ func (payload *settingsUpdatePayload) Validate(r *http.Request) error {
 // @description Update Portainer settings.
 // @description **Access policy**: administrator
 // @tags settings
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/ssl/ssl_inspect.go
+++ b/api/http/handler/ssl/ssl_inspect.go
@@ -12,6 +12,7 @@ import (
 // @description Retrieve the ssl settings.
 // @description **Access policy**: administrator
 // @tags ssl
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {object} portainer.SSLSettings "Success"

--- a/api/http/handler/ssl/ssl_update.go
+++ b/api/http/handler/ssl/ssl_update.go
@@ -28,6 +28,7 @@ func (payload *sslUpdatePayload) Validate(r *http.Request) error {
 // @description Update the ssl settings.
 // @description **Access policy**: administrator
 // @tags ssl
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/stacks/stack_associate.go
+++ b/api/http/handler/stacks/stack_associate.go
@@ -18,6 +18,7 @@ import (
 // @summary Associate an orphaned stack to a new environment(endpoint)
 // @description **Access policy**: administrator
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Stack identifier"

--- a/api/http/handler/stacks/stack_create.go
+++ b/api/http/handler/stacks/stack_create.go
@@ -35,6 +35,7 @@ func (handler *Handler) cleanUp(stack *portainer.Stack, doCleanUp *bool) error {
 // @description Deploy a new stack into a Docker environment(endpoint) specified via the environment(endpoint) identifier.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @accept json,multipart/form-data
 // @produce json

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -25,6 +25,7 @@ import (
 // @description Remove a stack.
 // @description **Access policy**: restricted
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Stack identifier"
 // @param external query boolean false "Set to true to delete an external stack. Only external Swarm stacks are supported"

--- a/api/http/handler/stacks/stack_file.go
+++ b/api/http/handler/stacks/stack_file.go
@@ -23,6 +23,7 @@ type stackFileResponse struct {
 // @description Get Stack file content.
 // @description **Access policy**: restricted
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Stack identifier"

--- a/api/http/handler/stacks/stack_inspect.go
+++ b/api/http/handler/stacks/stack_inspect.go
@@ -19,6 +19,7 @@ import (
 // @description Retrieve details about a stack.
 // @description **Access policy**: restricted
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Stack identifier"

--- a/api/http/handler/stacks/stack_list.go
+++ b/api/http/handler/stacks/stack_list.go
@@ -26,6 +26,7 @@ type stackListOperationFilters struct {
 // @description will only return the list of stacks the user have access to.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @param filters query string false "Filters to process on the stack list. Encoded as JSON (a map[string]string). For example, {'SwarmID': 'jpofkc0i9uo9wtx1zesuk649w'} will only return stacks that are part of the specified Swarm cluster. Available filters: EndpointID, SwarmID."
 // @success 200 {array} portainer.Stack "Success"

--- a/api/http/handler/stacks/stack_migrate.go
+++ b/api/http/handler/stacks/stack_migrate.go
@@ -36,6 +36,7 @@ func (payload *stackMigratePayload) Validate(r *http.Request) error {
 // @description  Migrate a stack from an environment(endpoint) to another environment(endpoint). It will re-create the stack inside the target environment(endpoint) before removing the original stack.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Stack identifier"

--- a/api/http/handler/stacks/stack_start.go
+++ b/api/http/handler/stacks/stack_start.go
@@ -22,6 +22,7 @@ import (
 // @description Starts a stopped Stack.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Stack identifier"
 // @success 200 {object} portainer.Stack "Success"

--- a/api/http/handler/stacks/stack_stop.go
+++ b/api/http/handler/stacks/stack_stop.go
@@ -20,6 +20,7 @@ import (
 // @description Stops a stopped Stack.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Stack identifier"
 // @success 200 {object} portainer.Stack "Success"

--- a/api/http/handler/stacks/stack_update.go
+++ b/api/http/handler/stacks/stack_update.go
@@ -53,6 +53,7 @@ func (payload *updateSwarmStackPayload) Validate(r *http.Request) error {
 // @description Update a stack.
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/stacks/stack_update_git.go
+++ b/api/http/handler/stacks/stack_update_git.go
@@ -42,6 +42,7 @@ func (payload *stackGitUpdatePayload) Validate(r *http.Request) error {
 // @description Update the Git settings in a stack, e.g., RepositoryReferenceName and AutoUpdate
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/stacks/stack_update_git_redeploy.go
+++ b/api/http/handler/stacks/stack_update_git_redeploy.go
@@ -40,6 +40,7 @@ func (payload *stackGitRedployPayload) Validate(r *http.Request) error {
 // @description Pull and redeploy a stack via Git
 // @description **Access policy**: authenticated
 // @tags stacks
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/status/status_inspect_version.go
+++ b/api/http/handler/status/status_inspect_version.go
@@ -27,6 +27,7 @@ type githubData struct {
 // @summary Check for portainer updates
 // @description Check if portainer has an update available
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags status
 // @produce json

--- a/api/http/handler/tags/tag_create.go
+++ b/api/http/handler/tags/tag_create.go
@@ -28,6 +28,7 @@ func (payload *tagCreatePayload) Validate(r *http.Request) error {
 // @description Create a new tag.
 // @description **Access policy**: administrator
 // @tags tags
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/tags/tag_delete.go
+++ b/api/http/handler/tags/tag_delete.go
@@ -16,6 +16,7 @@ import (
 // @description Remove a tag.
 // @description **Access policy**: administrator
 // @tags tags
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "Tag identifier"
 // @success 204 "Success"

--- a/api/http/handler/tags/tag_list.go
+++ b/api/http/handler/tags/tag_list.go
@@ -12,6 +12,7 @@ import (
 // @description List tags.
 // @description **Access policy**: authenticated
 // @tags tags
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.Tag "Success"

--- a/api/http/handler/teammemberships/teammembership_create.go
+++ b/api/http/handler/teammemberships/teammembership_create.go
@@ -39,6 +39,7 @@ func (payload *teamMembershipCreatePayload) Validate(r *http.Request) error {
 // @description Create a new team memberships. Access is only available to administrators leaders of the associated team.
 // @description **Access policy**: administrator
 // @tags team_memberships
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/teammemberships/teammembership_delete.go
+++ b/api/http/handler/teammemberships/teammembership_delete.go
@@ -17,6 +17,7 @@ import (
 // @description Remove a team membership. Access is only available to administrators leaders of the associated team.
 // @description **Access policy**: administrator
 // @tags team_memberships
+// @security ApiKeyAuth
 // @security jwt
 // @param id path int true "TeamMembership identifier"
 // @success 204 "Success"

--- a/api/http/handler/teammemberships/teammembership_list.go
+++ b/api/http/handler/teammemberships/teammembership_list.go
@@ -14,6 +14,7 @@ import (
 // @description  List team memberships. Access is only available to administrators and team leaders.
 // @description **Access policy**: administrator
 // @tags team_memberships
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.TeamMembership "Success"

--- a/api/http/handler/teammemberships/teammembership_update.go
+++ b/api/http/handler/teammemberships/teammembership_update.go
@@ -40,6 +40,7 @@ func (payload *teamMembershipUpdatePayload) Validate(r *http.Request) error {
 // @description Update a team membership. Access is only available to administrators leaders of the associated team.
 // @description **Access policy**: administrator
 // @tags team_memberships
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/teams/team_create.go
+++ b/api/http/handler/teams/team_create.go
@@ -29,6 +29,7 @@ func (payload *teamCreatePayload) Validate(r *http.Request) error {
 // @description Create a new team.
 // @description **Access policy**: administrator
 // @tags teams
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/teams/team_delete.go
+++ b/api/http/handler/teams/team_delete.go
@@ -16,6 +16,7 @@ import (
 // @description Remove a team.
 // @description **Access policy**: administrator
 // @tags teams
+// @security ApiKeyAuth
 // @security jwt
 // @param id path string true "Team Id"
 // @success 204 "Success"

--- a/api/http/handler/teams/team_inspect.go
+++ b/api/http/handler/teams/team_inspect.go
@@ -17,6 +17,7 @@ import (
 // @description Retrieve details about a team. Access is only available for administrator and leaders of that team.
 // @description **Access policy**: administrator
 // @tags teams
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "Team identifier"

--- a/api/http/handler/teams/team_list.go
+++ b/api/http/handler/teams/team_list.go
@@ -13,6 +13,7 @@ import (
 // @description List teams. For non-administrator users, will only list the teams they are member of.
 // @description **Access policy**: restricted
 // @tags teams
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.Team "Success"

--- a/api/http/handler/teams/team_memberships.go
+++ b/api/http/handler/teams/team_memberships.go
@@ -16,6 +16,7 @@ import (
 // @description List team memberships. Access is only available to administrators and team leaders.
 // @description **Access policy**: restricted
 // @tags team_memberships
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path string true "Team Id"

--- a/api/http/handler/teams/team_update.go
+++ b/api/http/handler/teams/team_update.go
@@ -24,6 +24,7 @@ func (payload *teamUpdatePayload) Validate(r *http.Request) error {
 // @description Update a team.
 // @description **Access policy**: administrator
 // @tags teams
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/templates/template_file.go
+++ b/api/http/handler/templates/template_file.go
@@ -40,6 +40,7 @@ func (payload *filePayload) Validate(r *http.Request) error {
 // @description Get a template's file
 // @description **Access policy**: authenticated
 // @tags templates
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/templates/template_list.go
+++ b/api/http/handler/templates/template_list.go
@@ -19,6 +19,7 @@ type listResponse struct {
 // @description List available templates.
 // @description **Access policy**: authenticated
 // @tags templates
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {object} listResponse "Success"

--- a/api/http/handler/upload/upload_tls.go
+++ b/api/http/handler/upload/upload_tls.go
@@ -15,6 +15,7 @@ import (
 // @description Use this environment(endpoint) to upload TLS files.
 // @description **Access policy**: administrator
 // @tags upload
+// @security ApiKeyAuth
 // @security jwt
 // @accept multipart/form-data
 // @produce json

--- a/api/http/handler/users/user_create.go
+++ b/api/http/handler/users/user_create.go
@@ -39,6 +39,7 @@ func (payload *userCreatePayload) Validate(r *http.Request) error {
 // @description Only administrators can create an administrator user account.
 // @description **Access policy**: restricted
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/users/user_delete.go
+++ b/api/http/handler/users/user_delete.go
@@ -17,6 +17,7 @@ import (
 // @description Remove a user.
 // @description **Access policy**: administrator
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "User identifier"

--- a/api/http/handler/users/user_get_access_tokens.go
+++ b/api/http/handler/users/user_get_access_tokens.go
@@ -18,8 +18,8 @@ import (
 // @description Only the calling user or admin can retrieve api-keys.
 // @description **Access policy**: authenticated
 // @tags users
-// @security jwt
 // @security ApiKeyAuth
+// @security jwt
 // @produce json
 // @param id path int true "User identifier"
 // @success 200 {array} portainer.APIKey "Success"

--- a/api/http/handler/users/user_inspect.go
+++ b/api/http/handler/users/user_inspect.go
@@ -18,6 +18,7 @@ import (
 // @description User passwords are filtered out, and should never be accessible.
 // @description **Access policy**: authenticated
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "User identifier"

--- a/api/http/handler/users/user_list.go
+++ b/api/http/handler/users/user_list.go
@@ -15,6 +15,7 @@ import (
 // @description User passwords are filtered out, and should never be accessible.
 // @description **Access policy**: restricted
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @success 200 {array} portainer.User "Success"

--- a/api/http/handler/users/user_memberships.go
+++ b/api/http/handler/users/user_memberships.go
@@ -16,6 +16,7 @@ import (
 // @description Inspect a user memberships.
 // @description **Access policy**: restricted
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @produce json
 // @param id path int true "User identifier"

--- a/api/http/handler/users/user_remove_access_token.go
+++ b/api/http/handler/users/user_remove_access_token.go
@@ -19,8 +19,8 @@ import (
 // @description Only the calling user or admin can remove api-key.
 // @description **Access policy**: authenticated
 // @tags users
-// @security jwt
 // @security ApiKeyAuth
+// @security jwt
 // @param id path int true "User identifier"
 // @param keyID path int true "Api Key identifier"
 // @success 204 "Success"

--- a/api/http/handler/users/user_update.go
+++ b/api/http/handler/users/user_update.go
@@ -15,8 +15,8 @@ import (
 )
 
 type userUpdatePayload struct {
-	Username string `validate:"required" example:"bob"`
-	Password string `validate:"required" example:"cg9Wgky3"`
+	Username  string `validate:"required" example:"bob"`
+	Password  string `validate:"required" example:"cg9Wgky3"`
 	UserTheme string `example:"dark"`
 	// User role (1 for administrator account and 2 for regular account)
 	Role int `validate:"required" enums:"1,2" example:"2"`
@@ -38,6 +38,7 @@ func (payload *userUpdatePayload) Validate(r *http.Request) error {
 // @description Update user details. A regular user account can only update his details.
 // @description **Access policy**: authenticated
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/users/user_update_password.go
+++ b/api/http/handler/users/user_update_password.go
@@ -36,6 +36,7 @@ func (payload *userUpdatePasswordPayload) Validate(r *http.Request) error {
 // @description Update password for the specified user.
 // @description **Access policy**: authenticated
 // @tags users
+// @security ApiKeyAuth
 // @security jwt
 // @accept json
 // @produce json

--- a/api/http/handler/webhooks/webhook_create.go
+++ b/api/http/handler/webhooks/webhook_create.go
@@ -34,6 +34,7 @@ func (payload *webhookCreatePayload) Validate(r *http.Request) error {
 
 // @summary Create a webhook
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags webhooks
 // @accept json

--- a/api/http/handler/webhooks/webhook_delete.go
+++ b/api/http/handler/webhooks/webhook_delete.go
@@ -11,6 +11,7 @@ import (
 
 // @summary Delete a webhook
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags webhooks
 // @param id path int true "Webhook id"

--- a/api/http/handler/webhooks/webhook_list.go
+++ b/api/http/handler/webhooks/webhook_list.go
@@ -16,6 +16,7 @@ type webhookListOperationFilters struct {
 
 // @summary List webhooks
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags webhooks
 // @accept json

--- a/api/http/handler/websocket/attach.go
+++ b/api/http/handler/websocket/attach.go
@@ -19,6 +19,7 @@ import (
 // @description If the nodeName query parameter is not specified, the request will be upgraded to the websocket protocol and
 // @description an AttachStart operation HTTP request will be created and hijacked.
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags websocket
 // @accept json

--- a/api/http/handler/websocket/exec.go
+++ b/api/http/handler/websocket/exec.go
@@ -27,6 +27,7 @@ type execStartOperationPayload struct {
 // @description If the nodeName query parameter is not specified, the request will be upgraded to the websocket protocol and
 // @description an ExecStart operation HTTP request will be created and hijacked.
 // @**Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags websocket
 // @accept json

--- a/api/http/handler/websocket/pod.go
+++ b/api/http/handler/websocket/pod.go
@@ -20,6 +20,7 @@ import (
 // @summary Execute a websocket on pod
 // @description The request will be upgraded to the websocket protocol.
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags websocket
 // @accept json

--- a/api/http/handler/websocket/shell_pod.go
+++ b/api/http/handler/websocket/shell_pod.go
@@ -13,6 +13,7 @@ import (
 // @summary Execute a websocket on kubectl shell pod
 // @description The request will be upgraded to the websocket protocol. The request will proxy input from the client to the pod via long-lived websocket connection.
 // @description **Access policy**: authenticated
+// @security ApiKeyAuth
 // @security jwt
 // @tags websocket
 // @accept json


### PR DESCRIPTION
Closes [EE-2051](https://portainer.atlassian.net/browse/EE-2051).

# changelog
- `ApiKeyAuth` security scheme added to generated openapi spec
- All existing API endpoints that previously supported jwt auth in openapi spec now also support api-key based auth