### PR TITLE
fix(environments): show kubeconfig env list in dark mode

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -459,6 +459,11 @@ a[ng-click] {
   border-radius: 4px;
 }
 
+:root[theme='dark'] .bootbox-checkbox-list,
+:root[theme='highcontrast'] .bootbox-checkbox-list {
+  background-color: var(--black-color);
+}
+
 .small-select {
   display: inline-block;
   padding: 0px 6px;


### PR DESCRIPTION
[EE-2097]

[EE-2097]: https://portainer.atlassian.net/browse/EE-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ