### PR TITLE
feat(git): EE-2026: let the remote git service decide what the defaul…

### DIFF
--- a/api/git/git.go
+++ b/api/git/git.go
@@ -68,6 +68,11 @@ func (c gitClient) download(ctx context.Context, dst string, opt cloneOptions) e
 }
 
 func (c gitClient) latestCommitID(ctx context.Context, opt fetchOptions) (string, error) {
+	if opt.referenceName == "" {
+		// allow the remote git to give us whatever is default.
+		return "", nil
+	}
+
 	remote := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		Name: "origin",
 		URLs: []string{opt.repositoryUrl},
@@ -153,7 +158,7 @@ func (service *Service) cloneRepository(destination string, options cloneOptions
 	return service.git.download(context.TODO(), destination, options)
 }
 
-// LatestCommitID returns SHA1 of the latest commit of the specified reference
+// LatestCommitID returns SHA1 of the latest commit of the specified reference (or an empty string if referenceName is "" - to allow git to use its defaults.)
 func (service *Service) LatestCommitID(repositoryURL, referenceName, username, password string) (string, error) {
 	options := fetchOptions{
 		repositoryUrl: repositoryURL,

--- a/api/http/handler/stacks/handler.go
+++ b/api/http/handler/stacks/handler.go
@@ -18,9 +18,10 @@ import (
 	"github.com/portainer/portainer/api/internal/authorization"
 	"github.com/portainer/portainer/api/scheduler"
 	"github.com/portainer/portainer/api/stacks"
+	"github.com/sirupsen/logrus"
 )
 
-const defaultGitReferenceName = "refs/heads/master"
+const defaultGitReferenceName = ""
 
 var (
 	errStackAlreadyExists     = errors.New("A stack already exists with this name")
@@ -45,7 +46,7 @@ type Handler struct {
 	StackDeployer       stacks.StackDeployer
 }
 
-func stackExistsError(name string) (*httperror.HandlerError){
+func stackExistsError(name string) *httperror.HandlerError {
 	msg := fmt.Sprintf("A stack with the normalized name '%s' already exists", name)
 	err := errors.New(msg)
 	return &httperror.HandlerError{StatusCode: http.StatusConflict, Message: msg, Err: err}
@@ -202,6 +203,8 @@ func (handler *Handler) clone(projectPath, repositoryURL, refName string, auth b
 		username = ""
 		password = ""
 	}
+
+	logrus.WithField("repositoryURL", repositoryURL).WithField("refName", refName).WithField("dst", projectPath).Info("clone repository")
 
 	err := handler.GitService.CloneRepository(projectPath, repositoryURL, refName, username, password)
 	if err != nil {


### PR DESCRIPTION
…t branch name is

This is a potential fix for #6002

@DimaSalakhov I was using this to let me use a non "master" default branch for an app template, but as i was going, realised this also may permit the gitops functions to default

@mariyam-portainer https://portainer.atlassian.net/browse/EE-2026 ?