### PR TITLE
chore(build): EE-2076: add a PORTAINER_FLAGS env var for yarn so I can default a password, and enable feature flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The feature request process is similar to the bug report process but has an extr
 
 ![portainer_featurerequest_workflow](https://user-images.githubusercontent.com/5485061/45727229-5ad39f00-bbf5-11e8-9550-16ba66c50615.png)
 
-## Build Portainer locally
+## Build and run Portainer locally
 
 Ensure you have Docker, Node.js, yarn, and Golang installed in the correct versions.
 
@@ -85,7 +85,7 @@ Install dependencies with yarn:
 $ yarn
 ```
 
-Then build and run the project:
+Then build and run the project in a Docker container:
 
 ```sh
 $ yarn start
@@ -94,6 +94,14 @@ $ yarn start
 Portainer can now be accessed at <https://localhost:9443>.
 
 Find more detailed steps at <https://documentation.portainer.io/contributing/instructions/>.
+
+### Build customisation
+
+You can customise the following settings:
+
+- `PORTAINER_DATA`: The host dir or volume name used by portainer (default is `/tmp/portainer`, which won't persist over reboots).
+- `PORTAINER_PROJECT`: The root dir of the repository - `${portainerRoot}/dist/` is imported into the container to get the build artifacts and external tools (defaults to `your current dir`).
+- `PORTAINER_FLAGS`: a list of flags to be used on the portainer commandline, in the form `--admin-password=<pwd hash> --feat fdo=false --feat open-amt` (default: `""`).
 
 ## Adding api docs
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -158,6 +158,7 @@ function shell_build_binary_azuredevops(platform, arch) {
 function shell_run_container() {
   const portainerData = '${PORTAINER_DATA:-/tmp/portainer}';
   const portainerRoot = process.env.PORTAINER_PROJECT ? process.env.PORTAINER_PROJECT : process.env.PWD;
+  const portainerFlags = '${PORTAINER_FLAGS:-}';
 
   return `
     docker rm -f portainer
@@ -172,7 +173,7 @@ function shell_run_container() {
       -v /tmp:/tmp \
       --name portainer \
       portainer/base \
-      /app/portainer
+      /app/portainer ${portainerFlags}
   `;
 }
 


### PR DESCRIPTION
documented the 2 existing env vars, and added a new one so I can add some defaults to every run (notably, my admin password, so I don' have to do the initialization steps)

https://portainer.atlassian.net/browse/EE-2076