### PR TITLE
fix(api-keys): standard user should not be able to delete another users api keys EE-2126

### DIFF
--- a/api/apikey/apikey.go
+++ b/api/apikey/apikey.go
@@ -11,6 +11,7 @@ import (
 type APIKeyService interface {
 	HashRaw(rawKey string) []byte
 	GenerateApiKey(user portainer.User, description string) (string, *portainer.APIKey, error)
+	GetAPIKey(apiKeyID portainer.APIKeyID) (*portainer.APIKey, error)
 	GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error)
 	GetDigestUserAndKey(digest []byte) (portainer.User, portainer.APIKey, error)
 	UpdateAPIKey(apiKey *portainer.APIKey) error

--- a/api/apikey/service.go
+++ b/api/apikey/service.go
@@ -63,6 +63,11 @@ func (a *apiKeyService) GenerateApiKey(user portainer.User, description string) 
 	return prefixedAPIKey, apiKey, nil
 }
 
+// GetAPIKey returns an API key by its ID.
+func (a *apiKeyService) GetAPIKey(apiKeyID portainer.APIKeyID) (*portainer.APIKey, error) {
+	return a.apiKeyRepository.GetAPIKey(apiKeyID)
+}
+
 // GetAPIKeys returns all the API keys associated to a user.
 func (a *apiKeyService) GetAPIKeys(userID portainer.UserID) ([]portainer.APIKey, error) {
 	return a.apiKeyRepository.GetAPIKeysByUserID(userID)

--- a/api/apikey/service_test.go
+++ b/api/apikey/service_test.go
@@ -71,6 +71,26 @@ func Test_GenerateApiKey(t *testing.T) {
 	})
 }
 
+func Test_GetAPIKey(t *testing.T) {
+	is := assert.New(t)
+
+	store, teardown := bolt.MustNewTestStore(true)
+	defer teardown()
+
+	service := NewAPIKeyService(store.APIKeyRepository(), store.User())
+
+	t.Run("Successfully returns all API keys", func(t *testing.T) {
+		user := portainer.User{ID: 1}
+		_, apiKey, err := service.GenerateApiKey(user, "test-1")
+		is.NoError(err)
+
+		apiKeyGot, err := service.GetAPIKey(apiKey.ID)
+		is.NoError(err)
+
+		is.Equal(apiKey, apiKeyGot)
+	})
+}
+
 func Test_GetAPIKeys(t *testing.T) {
 	is := assert.New(t)
 

--- a/api/http/handler/users/user_remove_access_token.go
+++ b/api/http/handler/users/user_remove_access_token.go
@@ -56,6 +56,15 @@ func (handler *Handler) userRemoveAccessToken(w http.ResponseWriter, r *http.Req
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to find a user with the specified identifier inside the database", err}
 	}
 
+	// check if the key exists and the key belongs to the user
+	apiKey, err := handler.apiKeyService.GetAPIKey(portainer.APIKeyID(apiKeyID))
+	if err != nil {
+		return &httperror.HandlerError{http.StatusInternalServerError, "API Key not found", err}
+	}
+	if apiKey.UserID != portainer.UserID(userID) {
+		return &httperror.HandlerError{http.StatusForbidden, "Permission denied to remove api-key", httperrors.ErrUnauthorized}
+	}
+
 	err = handler.apiKeyService.DeleteAPIKey(portainer.APIKeyID(apiKeyID))
 	if err != nil {
 		if err == apikey.ErrInvalidAPIKey {


### PR DESCRIPTION
Closes [EE-2126](https://portainer.atlassian.net/browse/EE-2126).