### PR TITLE
wip: bootstrap encryption key

### DIFF
--- a/api/bolt/apikeyrepository/apikeyrepository.go
+++ b/api/bolt/apikeyrepository/apikeyrepository.go
@@ -42,7 +42,7 @@ func (service *Service) GetAPIKeysByUserID(userID portainer.UserID) ([]portainer
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var record portainer.APIKey
-			err := internal.UnmarshalObject(v, &record)
+			err := internal.UnmarshalObject(v, &record, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func (service *Service) GetAPIKeyByDigest(digest []byte) (*portainer.APIKey, err
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var record portainer.APIKey
-			err := internal.UnmarshalObject(v, &record)
+			err := internal.UnmarshalObject(v, &record, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ func (service *Service) CreateAPIKey(record *portainer.APIKey) error {
 		id, _ := bucket.NextSequence()
 		record.ID = portainer.APIKeyID(id)
 
-		data, err := internal.MarshalObject(record)
+		data, err := internal.MarshalObject(record, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func (service *Service) GetAPIKey(keyID portainer.APIKeyID) (*portainer.APIKey, 
 			return errors.ErrObjectNotFound
 		}
 
-		err := internal.UnmarshalObject(item, &apiKey)
+		err := internal.UnmarshalObject(item, &apiKey, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/customtemplate/customtemplate.go
+++ b/api/bolt/customtemplate/customtemplate.go
@@ -38,7 +38,7 @@ func (service *Service) CustomTemplates() ([]portainer.CustomTemplate, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var customTemplate portainer.CustomTemplate
-			err := internal.UnmarshalObjectWithJsoniter(v, &customTemplate)
+			err := internal.UnmarshalObjectWithJsoniter(v, &customTemplate, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -81,7 +81,7 @@ func (service *Service) CreateCustomTemplate(customTemplate *portainer.CustomTem
 	return service.connection.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(BucketName))
 
-		data, err := internal.MarshalObject(customTemplate)
+		data, err := internal.MarshalObject(customTemplate, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -73,7 +73,6 @@ type Store struct {
 	UserService               *user.Service
 	VersionService            *version.Service
 	WebhookService            *webhook.Service
-	EncryptionKey			  string
 }
 
 func (store *Store) version() (int, error) {
@@ -98,8 +97,7 @@ func NewStore(storePath string, fileService portainer.FileService, encryptionKey
 		path:        storePath,
 		fileService: fileService,
 		isNew:       true,
-		connection:  &internal.DbConnection{},
-		EncryptionKey: encryptionKey,
+		connection:  &internal.DbConnection{EncryptionKey: encryptionKey},
 	}
 }
 

--- a/api/bolt/datastore.go
+++ b/api/bolt/datastore.go
@@ -73,6 +73,7 @@ type Store struct {
 	UserService               *user.Service
 	VersionService            *version.Service
 	WebhookService            *webhook.Service
+	EncryptionKey			  string
 }
 
 func (store *Store) version() (int, error) {
@@ -92,12 +93,13 @@ func (store *Store) edition() portainer.SoftwareEdition {
 }
 
 // NewStore initializes a new Store and the associated services
-func NewStore(storePath string, fileService portainer.FileService) *Store {
+func NewStore(storePath string, fileService portainer.FileService, encryptionKey string) *Store {
 	return &Store{
 		path:        storePath,
 		fileService: fileService,
 		isNew:       true,
 		connection:  &internal.DbConnection{},
+		EncryptionKey: encryptionKey,
 	}
 }
 

--- a/api/bolt/edgegroup/edgegroup.go
+++ b/api/bolt/edgegroup/edgegroup.go
@@ -38,7 +38,7 @@ func (service *Service) EdgeGroups() ([]portainer.EdgeGroup, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var group portainer.EdgeGroup
-			err := internal.UnmarshalObjectWithJsoniter(v, &group)
+			err := internal.UnmarshalObjectWithJsoniter(v, &group, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func (service *Service) CreateEdgeGroup(group *portainer.EdgeGroup) error {
 		id, _ := bucket.NextSequence()
 		group.ID = portainer.EdgeGroupID(id)
 
-		data, err := internal.MarshalObject(group)
+		data, err := internal.MarshalObject(group, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/edgejob/edgejob.go
+++ b/api/bolt/edgejob/edgejob.go
@@ -38,7 +38,7 @@ func (service *Service) EdgeJobs() ([]portainer.EdgeJob, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var edgeJob portainer.EdgeJob
-			err := internal.UnmarshalObject(v, &edgeJob)
+			err := internal.UnmarshalObject(v, &edgeJob, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ func (service *Service) CreateEdgeJob(edgeJob *portainer.EdgeJob) error {
 			edgeJob.ID = portainer.EdgeJobID(id)
 		}
 
-		data, err := internal.MarshalObject(edgeJob)
+		data, err := internal.MarshalObject(edgeJob, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/edgestack/edgestack.go
+++ b/api/bolt/edgestack/edgestack.go
@@ -38,7 +38,7 @@ func (service *Service) EdgeStacks() ([]portainer.EdgeStack, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var stack portainer.EdgeStack
-			err := internal.UnmarshalObject(v, &stack)
+			err := internal.UnmarshalObject(v, &stack, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ func (service *Service) CreateEdgeStack(edgeStack *portainer.EdgeStack) error {
 			edgeStack.ID = portainer.EdgeStackID(id)
 		}
 
-		data, err := internal.MarshalObject(edgeStack)
+		data, err := internal.MarshalObject(edgeStack, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/endpoint/endpoint.go
+++ b/api/bolt/endpoint/endpoint.go
@@ -63,7 +63,7 @@ func (service *Service) Endpoints() ([]portainer.Endpoint, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var endpoint portainer.Endpoint
-			err := internal.UnmarshalObjectWithJsoniter(v, &endpoint)
+			err := internal.UnmarshalObjectWithJsoniter(v, &endpoint, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func (service *Service) CreateEndpoint(endpoint *portainer.Endpoint) error {
 			return err
 		}
 
-		data, err := internal.MarshalObject(endpoint)
+		data, err := internal.MarshalObject(endpoint, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func (service *Service) Synchronize(toCreate, toUpdate, toDelete []*portainer.En
 			id, _ := bucket.NextSequence()
 			endpoint.ID = portainer.EndpointID(id)
 
-			data, err := internal.MarshalObject(endpoint)
+			data, err := internal.MarshalObject(endpoint, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func (service *Service) Synchronize(toCreate, toUpdate, toDelete []*portainer.En
 		}
 
 		for _, endpoint := range toUpdate {
-			data, err := internal.MarshalObject(endpoint)
+			data, err := internal.MarshalObject(endpoint, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}

--- a/api/bolt/endpointgroup/endpointgroup.go
+++ b/api/bolt/endpointgroup/endpointgroup.go
@@ -64,7 +64,7 @@ func (service *Service) EndpointGroups() ([]portainer.EndpointGroup, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var endpointGroup portainer.EndpointGroup
-			err := internal.UnmarshalObject(v, &endpointGroup)
+			err := internal.UnmarshalObject(v, &endpointGroup, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -85,7 +85,7 @@ func (service *Service) CreateEndpointGroup(endpointGroup *portainer.EndpointGro
 		id, _ := bucket.NextSequence()
 		endpointGroup.ID = portainer.EndpointGroupID(id)
 
-		data, err := internal.MarshalObject(endpointGroup)
+		data, err := internal.MarshalObject(endpointGroup, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/endpointrelation/endpointrelation.go
+++ b/api/bolt/endpointrelation/endpointrelation.go
@@ -46,7 +46,7 @@ func (service *Service) CreateEndpointRelation(endpointRelation *portainer.Endpo
 	return service.connection.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(BucketName))
 
-		data, err := internal.MarshalObject(endpointRelation)
+		data, err := internal.MarshalObject(endpointRelation, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/extension/extension.go
+++ b/api/bolt/extension/extension.go
@@ -52,7 +52,7 @@ func (service *Service) Extensions() ([]portainer.Extension, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var extension portainer.Extension
-			err := internal.UnmarshalObject(v, &extension)
+			err := internal.UnmarshalObject(v, &extension, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -70,7 +70,7 @@ func (service *Service) Persist(extension *portainer.Extension) error {
 	return service.connection.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(BucketName))
 
-		data, err := internal.MarshalObject(extension)
+		data, err := internal.MarshalObject(extension, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/helmuserrepository/helmuserrepository.go
+++ b/api/bolt/helmuserrepository/helmuserrepository.go
@@ -39,7 +39,7 @@ func (service *Service) HelmUserRepositoryByUserID(userID portainer.UserID) ([]p
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var record portainer.HelmUserRepository
-			err := internal.UnmarshalObject(v, &record)
+			err := internal.UnmarshalObject(v, &record, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -63,7 +63,7 @@ func (service *Service) CreateHelmUserRepository(record *portainer.HelmUserRepos
 		id, _ := bucket.NextSequence()
 		record.ID = portainer.HelmUserRepositoryID(id)
 
-		data, err := internal.MarshalObject(record)
+		data, err := internal.MarshalObject(record, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/internal/db.go
+++ b/api/bolt/internal/db.go
@@ -8,6 +8,7 @@ import (
 )
 
 type DbConnection struct {
+	EncryptionKey string
 	*bolt.DB
 }
 
@@ -52,7 +53,7 @@ func GetObject(connection *DbConnection, bucketName string, key []byte, object i
 		return err
 	}
 
-	return UnmarshalObject(data, object)
+	return UnmarshalObject(data, object, connection.EncryptionKey)
 }
 
 // UpdateObject is a generic function used to update an object inside a bolt database.
@@ -60,7 +61,7 @@ func UpdateObject(connection *DbConnection, bucketName string, key []byte, objec
 	return connection.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(bucketName))
 
-		data, err := MarshalObject(object)
+		data, err := MarshalObject(object, connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/internal/json.go
+++ b/api/bolt/internal/json.go
@@ -65,7 +65,7 @@ func UnmarshalObjectWithJsoniter(data []byte, object interface{}, passphrase str
 // https://gist.github.com/atoponce/07d8d4c833873be2f68c34f9afc5a78a#symmetric-encryption
 
 func encrypt(plaintext []byte, passphrase string) (encrypted []byte, err error) {
-	logrus.Infof("encrypt")
+	logrus.Infof("encrypt: " + passphrase)
 	block, _ := aes.NewCipher([]byte(passphrase))
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {

--- a/api/bolt/internal/json.go
+++ b/api/bolt/internal/json.go
@@ -65,7 +65,6 @@ func UnmarshalObjectWithJsoniter(data []byte, object interface{}, passphrase str
 // https://gist.github.com/atoponce/07d8d4c833873be2f68c34f9afc5a78a#symmetric-encryption
 
 func encrypt(plaintext []byte, passphrase string) (encrypted []byte, err error) {
-	logrus.Infof("encrypt: " + passphrase)
 	block, _ := aes.NewCipher([]byte(passphrase))
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {

--- a/api/bolt/internal/json.go
+++ b/api/bolt/internal/json.go
@@ -1,25 +1,120 @@
 package internal
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/json"
+	"fmt"
+	"io"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
 )
 
+var encryptedStringTooShort = fmt.Errorf("encrypted string too short")
+
 // MarshalObject encodes an object to binary format
-func MarshalObject(object interface{}) ([]byte, error) {
-	return json.Marshal(object)
+func MarshalObject(object interface{}, passphrase string) ([]byte, error) {
+	data, err := json.Marshal(object)
+	if err != nil {
+		logrus.WithError(err).Errorf("failed marshaling object")
+		return data, err
+	}
+	if passphrase == "" {
+		logrus.Infof("no encryption passphrase")
+		return data, nil
+	}
+	return encrypt(data, passphrase)
 }
 
 // UnmarshalObject decodes an object from binary data
-func UnmarshalObject(data []byte, object interface{}) error {
+func UnmarshalObject(data []byte, object interface{}, passphrase string) error {
+	if passphrase == "" {
+		logrus.Infof("no encryption passphrase")
+	} else {
+		var err error
+		data, err = decrypt(data, passphrase)
+		if err != nil {
+			logrus.WithError(err).Errorf("failed decrypting object")
+			return err
+		}
+	}
 	return json.Unmarshal(data, object)
 }
 
 // UnmarshalObjectWithJsoniter decodes an object from binary data
 // using the jsoniter library. It is mainly used to accelerate environment(endpoint)
 // decoding at the moment.
-func UnmarshalObjectWithJsoniter(data []byte, object interface{}) error {
+func UnmarshalObjectWithJsoniter(data []byte, object interface{}, passphrase string) error {
+	if passphrase == "" {
+		logrus.Infof("no encryption passphrase")
+	} else {
+		var err error
+		data, err = decrypt(data, passphrase)
+		if err != nil {
+			logrus.WithError(err).Errorf("failed decrypting object")
+			return err
+		}
+	}
 	var jsoni = jsoniter.ConfigCompatibleWithStandardLibrary
 	return jsoni.Unmarshal(data, &object)
+}
+
+// mmm, don't have a KMS .... aes GCM seems the most likely from
+// https://gist.github.com/atoponce/07d8d4c833873be2f68c34f9afc5a78a#symmetric-encryption
+
+func encrypt(plaintext []byte, passphrase string) (encrypted []byte, err error) {
+	logrus.Infof("encrypt")
+	block, _ := aes.NewCipher([]byte(passphrase))
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return encrypted, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return encrypted, err
+	}
+	ciphertextByte := gcm.Seal(
+		nonce,
+		nonce,
+		plaintext,
+		nil)
+	return ciphertextByte, nil
+}
+
+// On error, return the original byte array - it might be unencrypted...
+func decrypt(encrypted []byte, passphrase string) (plaintextByte []byte, err error) {
+	passphraseByte := []byte(passphrase)
+	block, err := aes.NewCipher(passphraseByte)
+	if err != nil {
+		logrus.Infof("NOT decrypted")
+
+		return encrypted, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		logrus.Infof("NOT decrypted")
+
+		return encrypted, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(encrypted) < nonceSize {
+		logrus.Infof("NOT decrypted")
+
+		return encrypted, encryptedStringTooShort
+	}
+	nonce, ciphertextByteClean := encrypted[:nonceSize], encrypted[nonceSize:]
+	plaintextByte, err = gcm.Open(
+		nil,
+		nonce,
+		ciphertextByteClean,
+		nil)
+	if err != nil {
+		logrus.Infof("NOT decrypted")
+
+		return encrypted, err
+	}
+	logrus.Infof("decrypted")
+	return plaintextByte, err
 }

--- a/api/bolt/migrator/migrate_dbversion1.go
+++ b/api/bolt/migrator/migrate_dbversion1.go
@@ -2,7 +2,7 @@ package migrator
 
 import (
 	"github.com/boltdb/bolt"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt/internal"
 )
 
@@ -66,7 +66,7 @@ func (m *Migrator) retrieveLegacyResourceControls() ([]portainer.ResourceControl
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var resourceControl portainer.ResourceControl
-			err := internal.UnmarshalObject(v, &resourceControl)
+			err := internal.UnmarshalObject(v, &resourceControl, "") // TODO
 			if err != nil {
 				return err
 			}
@@ -78,7 +78,7 @@ func (m *Migrator) retrieveLegacyResourceControls() ([]portainer.ResourceControl
 		cursor = bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var resourceControl portainer.ResourceControl
-			err := internal.UnmarshalObject(v, &resourceControl)
+			err := internal.UnmarshalObject(v, &resourceControl, "") // TODO
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func (m *Migrator) retrieveLegacyResourceControls() ([]portainer.ResourceControl
 		cursor = bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var resourceControl portainer.ResourceControl
-			err := internal.UnmarshalObject(v, &resourceControl)
+			err := internal.UnmarshalObject(v, &resourceControl, "") // TODO
 			if err != nil {
 				return err
 			}

--- a/api/bolt/migrator/migrate_dbversion11.go
+++ b/api/bolt/migrator/migrate_dbversion11.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/boltdb/bolt"
-	"github.com/portainer/portainer/api"
+	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/bolt/internal"
 	"github.com/portainer/portainer/api/bolt/stack"
 )
@@ -113,7 +113,7 @@ func (m *Migrator) retrieveLegacyStacks() ([]legacyStack, error) {
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var stack legacyStack
-			err := internal.UnmarshalObject(v, &stack)
+			err := internal.UnmarshalObject(v, &stack, "") // TODO
 			if err != nil {
 				return err
 			}

--- a/api/bolt/registry/registry.go
+++ b/api/bolt/registry/registry.go
@@ -52,7 +52,7 @@ func (service *Service) Registries() ([]portainer.Registry, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var registry portainer.Registry
-			err := internal.UnmarshalObject(v, &registry)
+			err := internal.UnmarshalObject(v, &registry, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func (service *Service) CreateRegistry(registry *portainer.Registry) error {
 		id, _ := bucket.NextSequence()
 		registry.ID = portainer.RegistryID(id)
 
-		data, err := internal.MarshalObject(registry)
+		data, err := internal.MarshalObject(registry, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/resourcecontrol/resourcecontrol.go
+++ b/api/bolt/resourcecontrol/resourcecontrol.go
@@ -54,7 +54,7 @@ func (service *Service) ResourceControlByResourceIDAndType(resourceID string, re
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var rc portainer.ResourceControl
-			err := internal.UnmarshalObject(v, &rc)
+			err := internal.UnmarshalObject(v, &rc, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func (service *Service) ResourceControls() ([]portainer.ResourceControl, error) 
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var resourceControl portainer.ResourceControl
-			err := internal.UnmarshalObject(v, &resourceControl)
+			err := internal.UnmarshalObject(v, &resourceControl, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func (service *Service) CreateResourceControl(resourceControl *portainer.Resourc
 		id, _ := bucket.NextSequence()
 		resourceControl.ID = portainer.ResourceControlID(id)
 
-		data, err := internal.MarshalObject(resourceControl)
+		data, err := internal.MarshalObject(resourceControl, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/role/role.go
+++ b/api/bolt/role/role.go
@@ -52,7 +52,7 @@ func (service *Service) Roles() ([]portainer.Role, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var set portainer.Role
-			err := internal.UnmarshalObject(v, &set)
+			err := internal.UnmarshalObject(v, &set, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func (service *Service) CreateRole(role *portainer.Role) error {
 		id, _ := bucket.NextSequence()
 		role.ID = portainer.RoleID(id)
 
-		data, err := internal.MarshalObject(role)
+		data, err := internal.MarshalObject(role, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/schedule/schedule.go
+++ b/api/bolt/schedule/schedule.go
@@ -64,7 +64,7 @@ func (service *Service) Schedules() ([]portainer.Schedule, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var schedule portainer.Schedule
-			err := internal.UnmarshalObject(v, &schedule)
+			err := internal.UnmarshalObject(v, &schedule, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func (service *Service) SchedulesByJobType(jobType portainer.JobType) ([]portain
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var schedule portainer.Schedule
-			err := internal.UnmarshalObject(v, &schedule)
+			err := internal.UnmarshalObject(v, &schedule, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -114,7 +114,7 @@ func (service *Service) CreateSchedule(schedule *portainer.Schedule) error {
 			return err
 		}
 
-		data, err := internal.MarshalObject(schedule)
+		data, err := internal.MarshalObject(schedule, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/stack/stack.go
+++ b/api/bolt/stack/stack.go
@@ -56,7 +56,7 @@ func (service *Service) StackByName(name string) (*portainer.Stack, error) {
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var t portainer.Stack
-			err := internal.UnmarshalObject(v, &t)
+			err := internal.UnmarshalObject(v, &t, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func (service *Service) StacksByName(name string) ([]portainer.Stack, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var t portainer.Stack
-			err := internal.UnmarshalObject(v, &t)
+			err := internal.UnmarshalObject(v, &t, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -112,7 +112,7 @@ func (service *Service) Stacks() ([]portainer.Stack, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var stack portainer.Stack
-			err := internal.UnmarshalObject(v, &stack)
+			err := internal.UnmarshalObject(v, &stack, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -141,7 +141,7 @@ func (service *Service) CreateStack(stack *portainer.Stack) error {
 			return err
 		}
 
-		data, err := internal.MarshalObject(stack)
+		data, err := internal.MarshalObject(stack, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}
@@ -182,14 +182,14 @@ func (service *Service) StackByWebhookID(id string) (*portainer.Stack, error) {
 				} `json:"AutoUpdate"`
 			}
 
-			err := internal.UnmarshalObject(v, &t)
+			err := internal.UnmarshalObject(v, &t, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
 
 			if t.AutoUpdate != nil && strings.EqualFold(t.AutoUpdate.WebhookID, id) {
 				found = true
-				err := internal.UnmarshalObject(v, &stack)
+				err := internal.UnmarshalObject(v, &stack, service.connection.EncryptionKey)
 				if err != nil {
 					return err
 				}
@@ -219,7 +219,7 @@ func (service *Service) RefreshableStacks() ([]portainer.Stack, error) {
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			stack := portainer.Stack{}
-			err := internal.UnmarshalObject(v, &stack)
+			err := internal.UnmarshalObject(v, &stack, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}

--- a/api/bolt/tag/tag.go
+++ b/api/bolt/tag/tag.go
@@ -39,7 +39,7 @@ func (service *Service) Tags() ([]portainer.Tag, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var tag portainer.Tag
-			err := internal.UnmarshalObject(v, &tag)
+			err := internal.UnmarshalObject(v, &tag, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func (service *Service) CreateTag(tag *portainer.Tag) error {
 		id, _ := bucket.NextSequence()
 		tag.ID = portainer.TagID(id)
 
-		data, err := internal.MarshalObject(tag)
+		data, err := internal.MarshalObject(tag, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/team/team.go
+++ b/api/bolt/team/team.go
@@ -55,7 +55,7 @@ func (service *Service) TeamByName(name string) (*portainer.Team, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var t portainer.Team
-			err := internal.UnmarshalObject(v, &t)
+			err := internal.UnmarshalObject(v, &t, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func (service *Service) Teams() ([]portainer.Team, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var team portainer.Team
-			err := internal.UnmarshalObject(v, &team)
+			err := internal.UnmarshalObject(v, &team, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -113,7 +113,7 @@ func (service *Service) CreateTeam(team *portainer.Team) error {
 		id, _ := bucket.NextSequence()
 		team.ID = portainer.TeamID(id)
 
-		data, err := internal.MarshalObject(team)
+		data, err := internal.MarshalObject(team, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/teammembership/teammembership.go
+++ b/api/bolt/teammembership/teammembership.go
@@ -52,7 +52,7 @@ func (service *Service) TeamMemberships() ([]portainer.TeamMembership, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var membership portainer.TeamMembership
-			err := internal.UnmarshalObject(v, &membership)
+			err := internal.UnmarshalObject(v, &membership, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -75,7 +75,7 @@ func (service *Service) TeamMembershipsByUserID(userID portainer.UserID) ([]port
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var membership portainer.TeamMembership
-			err := internal.UnmarshalObject(v, &membership)
+			err := internal.UnmarshalObject(v, &membership, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ func (service *Service) TeamMembershipsByTeamID(teamID portainer.TeamID) ([]port
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var membership portainer.TeamMembership
-			err := internal.UnmarshalObject(v, &membership)
+			err := internal.UnmarshalObject(v, &membership, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -131,7 +131,7 @@ func (service *Service) CreateTeamMembership(membership *portainer.TeamMembershi
 		id, _ := bucket.NextSequence()
 		membership.ID = portainer.TeamMembershipID(id)
 
-		data, err := internal.MarshalObject(membership)
+		data, err := internal.MarshalObject(membership, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func (service *Service) DeleteTeamMembershipByUserID(userID portainer.UserID) er
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var membership portainer.TeamMembership
-			err := internal.UnmarshalObject(v, &membership)
+			err := internal.UnmarshalObject(v, &membership, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func (service *Service) DeleteTeamMembershipByTeamID(teamID portainer.TeamID) er
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var membership portainer.TeamMembership
-			err := internal.UnmarshalObject(v, &membership)
+			err := internal.UnmarshalObject(v, &membership, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}

--- a/api/bolt/teststore.go
+++ b/api/bolt/teststore.go
@@ -35,7 +35,7 @@ func NewTestStore(init bool) (*Store, func(), error) {
 		return nil, nil, err
 	}
 
-	store := NewStore(dataStorePath, fileService)
+	store := NewStore(dataStorePath, fileService, "") // TODO: encryption key
 	err = store.Open()
 	if err != nil {
 		return nil, nil, err

--- a/api/bolt/user/user.go
+++ b/api/bolt/user/user.go
@@ -57,7 +57,7 @@ func (service *Service) UserByUsername(username string) (*portainer.User, error)
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var u portainer.User
-			err := internal.UnmarshalObject(v, &u)
+			err := internal.UnmarshalObject(v, &u, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func (service *Service) Users() ([]portainer.User, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var user portainer.User
-			err := internal.UnmarshalObject(v, &user)
+			err := internal.UnmarshalObject(v, &user, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func (service *Service) UsersByRole(role portainer.UserRole) ([]portainer.User, 
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var user portainer.User
-			err := internal.UnmarshalObject(v, &user)
+			err := internal.UnmarshalObject(v, &user, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func (service *Service) CreateUser(user *portainer.User) error {
 		user.ID = portainer.UserID(id)
 		user.Username = strings.ToLower(user.Username)
 
-		data, err := internal.MarshalObject(user)
+		data, err := internal.MarshalObject(user, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/bolt/webhook/webhook.go
+++ b/api/bolt/webhook/webhook.go
@@ -40,7 +40,7 @@ func (service *Service) Webhooks() ([]portainer.Webhook, error) {
 		cursor := bucket.Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var webhook portainer.Webhook
-			err := internal.UnmarshalObject(v, &webhook)
+			err := internal.UnmarshalObject(v, &webhook, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func (service *Service) WebhookByResourceID(ID string) (*portainer.Webhook, erro
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var w portainer.Webhook
-			err := internal.UnmarshalObject(v, &w)
+			err := internal.UnmarshalObject(v, &w, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -107,7 +107,7 @@ func (service *Service) WebhookByToken(token string) (*portainer.Webhook, error)
 
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 			var w portainer.Webhook
-			err := internal.UnmarshalObject(v, &w)
+			err := internal.UnmarshalObject(v, &w, service.connection.EncryptionKey)
 			if err != nil {
 				return err
 			}
@@ -142,7 +142,7 @@ func (service *Service) CreateWebhook(webhook *portainer.Webhook) error {
 		id, _ := bucket.NextSequence()
 		webhook.ID = portainer.WebhookID(id)
 
-		data, err := internal.MarshalObject(webhook)
+		data, err := internal.MarshalObject(webhook, service.connection.EncryptionKey)
 		if err != nil {
 			return err
 		}

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -55,7 +55,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		Labels:                    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
 		Logo:                      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
 		Templates:                 kingpin.Flag("templates", "URL to the templates definitions.").Short('t').String(),
-		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption").Default(defaultSecretKeyName).String(),
+		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption and will be used as /run/secrets/<secret-key-name>.").Default(defaultSecretKeyName).String(),
 	}
 
 	kingpin.Parse()

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -55,6 +55,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		Labels:                    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
 		Logo:                      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
 		Templates:                 kingpin.Flag("templates", "URL to the templates definitions.").Short('t').String(),
+		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption").Default(defaultSecretKeyName).String(),
 	}
 
 	kingpin.Parse()

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -19,4 +19,5 @@ const (
 	defaultSSLCertPath         = "/certs/portainer.crt"
 	defaultSSLKeyPath          = "/certs/portainer.key"
 	defaultSnapshotInterval    = "5m"
+	defaultSecretKeyName       = "portainer"
 )

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -17,4 +17,5 @@ const (
 	defaultSSLCertPath         = "C:\\certs\\portainer.crt"
 	defaultSSLKeyPath          = "C:\\certs\\portainer.key"
 	defaultSnapshotInterval    = "5m"
+	defaultSecretKeyName       = "portainer"
 )

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -59,7 +59,7 @@ func initFileService(dataStorePath string) portainer.FileService {
 	return fileService
 }
 
-func initDataStore(dataStorePath string, encryptionKey string, rollback bool, fileService portainer.FileService, shutdownCtx context.Context) portainer.DataStore {
+func initDataStore(dataStorePath, encryptionKey string, rollback bool, fileService portainer.FileService, shutdownCtx context.Context) portainer.DataStore {
 	store := bolt.NewStore(dataStorePath, fileService, encryptionKey)
 	err := store.Open()
 	if err != nil {
@@ -471,7 +471,7 @@ func initSecretKey(fileName string) string {
 		return ""
 	}
 
-	return string(content)
+	return strings.TrimSuffix(string(content), "\n")
 }
 
 func buildServer(flags *portainer.CLIFlags) portainer.Server {

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -59,8 +59,8 @@ func initFileService(dataStorePath string) portainer.FileService {
 	return fileService
 }
 
-func initDataStore(dataStorePath string, rollback bool, fileService portainer.FileService, shutdownCtx context.Context) portainer.DataStore {
-	store := bolt.NewStore(dataStorePath, fileService)
+func initDataStore(dataStorePath string, encryptionKey string, rollback bool, fileService portainer.FileService, shutdownCtx context.Context) portainer.DataStore {
+	store := bolt.NewStore(dataStorePath, fileService, encryptionKey)
 	err := store.Open()
 	if err != nil {
 		log.Fatalf("failed opening store: %v", err)
@@ -483,7 +483,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 		log.Println("proceeding without encryption key")
 	}
 
-	dataStore := initDataStore(*flags.Data, *flags.Rollback, fileService, shutdownCtx)
+	dataStore := initDataStore(*flags.Data, encryptionKey, *flags.Rollback, fileService, shutdownCtx)
 
 	if err := dataStore.CheckCurrentEdition(); err != nil {
 		log.Fatal(err)

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -613,7 +613,7 @@ type (
 		ManagementConfiguration *RegistryManagementConfiguration `json:"ManagementConfiguration"`
 		Gitlab                  GitlabRegistryData               `json:"Gitlab"`
 		Quay                    QuayRegistryData                 `json:"Quay"`
-		Ecr                  	EcrData                       	 `json:"Ecr"`
+		Ecr                     EcrData                          `json:"Ecr"`
 		RegistryAccesses        RegistryAccesses                 `json:"RegistryAccesses"`
 
 		// Deprecated fields

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -95,6 +95,7 @@ type (
 		SSLKey                    *string
 		Rollback                  *bool
 		SnapshotInterval          *string
+		SecretKeyName             *string
 	}
 
 	// CustomTemplate represents a custom template


### PR DESCRIPTION
### Deploy on Docker standalone
- Generate AES 128 bit key
```
openssl enc -aes-128-cbc -k secret -P -md sha1
```
- Create `portainer_key` file and copy `key` in the file
- Mount `portainer_key` as `/run/secrets/portainer`and run
```
docker run -d -p 8000:8000 -p 9443:9443 --name portainer \
    --restart=always \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -v portainer_data:/data \
    -v "$(pwd)"/portainer_key:/run/secrets/portainer \
    portainerci/portainer:pr6201
```
### Deploy on Kubernetes

- Generate AES 128 bit key
```
openssl enc -aes-128-cbc -k secret -P -md sha1
```
- Create portainer key secret
```
kubectl create secret generic portainer-key --from-literal=secret=<AES-128-byte-key> -n portainer
```
- Mount key as a volume and deploy below yaml file
```
---
# Source: portainer/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: portainer
---
# Source: portainer/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: portainer-sa-clusteradmin
  namespace: portainer
  labels:
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
    app.kubernetes.io/version: "ce-latest-ee-2.10.0"
---
# Source: portainer/templates/pvc.yaml
kind: "PersistentVolumeClaim"
apiVersion: "v1"
metadata:
  name: portainer
  namespace: portainer  
  annotations:
    volume.alpha.kubernetes.io/storage-class: "generic"
  labels:
    io.portainer.kubernetes.application.stack: portainer
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
    app.kubernetes.io/version: "ce-latest-ee-2.10.0"
spec:
  accessModes:
    - "ReadWriteOnce"
  resources:
    requests:
      storage: "10Gi"
---
# Source: portainer/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: portainer
  labels:
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
    app.kubernetes.io/version: "ce-latest-ee-2.10.0"
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- kind: ServiceAccount
  namespace: portainer
  name: portainer-sa-clusteradmin
---
# Source: portainer/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: portainer
  namespace: portainer
  labels:
    io.portainer.kubernetes.application.stack: portainer
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
    app.kubernetes.io/version: "ce-latest-ee-2.10.0"
spec:
  type: NodePort
  ports:
    - port: 9000
      targetPort: 9000
      protocol: TCP
      name: http
      nodePort: 30777  
    - port: 9443
      targetPort: 9443
      protocol: TCP
      name: https
      nodePort: 30779      
    - port: 30776
      targetPort: 30776
      protocol: TCP
      name: edge
      nodePort: 30776
  selector:
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
---
# Source: portainer/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: portainer
  namespace: portainer
  labels:
    io.portainer.kubernetes.application.stack: portainer
    app.kubernetes.io/name: portainer
    app.kubernetes.io/instance: portainer
    app.kubernetes.io/version: "ce-latest-ee-2.10.0"
spec:
  replicas: 1
  strategy:
    type: "Recreate"
  selector:
    matchLabels:
      app.kubernetes.io/name: portainer
      app.kubernetes.io/instance: portainer
  template:
    metadata:
      labels:
        app.kubernetes.io/name: portainer
        app.kubernetes.io/instance: portainer
    spec:
      nodeSelector:
        {}
      serviceAccountName: portainer-sa-clusteradmin
      volumes:
        - name: "data"
          persistentVolumeClaim:
            claimName: portainer
        - name: "secrets"
          secret:
            secretName: portainer-key
            defaultMode: 0400
            items:
              - key: secret
                path: portainer
      containers:
        - name: portainer
          image: "portainerci/portainer:pr6201"
          imagePullPolicy: Always
          args:
          - '--tunnel-port=30776'          
          volumeMounts:
            - name: data
              mountPath: /data
            - name: secrets
              mountPath: /run/secrets
              readOnly: true            
          ports:
            - name: http
              containerPort: 9000
              protocol: TCP
            - name: https
              containerPort: 9443
              protocol: TCP                
            - name: tcp-edge
              containerPort: 8000
              protocol: TCP              
          livenessProbe:
            httpGet:
              path: /
              port: 9443
              scheme: HTTPS
          readinessProbe:
            httpGet:
              path: /
              port: 9443
              scheme: HTTPS        
          resources:
            {}
```