### PR TITLE
feat(migrations): add more logging EE-2071

### DIFF
--- a/api/bolt/migrate_data.go
+++ b/api/bolt/migrate_data.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/portainer/portainer/api/cli"
 
@@ -22,7 +23,7 @@ func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			store.Rollback(true)
-			err = fmt.Errorf("%v", e)
+			err = fmt.Errorf("%v %v", e, string(debug.Stack()))
 		}
 	}()
 

--- a/api/bolt/migrate_data.go
+++ b/api/bolt/migrate_data.go
@@ -23,7 +23,7 @@ func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			store.Rollback(true)
-			err = fmt.Errorf("%v %v", e, string(debug.Stack()))
+			err = fmt.Errorf("%v %s", e, string(debug.Stack()))
 		}
 	}()
 

--- a/api/bolt/migrate_data.go
+++ b/api/bolt/migrate_data.go
@@ -23,6 +23,7 @@ func (store *Store) FailSafeMigrate(migrator *migrator.Migrator) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			store.Rollback(true)
+			// return error with cause and stacktrace (recover() doesn't include a stacktrace)
 			err = fmt.Errorf("%v %s", e, string(debug.Stack()))
 		}
 	}()

--- a/api/bolt/migrator/migrate_ce.go
+++ b/api/bolt/migrator/migrate_ce.go
@@ -237,6 +237,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 1.24.0
 	if m.currentDBVersion < 23 {
+		migrateLog.Info("Migrating to DB 23")
 		err := m.updateTagsToDBVersion23()
 		if err != nil {
 			return migrationError(err, "updateTagsToDBVersion23")
@@ -250,6 +251,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 1.24.1
 	if m.currentDBVersion < 24 {
+		migrateLog.Info("Migrating to DB 24")
 		err := m.updateSettingsToDB24()
 		if err != nil {
 			return migrationError(err, "updateSettingsToDB24")
@@ -258,6 +260,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.0.0
 	if m.currentDBVersion < 25 {
+		migrateLog.Info("Migrating to DB 25")
 		err := m.updateSettingsToDB25()
 		if err != nil {
 			return migrationError(err, "updateSettingsToDB25")
@@ -271,6 +274,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.1.0
 	if m.currentDBVersion < 26 {
+		migrateLog.Info("Migrating to DB 26")
 		err := m.updateEndpointSettingsToDB25()
 		if err != nil {
 			return migrationError(err, "updateEndpointSettingsToDB25")
@@ -279,6 +283,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.2.0
 	if m.currentDBVersion < 27 {
+		migrateLog.Info("Migrating to DB 27")
 		err := m.updateStackResourceControlToDB27()
 		if err != nil {
 			return migrationError(err, "updateStackResourceControlToDB27")
@@ -287,6 +292,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.6.0
 	if m.currentDBVersion < 30 {
+		migrateLog.Info("Migrating to DB 30")
 		err := m.migrateDBVersionToDB30()
 		if err != nil {
 			return migrationError(err, "migrateDBVersionToDB30")
@@ -303,6 +309,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.9.1, 2.9.2
 	if m.currentDBVersion < 33 {
+		migrateLog.Info("Migrating to DB 33")
 		err := m.migrateDBVersionToDB33()
 		if err != nil {
 			return migrationError(err, "migrateDBVersionToDB33")
@@ -311,6 +318,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.10
 	if m.currentDBVersion < 34 {
+		migrateLog.Info("Migrating to DB 34")
 		if err := m.migrateDBVersionToDB34(); err != nil {
 			return migrationError(err, "migrateDBVersionToDB34")
 		}
@@ -318,6 +326,7 @@ func (m *Migrator) Migrate() error {
 
 	// Portainer 2.9.3 (yep out of order, but 2.10 is EE only)
 	if m.currentDBVersion < 35 {
+		migrateLog.Info("Migrating to DB 35")
 		if err := m.migrateDBVersionToDB35(); err != nil {
 			return migrationError(err, "migrateDBVersionToDB35")
 		}

--- a/api/bolt/migrator/migrate_dbversion22.go
+++ b/api/bolt/migrator/migrate_dbversion22.go
@@ -1,8 +1,9 @@
 package migrator
 
-import "github.com/portainer/portainer/api"
+import portainer "github.com/portainer/portainer/api"
 
 func (m *Migrator) updateTagsToDBVersion23() error {
+	migrateLog.Info("Updating tags")
 	tags, err := m.tagService.Tags()
 	if err != nil {
 		return err
@@ -20,6 +21,7 @@ func (m *Migrator) updateTagsToDBVersion23() error {
 }
 
 func (m *Migrator) updateEndpointsAndEndpointGroupsToDBVersion23() error {
+	migrateLog.Info("Updating endpoints and endpoint groups")
 	tags, err := m.tagService.Tags()
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion23.go
+++ b/api/bolt/migrator/migrate_dbversion23.go
@@ -3,6 +3,8 @@ package migrator
 import portainer "github.com/portainer/portainer/api"
 
 func (m *Migrator) updateSettingsToDB24() error {
+	migrateLog.Info("Updating Settings")
+
 	legacySettings, err := m.settingsService.Settings()
 	if err != nil {
 		return err
@@ -16,6 +18,7 @@ func (m *Migrator) updateSettingsToDB24() error {
 }
 
 func (m *Migrator) updateStacksToDB24() error {
+	migrateLog.Info("Updating stacks")
 	stacks, err := m.stackService.Stacks()
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion24.go
+++ b/api/bolt/migrator/migrate_dbversion24.go
@@ -1,10 +1,12 @@
 package migrator
 
 import (
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 )
 
 func (m *Migrator) updateSettingsToDB25() error {
+	migrateLog.Info("Updating settings")
+
 	legacySettings, err := m.settingsService.Settings()
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion25.go
+++ b/api/bolt/migrator/migrate_dbversion25.go
@@ -5,6 +5,7 @@ import (
 )
 
 func (m *Migrator) updateEndpointSettingsToDB25() error {
+	migrateLog.Info("Updating endpoint settings")
 	settings, err := m.settingsService.Settings()
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion26.go
+++ b/api/bolt/migrator/migrate_dbversion26.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (m *Migrator) updateStackResourceControlToDB27() error {
+	migrateLog.Info("Updating stack resource controls")
 	resourceControls, err := m.resourceControlService.ResourceControls()
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion29.go
+++ b/api/bolt/migrator/migrate_dbversion29.go
@@ -1,6 +1,7 @@
 package migrator
 
 func (m *Migrator) migrateDBVersionToDB30() error {
+	migrateLog.Info("Updating legacy settings")
 	if err := m.migrateSettingsToDB30(); err != nil {
 		return err
 	}
@@ -13,6 +14,7 @@ func (m *Migrator) migrateSettingsToDB30() error {
 	if err != nil {
 		return err
 	}
+
 	legacySettings.OAuthSettings.SSO = false
 	legacySettings.OAuthSettings.LogoutURI = ""
 	return m.settingsService.UpdateSettings(legacySettings)

--- a/api/bolt/migrator/migrate_dbversion31.go
+++ b/api/bolt/migrator/migrate_dbversion31.go
@@ -11,24 +11,29 @@ import (
 )
 
 func (m *Migrator) migrateDBVersionToDB32() error {
+	migrateLog.Info("Updating registries")
 	err := m.updateRegistriesToDB32()
 	if err != nil {
 		return err
 	}
 
+	migrateLog.Info("Updating dockerhub")
 	err = m.updateDockerhubToDB32()
 	if err != nil {
 		return err
 	}
 
+	migrateLog.Info("Updating resource controls")
 	if err := m.updateVolumeResourceControlToDB32(); err != nil {
 		return err
 	}
 
+	migrateLog.Info("Updating kubeconfig expiry")
 	if err := m.kubeconfigExpiryToDB32(); err != nil {
 		return err
 	}
 
+	migrateLog.Info("Setting default helm repository url")
 	if err := m.helmRepositoryURLToDB32(); err != nil {
 		return err
 	}

--- a/api/bolt/migrator/migrate_dbversion32.go
+++ b/api/bolt/migrator/migrate_dbversion32.go
@@ -16,6 +16,7 @@ func (m *Migrator) migrateSettingsToDB33() error {
 		return err
 	}
 
+	migrateLog.Info("Setting default kubectl shell image")
 	settings.KubectlShellImage = portainer.DefaultKubectlShellImage
 	return m.settingsService.UpdateSettings(settings)
 }

--- a/api/bolt/migrator/migrate_dbversion33.go
+++ b/api/bolt/migrator/migrate_dbversion33.go
@@ -5,6 +5,7 @@ import (
 )
 
 func (m *Migrator) migrateDBVersionToDB34() error {
+	migrateLog.Info("Migrating stacks")
 	err := migrateStackEntryPoint(m.stackService)
 	if err != nil {
 		return err

--- a/api/bolt/migrator/migrate_dbversion34.go
+++ b/api/bolt/migrator/migrate_dbversion34.go
@@ -3,6 +3,7 @@ package migrator
 func (m *Migrator) migrateDBVersionToDB35() error {
 	// These should have been migrated already, but due to an earlier bug and a bunch of duplicates,
 	// calling it again will now fix the issue as the function has been repaired.
+	migrateLog.Info("Updating dockerhub registries")
 	err := m.updateDockerhubToDB32()
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes [EE-2071](https://portainer.atlassian.net/browse/EE-2071)

Specifically, for logging of upgrades from the latest 1.x release to the current release.
This should help in diagnosing any issues during migration should there be a failure during upgrade.

I've also added a stack trace to the error returned from failsafe_migrate should a panic occur.

I haven't created any test code for this because as you can imagine, generating old data structures to run migrate is rather difficult.  I don't actually know what the old data looks like in many cases