### PR TITLE
feat(testing): db fixture support using `db-seed` feature flag

### DIFF
--- a/api/backup/import.go
+++ b/api/backup/import.go
@@ -1,0 +1,167 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/sirupsen/logrus"
+)
+
+// TODO: use portainer-cli to import
+
+func ImportJsonToDatabase(jsonFilePath, portainerDbPath string) error {
+	if _, err := os.Stat(jsonFilePath); err != nil {
+		return fmt.Errorf("import file not found: %s: %s", jsonFilePath, err)
+	}
+	// if _, err := os.Stat(portainerDbPath); err == nil {
+	// 	return fmt.Errorf("ERROR: database file already exists: %s", portainerDbPath)
+	// }
+
+	return importJson(jsonFilePath, portainerDbPath)
+}
+
+func importJson(jsonFilePath, portainerDbPath string) error {
+	backup := make(map[string]interface{})
+
+	s, err := ioutil.ReadFile(jsonFilePath)
+	if err != nil {
+		return err
+	}
+	//err = json.Unmarshal([]byte(s), &backup)
+	d := json.NewDecoder(bytes.NewReader(s))
+	d.UseNumber()
+	if err = d.Decode(&backup); err != nil {
+		return err
+	}
+
+	connection, err := bolt.Open(portainerDbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+
+	return connection.Update(func(tx *bolt.Tx) error {
+		for bucketName, v := range backup {
+			logrus.WithField("bucketName", bucketName).Printf("CreateBucketIfNotExists")
+			_, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+			if err != nil {
+				logrus.WithError(err).WithField("bucketName", bucketName).Printf("CreateBucketIfNotExists")
+				return err
+			}
+
+			bucket := tx.Bucket([]byte(bucketName))
+
+			switch bucketName {
+			case "version":
+				versions, ok := v.(map[string]interface{})
+				if !ok {
+					logrus.WithField("obj", v).Errorf("failed to cast %s map[string]interface{}", bucketName)
+				} else {
+					// TODO: test if those exist...
+					Put(bucketName, bucket, "DB_VERSION", versions["DB_VERSION"])
+					Put(bucketName, bucket, "INSTANCE_ID", versions["INSTANCE_ID"])
+				}
+			case "dockerhub":
+				Put(bucketName, bucket, "DOCKERHUB", v)
+
+				//obj, ok := v.([]map[string]string)
+				//if !ok {
+				//	logrus.WithField("obj", v).Errorf("failed to cast %s []map[string]interface{}", bucketName)
+				//} else {
+				//	Put(bucketName, bucket, "DOCKERHUB", obj)
+				//}
+			case "ssl":
+				obj, ok := v.(map[string]interface{})
+				if !ok {
+					logrus.WithField("obj", v).Errorf("failed to cast %s map[string]interface{}", bucketName)
+				} else {
+					Put(bucketName, bucket, "SSL", obj)
+				}
+			case "settings":
+				obj, ok := v.(map[string]interface{})
+				if !ok {
+					logrus.WithField("obj", v).Errorf("failed to cast %s map[string]interface{}", bucketName)
+				} else {
+					Put(bucketName, bucket, "SETTINGS", obj)
+				}
+			case "tunnel_server":
+				obj, ok := v.(map[string]interface{})
+				if !ok {
+					logrus.WithField("obj", v).Errorf("failed to cast %s map[string]interface{}", bucketName)
+				} else {
+					Put(bucketName, bucket, "INFO", obj)
+				}
+			default:
+				objlist, ok := v.([]interface{})
+				if !ok {
+					logrus.WithField("obj", v).Errorf("failed to cast %s []inferface{}", bucketName)
+				} else {
+					for _, ivalue := range objlist {
+						value, ok := ivalue.(map[string]interface{})
+						if !ok {
+							logrus.WithField("obj", value).Errorf("failed to cast %s map[string]interface{}", bucketName)
+						} else {
+							var ok bool
+							var id interface{}
+							switch bucketName {
+							case "endpoint_relations":
+								id, ok = value["EndpointID"] // TODO: need to make into an int, then do that weird stringification
+							default:
+								id, ok = value["Id"]
+							}
+							if !ok {
+								// endpoint_relations: EndpointID
+								logrus.WithField("obj", value).Errorf("No Id field:%s ", bucketName)
+								id = "error"
+							}
+							n, ok := id.(json.Number)
+							if !ok {
+								logrus.WithField("id", id).WithField("value", value).Errorf("failed to cast %s to int", bucketName)
+							} else {
+								key, err := n.Int64()
+								if err != nil {
+									logrus.WithError(err).WithField("id", id).WithField("key", key).WithField("value", value).Errorf("failed to cast %s to int", bucketName)
+								} else {
+									Put(bucketName, bucket, string(ConvertToKey(int(key))), value)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+// Honestly, I dunno why...
+func ConvertToKey(v int) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}
+
+func Put(bucketName string, bucket *bolt.Bucket, key string, object interface{}) error {
+	//logrus.WithField("bucketName", bucketName).WithField("key", key).WithField("object", object).Printf("Put")
+	data, err := json.Marshal(object)
+	if err != nil {
+		logrus.WithError(err).WithField("bucketName", bucketName).WithField("key", key).WithField("object", object).Errorf("failed marshal to json: (bucket: %s), (key: %s)", bucketName, key)
+
+		return err
+	}
+
+	err = bucket.Put([]byte(key), data)
+	if err != nil {
+		logrus.WithError(err).Errorf("failed Put into boltdb: (bucket: %s), (key: %s)", bucketName, key)
+
+		return err
+	}
+	return nil
+}

--- a/api/backup/import.go
+++ b/api/backup/import.go
@@ -14,6 +14,7 @@ import (
 )
 
 // TODO: use portainer-cli to import
+// source: https://github.com/portainer/portainer-cli/blob/master/util/database/import.go
 
 func ImportJsonToDatabase(jsonFilePath, portainerDbPath string) error {
 	if _, err := os.Stat(jsonFilePath); err != nil {

--- a/api/backup/import.go
+++ b/api/backup/import.go
@@ -41,7 +41,7 @@ func importJson(jsonFilePath, portainerDbPath string) error {
 		return err
 	}
 
-	connection, err := bolt.Open(portainerDbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	connection, err := bolt.Open(portainerDbPath, 0600, &bolt.Options{Timeout: 2 * time.Second})
 	if err != nil {
 		return err
 	}

--- a/api/backup/seed.go
+++ b/api/backup/seed.go
@@ -44,7 +44,7 @@ func writeMapToFile(mapData map[string]interface{}) (*os.File, error) {
 	// map (json export) -> string
 	jsonData, err := json.Marshal(mapData)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Unable to marshal map to json")
 	}
 
 	// write string (json) to temporary file
@@ -52,12 +52,10 @@ func writeMapToFile(mapData map[string]interface{}) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
+
 	_, err = file.Write(jsonData)
 	if err != nil {
-		file.Close()
-		return nil, err
-	}
-	if err = file.Close(); err != nil {
 		return nil, err
 	}
 

--- a/api/backup/seed.go
+++ b/api/backup/seed.go
@@ -7,14 +7,14 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	portainer "github.com/portainer/portainer/api"
-	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/database/boltdb"
+	"github.com/portainer/portainer/api/dataservices"
 	"github.com/portainer/portainer/api/http/offlinegate"
 )
 
 // SeedStore seeds the store with provided JSON/map data, will trigger system shutdown, when finished.
 // NOTE: THIS WILL COMPLETELY OVERWRITE THE CURRENT STORE - only use this for testing.
-func SeedStore(storeData map[string]interface{}, filestorePath string, gate *offlinegate.OfflineGate, datastore portainer.DataStore, shutdownTrigger context.CancelFunc) error {
+func SeedStore(storeData map[string]interface{}, filestorePath string, gate *offlinegate.OfflineGate, datastore dataservices.DataStore, shutdownTrigger context.CancelFunc) error {
 	// write storeData map to a temporary file
 	file, err := writeMapToFile(storeData)
 	if err != nil {
@@ -29,7 +29,7 @@ func SeedStore(storeData map[string]interface{}, filestorePath string, gate *off
 		return errors.Wrap(err, "Failed to stop db")
 	}
 
-	storePath := filepath.Join(filestorePath, bolt.DatabaseFileName)
+	storePath := filepath.Join(filestorePath, boltdb.DatabaseFileName)
 	// TODO: use portainer-cli to import
 	if err := ImportJsonToDatabase(file.Name(), storePath); err != nil {
 		return errors.Wrap(err, "Unable to import JSON data to database")

--- a/api/backup/seed.go
+++ b/api/backup/seed.go
@@ -1,0 +1,65 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/bolt"
+	"github.com/portainer/portainer/api/http/offlinegate"
+)
+
+// SeedStore seeds the store with provided JSON/map data, will trigger system shutdown, when finished.
+// NOTE: THIS WILL COMPLETELY OVERWRITE THE CURRENT STORE - only use this for testing.
+func SeedStore(storeData map[string]interface{}, filestorePath string, gate *offlinegate.OfflineGate, datastore portainer.DataStore, shutdownTrigger context.CancelFunc) error {
+	// write storeData map to a temporary file
+	file, err := writeMapToFile(storeData)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+
+	unlock := gate.Lock()
+	defer unlock()
+
+	if err := datastore.Close(); err != nil {
+		return errors.Wrap(err, "Failed to stop db")
+	}
+
+	storePath := filepath.Join(filestorePath, bolt.DatabaseFileName)
+	// TODO: use portainer-cli to import
+	if err := ImportJsonToDatabase(file.Name(), storePath); err != nil {
+		return errors.Wrap(err, "Unable to import JSON data to database")
+	}
+
+	shutdownTrigger()
+	return nil
+}
+
+// writeMapToFile writes a map to a temporary file and returns the file.
+func writeMapToFile(mapData map[string]interface{}) (*os.File, error) {
+	// map (json export) -> string
+	jsonData, err := json.Marshal(mapData)
+	if err != nil {
+		return nil, err
+	}
+
+	// write string (json) to temporary file
+	file, err := os.CreateTemp("", "temp-db-export-json")
+	if err != nil {
+		return nil, err
+	}
+	_, err = file.Write(jsonData)
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if err = file.Close(); err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/api/backup/seed_test.go
+++ b/api/backup/seed_test.go
@@ -1,0 +1,24 @@
+package backup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_writeMapToFile(t *testing.T) {
+	is := assert.New(t)
+
+	data := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	f, err := writeMapToFile(data)
+	defer os.Remove(f.Name())
+
+	is.NoError(err)
+
+	is.NotNil(f)
+}

--- a/api/cmd/portainer/main_test.go
+++ b/api/cmd/portainer/main_test.go
@@ -34,6 +34,8 @@ func Test_enableFeaturesFromFlags(t *testing.T) {
 		{"oPeN-amT", true},
 		{"fdo", true},
 		{"FDO", true},
+		{"Db-SeED", true},
+		{"DB-SEED", true},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s succeeds:%v", test.featureFlag, test.isSupported), func(t *testing.T) {

--- a/api/http/handler/backup/handler.go
+++ b/api/http/handler/backup/handler.go
@@ -39,6 +39,9 @@ func NewHandler(bouncer *security.RequestBouncer, dataStore dataservices.DataSto
 	h.Handle("/backup", bouncer.RestrictedAccess(adminAccess(httperror.LoggerHandler(h.backup)))).Methods(http.MethodPost)
 	h.Handle("/restore", bouncer.PublicAccess(httperror.LoggerHandler(h.restore))).Methods(http.MethodPost)
 
+	// db seed functionality is only available if specifically set as feature flag
+	h.Handle("/seed", bouncer.RestrictedAccess(adminAccess(httperror.LoggerHandler(h.seed)))).Methods(http.MethodPost)
+
 	return h
 }
 

--- a/api/http/handler/backup/seed.go
+++ b/api/http/handler/backup/seed.go
@@ -1,0 +1,59 @@
+package backup
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	httperror "github.com/portainer/libhttp/error"
+	"github.com/portainer/libhttp/request"
+	portainer "github.com/portainer/portainer/api"
+	operations "github.com/portainer/portainer/api/backup"
+)
+
+type seedPayload map[string]interface{}
+
+func (p *seedPayload) Validate(r *http.Request) error {
+	if p == nil {
+		return errors.New("Invalid seed data")
+	}
+	return nil
+}
+
+// @id Seed
+// @summary Overrwrites the current key-val database with provided payload - ONLY USE FOR TESTING.
+// @description  Overrwrites the current key-val database with provided payload - ONLY USE FOR TESTING; enable with `db-seed` feature flag.
+// @description **Access policy**: admin
+// @tags backup
+// @security ApiKeyAuth
+// @security jwt
+// @accept json
+// @param body body seedPayload true "The db seed payload - used to override current DB state"
+// @success 200 "Success"
+// @failure 400 "Invalid request"
+// @failure 404 "Not found"
+// @failure 500 "Server error"
+// @router /seed [post]
+func (h *Handler) seed(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	if !h.dataStore.Settings().IsFeatureFlagEnabled(portainer.FeatDBSeed) {
+		return &httperror.HandlerError{
+			StatusCode: http.StatusNotFound,
+			Message:    "Not found",
+			Err:        fmt.Errorf("feature flag '%s' not set", portainer.FeatDBSeed),
+		}
+	}
+
+	h.adminMonitor.Stop()
+	defer h.adminMonitor.Start()
+
+	var payload seedPayload
+	if err := request.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+		return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Invalid request payload", Err: err}
+	}
+
+	if err := operations.SeedStore(payload, h.filestorePath, h.gate, h.dataStore, h.shutdownTrigger); err != nil {
+		return &httperror.HandlerError{StatusCode: http.StatusInternalServerError, Message: "Failed to seed the store", Err: err}
+	}
+
+	return nil
+}

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -157,9 +157,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(r.URL.Path, "/api/auth"):
 		http.StripPrefix("/api", h.AuthHandler).ServeHTTP(w, r)
-	case strings.HasPrefix(r.URL.Path, "/api/backup"):
-		http.StripPrefix("/api", h.BackupHandler).ServeHTTP(w, r)
-	case strings.HasPrefix(r.URL.Path, "/api/restore"):
+	case strings.HasPrefix(r.URL.Path, "/api/backup") || strings.HasPrefix(r.URL.Path, "/api/restore") || strings.HasPrefix(r.URL.Path, "/api/seed"):
 		http.StripPrefix("/api", h.BackupHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/custom_templates"):
 		http.StripPrefix("/api", h.CustomTemplatesHandler).ServeHTTP(w, r)

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -107,6 +107,10 @@ func (server *Server) Start() error {
 	requestBouncer := security.NewRequestBouncer(server.DataStore, server.JWTService, server.APIKeyService)
 
 	rateLimiter := security.NewRateLimiter(10, 1*time.Second, 1*time.Hour)
+	if server.DataStore.Settings().IsFeatureFlagEnabled(portainer.FeatDBSeed) {
+		rateLimiter.Max = 1000
+		rateLimiter.BanDuration = 1 * time.Second
+	}
 	offlineGate := offlinegate.NewOfflineGate()
 
 	var authHandler = auth.NewHandler(requestBouncer, rateLimiter)

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1352,12 +1352,14 @@ const (
 const (
 	FeatOpenAMT Feature = "open-amt"
 	FeatFDO     Feature = "fdo"
+	FeatDBSeed  Feature = "db-seed"
 )
 
 // List of supported features
 var SupportedFeatureFlags = []Feature{
 	FeatOpenAMT,
 	FeatFDO,
+	FeatDBSeed,
 }
 
 const (


### PR DESCRIPTION
# Feature
Support to fixture/seed/overwrite DB - via API request.
This feature is very useful for testing. It is hidden behind the `db-seed` feature flag.
Setting the `db-seed` feature flag will enable a new route `/api/seed` (`POST`).

One can post a JSON to this route - which is a representation of a boltdb database. The JSON will overwrite the whole database and restart the server.

## Usage
- start Portainer with `--feat 'db-seed'` CLI arg to enable db fixturing/seeding functionality
- Post a JSON representation of BoltDB to the `/api/seed` route:
```sh
curl -X POST \
  -H "Authorization: Bearer $(curl 'http://localhost:9000/api/auth' -d'{"username":"admin","password":"admin123"}' --compressed | jq -r '.jwt')" \
  -d @'export.json' \
  http://localhost:9000/api/seed
```

<details>
  <summary>Example JSON payload - export.json</summary>
  
```json
{
  "endpoint_groups": [
    {
      "AuthorizedTeams": null,
      "AuthorizedUsers": null,
      "Description": "Unassigned environments",
      "Id": 1,
      "Labels": [],
      "Name": "Unassigned",
      "TagIds": [],
      "Tags": null,
      "TeamAccessPolicies": {},
      "UserAccessPolicies": {}
    }
  ],
  "endpoint_relations": [
    {
      "EdgeStacks": {},
      "EndpointID": 2
    }
  ],
  "endpoints": [
    {
      "AuthorizedTeams": null,
      "AuthorizedUsers": null,
      "AzureCredentials": {
        "ApplicationID": "",
        "AuthenticationKey": "",
        "TenantID": ""
      },
      "ComposeSyntaxMaxVersion": "",
      "EdgeCheckinInterval": 0,
      "EdgeKey": "",
      "Extensions": [],
      "GroupId": 1,
      "Id": 2,
      "Kubernetes": {
        "Configuration": {
          "IngressClasses": [],
          "RestrictDefaultNamespace": false,
          "StorageClasses": [],
          "UseLoadBalancer": false,
          "UseServerMetrics": false
        },
        "Snapshots": []
      },
      "LastCheckInDate": 0,
      "Name": "local-5",
      "PublicURL": "",
      "SecuritySettings": {
        "allowBindMountsForRegularUsers": true,
        "allowContainerCapabilitiesForRegularUsers": true,
        "allowDeviceMappingForRegularUsers": true,
        "allowHostNamespaceForRegularUsers": true,
        "allowPrivilegedModeForRegularUsers": true,
        "allowStackManagementForRegularUsers": true,
        "allowSysctlSettingForRegularUsers": true,
        "allowVolumeBrowserForRegularUsers": false,
        "enableHostManagementFeatures": false
      },
      "Snapshots": [
        {
          "DockerSnapshotRaw": {
            "Containers": [
              {
                "Command": "/bin/sh -c nginx-proxy",
                "Created": 1640047496,
                "HostConfig": {
                  "NetworkMode": "default"
                },
                "Id": "df3903b12dee6614469711c598a23f77075b706886db0bcde025a0501d31a235",
                "Image": "docker.io/rancher/k3d-proxy:5.0.3",
                "ImageID": "sha256:f404e470bcb437df92d68a0aad7f679bcdb6cb96c1374d5afd1bc390828a8e0a",
                "Labels": {
                  "app": "k3d",
                  "k3d.cluster": "test",
                  "k3d.cluster.imageVolume": "k3d-test-images",
                  "k3d.cluster.network": "k3d-test",
                  "k3d.cluster.network.external": "true",
                  "k3d.cluster.network.id": "fcb71d2ad525c16b90f84991fa1cfa0e9ca7dd7b6b0d79c03038f83dc6b55f8d",
                  "k3d.cluster.network.iprange": "172.31.0.0/16",
                  "k3d.cluster.token": "fKbnWhEwjbPhhgtVaZHj",
                  "k3d.cluster.url": "https://k3d-test-server-0:6443",
                  "k3d.role": "loadbalancer",
                  "k3d.version": "v5.0.3",
                  "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
                  "org.opencontainers.image.created": "2021-10-29T13:02:59Z",
                  "org.opencontainers.image.revision": "89d979287e0cff56ac8e87e5e0ecab9dc3b6ba87",
                  "org.opencontainers.image.source": "https://github.com/rancher/k3d.git",
                  "org.opencontainers.image.url": "https://github.com/rancher/k3d"
                },
                "Mounts": [
                  {
                    "Destination": "/k3d/images",
                    "Driver": "local",
                    "Mode": "z",
                    "Name": "k3d-test-images",
                    "Propagation": "",
                    "RW": true,
                    "Source": "/var/lib/docker/volumes/k3d-test-images/_data",
                    "Type": "volume"
                  }
                ],
                "Names": [
                  "/k3d-test-serverlb"
                ],
                "NetworkSettings": {
                  "Networks": {
                    "k3d-test": {
                      "Aliases": null,
                      "DriverOpts": null,
                      "EndpointID": "d051e319bcdbd640efe68ee815b65d33512e0da6bf830e0bd6d74f6b0796fb9d",
                      "Gateway": "172.31.0.1",
                      "GlobalIPv6Address": "",
                      "GlobalIPv6PrefixLen": 0,
                      "IPAMConfig": null,
                      "IPAddress": "172.31.0.3",
                      "IPPrefixLen": 16,
                      "IPv6Gateway": "",
                      "Links": null,
                      "MacAddress": "02:42:ac:1f:00:03",
                      "NetworkID": "fcb71d2ad525c16b90f84991fa1cfa0e9ca7dd7b6b0d79c03038f83dc6b55f8d"
                    }
                  }
                },
                "Ports": [
                  {
                    "IP": "0.0.0.0",
                    "PrivatePort": 6443,
                    "PublicPort": 6443,
                    "Type": "tcp"
                  },
                  {
                    "IP": "0.0.0.0",
                    "PrivatePort": 80,
                    "PublicPort": 8090,
                    "Type": "tcp"
                  },
                  {
                    "IP": "0.0.0.0",
                    "PrivatePort": 9001,
                    "PublicPort": 9001,
                    "Type": "tcp"
                  }
                ],
                "State": "running",
                "Status": "Up 2 hours"
              },
              {
                "Command": "/bin/k3d-entrypoint.sh server --tls-san 0.0.0.0",
                "Created": 1640047496,
                "HostConfig": {
                  "NetworkMode": "default"
                },
                "Id": "d4a4a80b86495b91d5b27acfc9180dd86e6a2d3f9546ca9de0e0a5474c97fab2",
                "Image": "docker.io/rancher/k3s:v1.21.5-k3s2",
                "ImageID": "sha256:5b293fa21d54ceb4d66958a99b814109816702bbd07851943484c1063f965c24",
                "Labels": {
                  "app": "k3d",
                  "k3d.cluster": "test",
                  "k3d.cluster.imageVolume": "k3d-test-images",
                  "k3d.cluster.network": "k3d-test",
                  "k3d.cluster.network.external": "true",
                  "k3d.cluster.network.id": "fcb71d2ad525c16b90f84991fa1cfa0e9ca7dd7b6b0d79c03038f83dc6b55f8d",
                  "k3d.cluster.network.iprange": "172.31.0.0/16",
                  "k3d.cluster.token": "fKbnWhEwjbPhhgtVaZHj",
                  "k3d.cluster.url": "https://k3d-test-server-0:6443",
                  "k3d.role": "server",
                  "k3d.server.api.host": "0.0.0.0",
                  "k3d.server.api.hostIP": "0.0.0.0",
                  "k3d.server.api.port": "6443",
                  "k3d.version": "v5.0.3",
                  "org.opencontainers.image.created": "2021-10-05T20:08:21Z",
                  "org.opencontainers.image.revision": "724ef700bab896ff252a75e2be996d5f4ff1b842",
                  "org.opencontainers.image.source": "https://github.com/k3s-io/k3s.git",
                  "org.opencontainers.image.url": "https://github.com/k3s-io/k3s"
                },
                "Mounts": [
                  {
                    "Destination": "/k3d/images",
                    "Driver": "local",
                    "Mode": "z",
                    "Name": "k3d-test-images",
                    "Propagation": "",
                    "RW": true,
                    "Source": "/var/lib/docker/volumes/k3d-test-images/_data",
                    "Type": "volume"
                  },
                  {
                    "Destination": "/var/lib/cni",
                    "Driver": "local",
                    "Mode": "",
                    "Name": "1a2aa4f2890dd84041b6ea15c623ecb04a8f31d0dba80e00c6c50bc69b9b6753",
                    "Propagation": "",
                    "RW": true,
                    "Source": "",
                    "Type": "volume"
                  },
                  {
                    "Destination": "/var/lib/kubelet",
                    "Driver": "local",
                    "Mode": "",
                    "Name": "b9c016d325d2aac0cc8501c8160b3482d0612183770544be2d13a71e30026653",
                    "Propagation": "",
                    "RW": true,
                    "Source": "",
                    "Type": "volume"
                  },
                  {
                    "Destination": "/var/lib/rancher/k3s",
                    "Driver": "local",
                    "Mode": "",
                    "Name": "9927f21458f270e6e425514ea9e97e6eb97c569c664e780dabdd8b01e4315e3f",
                    "Propagation": "",
                    "RW": true,
                    "Source": "",
                    "Type": "volume"
                  },
                  {
                    "Destination": "/var/log",
                    "Driver": "local",
                    "Mode": "",
                    "Name": "06888cd087fa4d13d5e5759993ea8c98acacf8c8f46a685f74e0a92d160d980e",
                    "Propagation": "",
                    "RW": true,
                    "Source": "",
                    "Type": "volume"
                  }
                ],
                "Names": [
                  "/k3d-test-server-0"
                ],
                "NetworkSettings": {
                  "Networks": {
                    "k3d-test": {
                      "Aliases": null,
                      "DriverOpts": null,
                      "EndpointID": "60e065b5956080ba1b3a26f4ca8c5835506cfc71c79bd3c80896861d712372e5",
                      "Gateway": "172.31.0.1",
                      "GlobalIPv6Address": "",
                      "GlobalIPv6PrefixLen": 0,
                      "IPAMConfig": null,
                      "IPAddress": "172.31.0.2",
                      "IPPrefixLen": 16,
                      "IPv6Gateway": "",
                      "Links": null,
                      "MacAddress": "02:42:ac:1f:00:02",
                      "NetworkID": "fcb71d2ad525c16b90f84991fa1cfa0e9ca7dd7b6b0d79c03038f83dc6b55f8d"
                    }
                  }
                },
                "Ports": [],
                "State": "running",
                "Status": "Up 2 hours"
              }
            ],
            "Images": [
              {
                "Containers": -1,
                "Created": 1639478377,
                "Id": "sha256:90f272b0a634ce3b8d2e9a7d4db6ff2e739539d119772340d489997a02ab29d6",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer-ee@sha256:1a38c5701dd6ac67882c0ac8f26e9cd6c2bed2095a416efe116bf949db86effe"
                ],
                "RepoTags": [
                  "portainerci/portainer-ee:pr464"
                ],
                "SharedSize": -1,
                "Size": 268604736,
                "VirtualSize": 268604736
              },
              {
                "Containers": -1,
                "Created": 1638755058,
                "Id": "sha256:b7334653b43945fdb6ce48019d090c63333a875ccd89c4216592b68892f13a2d",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer@sha256:97bf8b80f1cacdf00df574c92a1db2c13a5db32116c2b8b03ab6471f62f21b71"
                ],
                "RepoTags": [
                  "portainerci/portainer:pr6173"
                ],
                "SharedSize": -1,
                "Size": 259679929,
                "VirtualSize": 259679929
              },
              {
                "Containers": -1,
                "Created": 1638441509,
                "Id": "sha256:63eb316dc556e75d3dc0d7e225407639cb1f85f7edaf396b42cba134fd795442",
                "Labels": {
                  "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e"
                },
                "ParentId": "",
                "RepoDigests": [
                  "nginx@sha256:9522864dd661dcadfd9958f9e0de192a1fdda2c162a35668ab6ac42b465f0603"
                ],
                "RepoTags": [
                  "nginx:latest"
                ],
                "SharedSize": -1,
                "Size": 134476096,
                "VirtualSize": 134476096
              },
              {
                "Containers": -1,
                "Created": 1638432475,
                "Id": "sha256:723b4a01cd2a11283cbeb1aa41ff94c3e8f53dedaf27f4809e2a4f17edf079bb",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "debian@sha256:45ee40a844048c2f6d0105899c1a17733530b56d481612608aab5e2e4048570b"
                ],
                "RepoTags": [
                  "debian:latest"
                ],
                "SharedSize": -1,
                "Size": 117835823,
                "VirtualSize": 117835823
              },
              {
                "Containers": -1,
                "Created": 1638246252,
                "Id": "sha256:fb25b0637406695332c6df944263aa7753e9d6adcc730cdbca9c5882369b236b",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer@sha256:33d9c55be4bc2acdab1ffd91cf008e61ac1f7f46928213cf33251d78e44b2b56"
                ],
                "RepoTags": [
                  "portainerci/portainer:develop"
                ],
                "SharedSize": -1,
                "Size": 259130363,
                "VirtualSize": 259130363
              },
              {
                "Containers": -1,
                "Created": 1638246122,
                "Id": "sha256:c1a75c92bbcee276e4a145e85a1b97d999b40d7763431936375240220ee9abf0",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer-ee@sha256:220ab4d137303894e25cbe4e897b0ccd5d3cb3df56488439d0c40aaf78289251"
                ],
                "RepoTags": [
                  "portainerci/portainer-ee:develop"
                ],
                "SharedSize": -1,
                "Size": 267487967,
                "VirtualSize": 267487967
              },
              {
                "Containers": -1,
                "Created": 1638182215,
                "Id": "sha256:221b0971705acaa4b06d980faee2e6d83f3c2e5a93bbd7bf33317e0a3afc708f",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainer/portable-env@sha256:c912c3a634875ed30bfa99d153a8eb67b4bbecdc0af40275c4aa0d1e21d1a18d"
                ],
                "RepoTags": [
                  "portainer/portable-env:latest"
                ],
                "SharedSize": -1,
                "Size": 185162434,
                "VirtualSize": 185162434
              },
              {
                "Containers": -1,
                "Created": 1637980812,
                "Id": "sha256:27cb28d49bcd280fb53ffd8390f2ed36c6dccbef76addaadedbc3fb5b06697ac",
                "Labels": {
                  "org.opencontainers.image.created": "2021-11-27T02:39:58Z",
                  "org.opencontainers.image.revision": "3b5345eb57280340a606cde9a8eb9d25bfec03b1",
                  "org.opencontainers.image.title": "openapi-generator-cli",
                  "org.opencontainers.image.version": ""
                },
                "ParentId": "",
                "RepoDigests": [
                  "openapitools/openapi-generator-cli@sha256:de2483a027ea0cf823184611892da7ad3375c820dfcc64121ffe95271a330811"
                ],
                "RepoTags": [
                  "openapitools/openapi-generator-cli:latest"
                ],
                "SharedSize": -1,
                "Size": 316450668,
                "VirtualSize": 316450668
              },
              {
                "Containers": -1,
                "Created": 1637898092,
                "Id": "sha256:222d1719def12efbb4d8ad5c69a1c9d001cdf5330dbee4bf2257ac5eff6419fb",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer@sha256:ffedc4c9cd619aed62bb6a3859d0263ef9d6addf73ea00dcfb4976754f0140dc"
                ],
                "RepoTags": null,
                "SharedSize": -1,
                "Size": 258772199,
                "VirtualSize": 258772199
              },
              {
                "Containers": -1,
                "Created": 1637897968,
                "Id": "sha256:3030e9dfd65d80e8967b15a17737a5ab3737dc893cfcd5dbf4d6a43fc7d2224d",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer-ee@sha256:091b58e1e75c0b112b0b0118d4a12f116c32f4022cfc048500c1ab4445897bd1"
                ],
                "RepoTags": null,
                "SharedSize": -1,
                "Size": 267370540,
                "VirtualSize": 267370540
              },
              {
                "Containers": -1,
                "Created": 1637889953,
                "Id": "sha256:a7026a8fbdacc5a55688883b05a096871a139b95d336b3a1ed547e99f7df945b",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/portainer-ee@sha256:08ef3aa0d90e6ff04b9e8e9e70c2b77dc2c74ed7f0dcbdfa808dbd866354e8bb"
                ],
                "RepoTags": [
                  "portainerci/portainer-ee:pr1031"
                ],
                "SharedSize": -1,
                "Size": 267466369,
                "VirtualSize": 267466369
              },
              {
                "Containers": -1,
                "Created": 1637828997,
                "Id": "sha256:3e05ce39fa21364d3769217acd4d7799d8a64f43e2ba3f7318cef1ae2c5997cc",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainerci/agent@sha256:b95c7de621152a8b17b045e065476b9090f95e8693cefa33440eba5a4a0dde4a"
                ],
                "RepoTags": [
                  "portainerci/agent:develop"
                ],
                "SharedSize": -1,
                "Size": 145824564,
                "VirtualSize": 145824564
              },
              {
                "Containers": -1,
                "Created": 1637630577,
                "Id": "sha256:7fd7d6a5f4ea8b47127a1a48ef55fbcce24b302f992bd16343e1a7f61b4273bf",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "portainer/portable-env@sha256:69ec6eedfaba392fb16f4ca501135ec9633acd3a79f61ae8793de383880190ba"
                ],
                "RepoTags": null,
                "SharedSize": -1,
                "Size": 185159540,
                "VirtualSize": 185159540
              },
              {
                "Containers": -1,
                "Created": 1637155250,
                "Id": "sha256:2d25c92337fcd3c70efbc26a52483a67751d4b1e6967d66aed3bba9d0e11afab",
                "Labels": {
                  "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e"
                },
                "ParentId": "",
                "RepoDigests": [
                  "nginx@sha256:097c3a0913d7e3a5b01b6c685a60c03632fc7a2b50bc8e35bcaa3691d788226e"
                ],
                "RepoTags": null,
                "SharedSize": -1,
                "Size": 134476096,
                "VirtualSize": 134476096
              },
              {
                "Containers": -1,
                "Created": 1637029766,
                "Id": "sha256:54233d2e774329d97263c3acced8de3aada3a15bccca8029fc3d7a736f04a380",
                "Labels": {
                  "maintainer": "Hoppscotch (support@hoppscotch.io)",
                  "org.opencontainers.image.created": "2021-11-16T02:23:34.082Z",
                  "org.opencontainers.image.description": "👽 Open source API development ecosystem https://hoppscotch.io",
                  "org.opencontainers.image.licenses": "MIT",
                  "org.opencontainers.image.revision": "8096ed300db2c3789ebb493c6c2c6a3ec454fcbe",
                  "org.opencontainers.image.source": "https://github.com/hoppscotch/hoppscotch",
                  "org.opencontainers.image.title": "hoppscotch",
                  "org.opencontainers.image.url": "https://github.com/hoppscotch/hoppscotch",
                  "org.opencontainers.image.version": "main"
                },
                "ParentId": "",
                "RepoDigests": [
                  "hoppscotch/hoppscotch@sha256:e93422ca93674bdff02b74000c00d6d2ee0b0883b763d74de21fa922931cf7c1"
                ],
                "RepoTags": [
                  "hoppscotch/hoppscotch:latest"
                ],
                "SharedSize": -1,
                "Size": 791291674,
                "VirtualSize": 791291674
              },
              {
                "Containers": -1,
                "Created": 1636741000,
                "Id": "sha256:4bd5494cab630ed31508338889d5d02c98d6113f9d818584913b8ddd68dd1121",
                "Labels": {
                  "org.opencontainers.image.description": "A modern reverse-proxy",
                  "org.opencontainers.image.documentation": "https://docs.traefik.io",
                  "org.opencontainers.image.title": "Traefik",
                  "org.opencontainers.image.url": "https://traefik.io",
                  "org.opencontainers.image.vendor": "Traefik Labs",
                  "org.opencontainers.image.version": "v2.5.4"
                },
                "ParentId": "",
                "RepoDigests": [
                  "traefik@sha256:7d0228d19042f1286765f0ef56ceba8e4e8a08ae9b45b854179cf09a9c3de633"
                ],
                "RepoTags": [
                  "traefik:latest"
                ],
                "SharedSize": -1,
                "Size": 97983378,
                "VirtualSize": 97983378
              },
              {
                "Containers": -1,
                "Created": 1635512610,
                "Id": "sha256:bc6b529b8d6a46727a301b8a699c5ca8721de3f13f038addaca9c971c48d2cd8",
                "Labels": {
                  "org.opencontainers.image.created": "2021-10-29T13:03:10Z",
                  "org.opencontainers.image.revision": "89d979287e0cff56ac8e87e5e0ecab9dc3b6ba87",
                  "org.opencontainers.image.source": "https://github.com/rancher/k3d.git",
                  "org.opencontainers.image.url": "https://github.com/rancher/k3d"
                },
                "ParentId": "",
                "RepoDigests": [
                  "rancher/k3d-tools@sha256:1293e88e9c0a159df980ab73d4270da71c18a3a640931aec372bba6bb7c86ac7"
                ],
                "RepoTags": [
                  "rancher/k3d-tools:5.0.3"
                ],
                "SharedSize": -1,
                "Size": 17626182,
                "VirtualSize": 17626182
              },
              {
                "Containers": -1,
                "Created": 1635512582,
                "Id": "sha256:f404e470bcb437df92d68a0aad7f679bcdb6cb96c1374d5afd1bc390828a8e0a",
                "Labels": {
                  "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
                  "org.opencontainers.image.created": "2021-10-29T13:02:59Z",
                  "org.opencontainers.image.revision": "89d979287e0cff56ac8e87e5e0ecab9dc3b6ba87",
                  "org.opencontainers.image.source": "https://github.com/rancher/k3d.git",
                  "org.opencontainers.image.url": "https://github.com/rancher/k3d"
                },
                "ParentId": "",
                "RepoDigests": [
                  "rancher/k3d-proxy@sha256:fd01c7495d6a49bde201dff751c57c8c8ff7b3b067e72009da13c9fdc02b0436"
                ],
                "RepoTags": [
                  "rancher/k3d-proxy:5.0.3"
                ],
                "SharedSize": -1,
                "Size": 39734217,
                "VirtualSize": 39734217
              },
              {
                "Containers": -1,
                "Created": 1634013430,
                "Id": "sha256:215eb9aea4b0cc7f8e12e888b39b18833b5d36a6d736e480a4eff8b4beb4aa0c",
                "Labels": {
                  "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e"
                },
                "ParentId": "",
                "RepoDigests": [
                  "nginx@sha256:644a70516a26004c97d0d85c7fe1d0c3a67ea8ab7ddf4aff193d9f301670cf36"
                ],
                "RepoTags": null,
                "SharedSize": -1,
                "Size": 125991555,
                "VirtualSize": 125991555
              },
              {
                "Containers": -1,
                "Created": 1633464534,
                "Id": "sha256:5b293fa21d54ceb4d66958a99b814109816702bbd07851943484c1063f965c24",
                "Labels": {
                  "org.opencontainers.image.created": "2021-10-05T20:08:21Z",
                  "org.opencontainers.image.revision": "724ef700bab896ff252a75e2be996d5f4ff1b842",
                  "org.opencontainers.image.source": "https://github.com/k3s-io/k3s.git",
                  "org.opencontainers.image.url": "https://github.com/k3s-io/k3s"
                },
                "ParentId": "",
                "RepoDigests": [
                  "rancher/k3s@sha256:b0547fcaca94480a7c84ea177f1b60f70339db15f7b321e9b5c6d47380e491a4"
                ],
                "RepoTags": [
                  "rancher/k3s:v1.21.5-k3s2"
                ],
                "SharedSize": -1,
                "Size": 161486326,
                "VirtualSize": 161486326
              },
              {
                "Containers": -1,
                "Created": 1630532387,
                "Id": "sha256:de95d7c2e2d4cc59123fcfef69442499876a675bb59ab504b9ad78c5881fe85a",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "docker@sha256:1efacb06edbb1e2bd4a39dcc69883866c7dd98562a49fa97d7d29c2da1c3974f"
                ],
                "RepoTags": [
                  "docker:20.10.8-dind"
                ],
                "SharedSize": -1,
                "Size": 213201334,
                "VirtualSize": 213201334
              },
              {
                "Containers": -1,
                "Created": 1622158691,
                "Id": "sha256:d91b572b66b87f2084e0b8b4851cb1865746cf294b25fa813dbe117e7a22fff1",
                "Labels": {},
                "ParentId": "",
                "RepoDigests": [
                  "kindest/node@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
                ],
                "RepoTags": [
                  "kindest/node:v1.20.7"
                ],
                "SharedSize": -1,
                "Size": 1059944754,
                "VirtualSize": 1059944754
              },
              {
                "Containers": -1,
                "Created": 1583929668,
                "Id": "sha256:072fd1aacecbccbdea9862bbe1d655e7d089103cb1698b216f4bf06ccec31097",
                "Labels": null,
                "ParentId": "",
                "RepoDigests": [
                  "containous/whoami@sha256:7d6a3c8f91470a23ef380320609ee6e69ac68d20bc804f3a1c6065fb56cfa34e"
                ],
                "RepoTags": [
                  "containous/whoami:latest"
                ],
                "SharedSize": -1,
                "Size": 7098914,
                "VirtualSize": 7098914
              }
            ],
            "Info": {
              "Architecture": "aarch64",
              "BridgeNfIp6tables": true,
              "BridgeNfIptables": true,
              "CPUSet": true,
              "CPUShares": true,
              "CgroupDriver": "cgroupfs",
              "CgroupVersion": "2",
              "ContainerdCommit": {
                "Expected": "7b11cfaabd73bb80907dd23182b9347b4245eb5d",
                "ID": "7b11cfaabd73bb80907dd23182b9347b4245eb5d"
              },
              "Containers": 2,
              "ContainersPaused": 0,
              "ContainersRunning": 2,
              "ContainersStopped": 0,
              "CpuCfsPeriod": true,
              "CpuCfsQuota": true,
              "Debug": false,
              "DefaultRuntime": "runc",
              "DockerRootDir": "/var/lib/docker",
              "Driver": "overlay2",
              "DriverStatus": [
                [
                  "Backing Filesystem",
                  "extfs"
                ],
                [
                  "Supports d_type",
                  "true"
                ],
                [
                  "Native Overlay Diff",
                  "true"
                ],
                [
                  "userxattr",
                  "false"
                ]
              ],
              "ExperimentalBuild": false,
              "GenericResources": null,
              "HttpProxy": "http.docker.internal:3128",
              "HttpsProxy": "http.docker.internal:3128",
              "ID": "2Y4M:2CV7:R4IF:SDAU:ICCE:RBG6:V73N:UFZZ:5RWE:DY5F:TSLO:7UJQ",
              "IPv4Forwarding": true,
              "Images": 23,
              "IndexServerAddress": "https://index.docker.io/v1/",
              "InitBinary": "docker-init",
              "InitCommit": {
                "Expected": "de40ad0",
                "ID": "de40ad0"
              },
              "Isolation": "",
              "KernelMemory": false,
              "KernelMemoryTCP": false,
              "KernelVersion": "5.10.76-linuxkit",
              "Labels": [],
              "LiveRestoreEnabled": false,
              "LoggingDriver": "json-file",
              "MemTotal": 2085158912,
              "MemoryLimit": true,
              "NCPU": 5,
              "NEventsListener": 3,
              "NFd": 63,
              "NGoroutines": 58,
              "Name": "docker-desktop",
              "NoProxy": "",
              "OSType": "linux",
              "OSVersion": "",
              "OomKillDisable": false,
              "OperatingSystem": "Docker Desktop",
              "PidsLimit": true,
              "Plugins": {
                "Authorization": null,
                "Log": [
                  "awslogs",
                  "fluentd",
                  "gcplogs",
                  "gelf",
                  "journald",
                  "json-file",
                  "local",
                  "logentries",
                  "splunk",
                  "syslog"
                ],
                "Network": [
                  "bridge",
                  "host",
                  "ipvlan",
                  "macvlan",
                  "null",
                  "overlay"
                ],
                "Volume": [
                  "local"
                ]
              },
              "RegistryConfig": {
                "AllowNondistributableArtifactsCIDRs": [],
                "AllowNondistributableArtifactsHostnames": [],
                "IndexConfigs": {
                  "docker.io": {
                    "Mirrors": [],
                    "Name": "docker.io",
                    "Official": true,
                    "Secure": true
                  }
                },
                "InsecureRegistryCIDRs": [
                  "127.0.0.0/8"
                ],
                "Mirrors": []
              },
              "RuncCommit": {
                "Expected": "v1.0.2-0-g52b36a2",
                "ID": "v1.0.2-0-g52b36a2"
              },
              "Runtimes": {
                "io.containerd.runc.v2": {
                  "path": "runc"
                },
                "io.containerd.runtime.v1.linux": {
                  "path": "runc"
                },
                "runc": {
                  "path": "runc"
                }
              },
              "SecurityOptions": [
                "name=seccomp,profile=default",
                "name=cgroupns"
              ],
              "ServerVersion": "20.10.11",
              "SwapLimit": true,
              "Swarm": {
                "ControlAvailable": false,
                "Error": "",
                "LocalNodeState": "inactive",
                "NodeAddr": "",
                "NodeID": "",
                "RemoteManagers": null
              },
              "SystemTime": "2021-12-21T03:12:02.748323336Z",
              "Warnings": null
            },
            "Networks": [
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:18.36916292Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.27.0.1",
                      "Subnet": "172.27.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "1e2b99668501e323bba6dab38bf51e037b0449771aae412c9558b5dce9dd9878",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_3abecf06-cce8-40db-afe7-f4c51e8cf694",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_3abecf06-cce8-40db-afe7-f4c51e8cf694_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:49.233140212Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "192.168.96.1",
                      "Subnet": "192.168.96.0/20"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "54dfde23723e27fd04726c5161cc6ae7074188498b2535d240b1775dda13a46c",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_483c6551-6af3-40a2-880a-15a3482d62d4",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_483c6551-6af3-40a2-880a-15a3482d62d4_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:48.589207754Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "192.168.80.1",
                      "Subnet": "192.168.80.0/20"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "77ee2418a537d2ff019bbd5286fdb5872752550c5a371bf8aa88c02870b3abbb",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_ca85b5fe-f432-461b-8c35-ba7745547ec8",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_ca85b5fe-f432-461b-8c35-ba7745547ec8_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-29T02:49:13.257832469Z",
                "Driver": "bridge",
                "EnableIPv6": true,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.21.0.1",
                      "Subnet": "172.21.0.0/16"
                    },
                    {
                      "Gateway": "fc00:f853:ccd:e793::1",
                      "Subnet": "fc00:f853:ccd:e793::/64"
                    }
                  ],
                  "Driver": "default",
                  "Options": {}
                },
                "Id": "b367f56a9ff61120ec4f591f928d8ead2b4ecee282223732441d9cf1ca164828",
                "Ingress": false,
                "Internal": false,
                "Labels": {},
                "Name": "kind",
                "Options": {
                  "com.docker.network.bridge.enable_ip_masquerade": "true",
                  "com.docker.network.driver.mtu": "1500"
                },
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:53:40.177864416Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "192.168.112.1",
                      "Subnet": "192.168.112.0/20"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "dc7609f41c164aacde1bd20116e8ac170eb99945fce1d97b403cf50fb545b1ac",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_c2066b40-27eb-491b-8acf-62db5fb798c2",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_c2066b40-27eb-491b-8acf-62db5fb798c2_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-12-21T00:44:51.608678625Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.17.0.1",
                      "Subnet": "172.17.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "ce6fac96f0d5b254e1a82fef151241c9182908125f65570df2c81eb02be5fff2",
                "Ingress": false,
                "Internal": false,
                "Labels": {},
                "Name": "bridge",
                "Options": {
                  "com.docker.network.bridge.default_bridge": "true",
                  "com.docker.network.bridge.enable_icc": "true",
                  "com.docker.network.bridge.enable_ip_masquerade": "true",
                  "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
                  "com.docker.network.bridge.name": "docker0",
                  "com.docker.network.driver.mtu": "1500"
                },
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-29T01:13:40.780172052Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.18.0.1",
                      "Subnet": "172.18.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "5a2fecb7cc24c708a10a34b98b5c4835c18a887c5adff2d0c29563291018c731",
                "Ingress": false,
                "Internal": false,
                "Labels": {},
                "Name": "docker_gwbridge",
                "Options": {
                  "com.docker.network.bridge.enable_icc": "false",
                  "com.docker.network.bridge.enable_ip_masquerade": "true",
                  "com.docker.network.bridge.name": "docker_gwbridge"
                },
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-05T10:57:25.912039468Z",
                "Driver": "host",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "60d11e981c76aa86083ed1a3f209c92ed9a104653ddfa3fd5d4de623b6317a59",
                "Ingress": false,
                "Internal": false,
                "Labels": {},
                "Name": "host",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:46:43.273633335Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.26.0.1",
                      "Subnet": "172.26.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "97173a717756e3eecc3ca897c1d6675560e1083e72bb9fc7e55c5075a68ec4e4",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_94fbe6d5-9aea-418f-862f-c49e2262e03a",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_94fbe6d5-9aea-418f-862f-c49e2262e03a_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-05T10:57:25.901653302Z",
                "Driver": "null",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "a3f7e8fc920e5f990f0b00e78a6baadd176e89adbac06b7635e9973c1be7e636",
                "Ingress": false,
                "Internal": false,
                "Labels": {},
                "Name": "none",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:30.781571968Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.29.0.1",
                      "Subnet": "172.29.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "d2b295626e60286a71f3826e6d588a449ce753b58d104159dc1ec995cf7b147a",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_6c33b546-2fa2-47f8-bae1-f6ba19cd4052",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_6c33b546-2fa2-47f8-bae1-f6ba19cd4052_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:31.40948301Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.30.0.1",
                      "Subnet": "172.30.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "c1388e4674f96c60f137db63e81fe0654cf5319ef2aecb5a9b85d2c5fe404369",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_d1e98f1f-636e-451f-b7c2-6a4935ed76bb",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_d1e98f1f-636e-451f-b7c2-6a4935ed76bb_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:46:42.691980959Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.25.0.1",
                      "Subnet": "172.25.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "09671aca7ed90e8a19ff9add3db27feebeb7ae62417b611a01bdac52ef9d87a6",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_16bebfe4-d53d-4dc2-aa07-eee22bc3b6bc",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_16bebfe4-d53d-4dc2-aa07-eee22bc3b6bc_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:47:18.967196421Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.28.0.1",
                      "Subnet": "172.28.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "a357ebd098df24a49512ec4ad95b061b99864a447ffb737a9f46f9142b40b091",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_b654f5d4-dd86-4994-b303-e5c66e3032cc",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_b654f5d4-dd86-4994-b303-e5c66e3032cc_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-28T22:53:39.562613055Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "192.168.48.1",
                      "Subnet": "192.168.48.0/20"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "f4b2168a50cb1c9a790d42d35ba30970a4e040d98498c639b65833d51043e676",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "com.docker.compose.network": "default",
                  "com.docker.compose.project": "test_stack_cd83faaa-a742-451b-8f7a-6dd3329ef280",
                  "com.docker.compose.version": "2.0.0"
                },
                "Name": "test_stack_cd83faaa-a742-451b-8f7a-6dd3329ef280_default",
                "Options": {},
                "Scope": "local"
              },
              {
                "Attachable": false,
                "ConfigFrom": {
                  "Network": ""
                },
                "ConfigOnly": false,
                "Containers": {},
                "Created": "2021-11-30T23:35:29.547185759Z",
                "Driver": "bridge",
                "EnableIPv6": false,
                "IPAM": {
                  "Config": [
                    {
                      "Gateway": "172.31.0.1",
                      "Subnet": "172.31.0.0/16"
                    }
                  ],
                  "Driver": "default",
                  "Options": null
                },
                "Id": "fcb71d2ad525c16b90f84991fa1cfa0e9ca7dd7b6b0d79c03038f83dc6b55f8d",
                "Ingress": false,
                "Internal": false,
                "Labels": {
                  "app": "k3d"
                },
                "Name": "k3d-test",
                "Options": {
                  "com.docker.network.bridge.enable_ip_masquerade": "true"
                },
                "Scope": "local"
              }
            ],
            "Version": {
              "ApiVersion": "1.41",
              "Arch": "arm64",
              "BuildTime": "2021-11-18T00:34:44.000000000+00:00",
              "Components": [
                {
                  "Details": {
                    "ApiVersion": "1.41",
                    "Arch": "arm64",
                    "BuildTime": "2021-11-18T00:34:44.000000000+00:00",
                    "Experimental": "false",
                    "GitCommit": "847da18",
                    "GoVersion": "go1.16.9",
                    "KernelVersion": "5.10.76-linuxkit",
                    "MinAPIVersion": "1.12",
                    "Os": "linux"
                  },
                  "Name": "Engine",
                  "Version": "20.10.11"
                },
                {
                  "Details": {
                    "GitCommit": "7b11cfaabd73bb80907dd23182b9347b4245eb5d"
                  },
                  "Name": "containerd",
                  "Version": "1.4.12"
                },
                {
                  "Details": {
                    "GitCommit": "v1.0.2-0-g52b36a2"
                  },
                  "Name": "runc",
                  "Version": "1.0.2"
                },
                {
                  "Details": {
                    "GitCommit": "de40ad0"
                  },
                  "Name": "docker-init",
                  "Version": "0.19.0"
                }
              ],
              "GitCommit": "847da18",
              "GoVersion": "go1.16.9",
              "KernelVersion": "5.10.76-linuxkit",
              "MinAPIVersion": "1.12",
              "Os": "linux",
              "Platform": {
                "Name": "Docker Engine - Community"
              },
              "Version": "20.10.11"
            },
            "Volumes": {
              "Volumes": [
                {
                  "CreatedAt": "2021-12-01T20:44:21Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/b8e9393bce1390449939bc1ce2168d48af576c7bef6039d901abb37d91382009/_data",
                  "Name": "b8e9393bce1390449939bc1ce2168d48af576c7bef6039d901abb37d91382009",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:04:44Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/dbbe3778c76820ab30cd6e9820ff20bad193b66f6d6bd4f60c5ed45ed83b76cf/_data",
                  "Name": "dbbe3778c76820ab30cd6e9820ff20bad193b66f6d6bd4f60c5ed45ed83b76cf",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-02T01:44:22Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/19f69d9b5ce48e49a26f213edfdc0ecddeca2777c3b57c930c2d43d1e879c636/_data",
                  "Name": "19f69d9b5ce48e49a26f213edfdc0ecddeca2777c3b57c930c2d43d1e879c636",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T06:22:18Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/69573784fd6cb0391aba04a0e0a1f0a2c8bd84c406013c670a79146e3d9e0728/_data",
                  "Name": "69573784fd6cb0391aba04a0e0a1f0a2c8bd84c406013c670a79146e3d9e0728",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T23:08:34Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/adcb9d8a17f28daae188ae4c0e5f45294714c55d2623e1040455d04690033ca5/_data",
                  "Name": "adcb9d8a17f28daae188ae4c0e5f45294714c55d2623e1040455d04690033ca5",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T21:37:39Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/f034159a4bbe48146c0ca54e53cf9b94a4b7529a1a9a5c35b8491bc1d8886fed/_data",
                  "Name": "f034159a4bbe48146c0ca54e53cf9b94a4b7529a1a9a5c35b8491bc1d8886fed",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-21T00:45:34Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/1a2aa4f2890dd84041b6ea15c623ecb04a8f31d0dba80e00c6c50bc69b9b6753/_data",
                  "Name": "1a2aa4f2890dd84041b6ea15c623ecb04a8f31d0dba80e00c6c50bc69b9b6753",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-26T13:51:16Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/2de81c58fb6d87a448b10df82bcd6a28ad2813f72a6c0d8b18cd0779fef8fa84/_data",
                  "Name": "2de81c58fb6d87a448b10df82bcd6a28ad2813f72a6c0d8b18cd0779fef8fa84",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T04:07:07Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/4eaa2f343b6373f5201f2bb526e6bffa23168fe1974aac1ab3d19c69b707c9c8/_data",
                  "Name": "4eaa2f343b6373f5201f2bb526e6bffa23168fe1974aac1ab3d19c69b707c9c8",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T06:19:14Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/b4142b75c47d5a45f2088219a84305e33905dfbef5dce9da9f1d1888bd47cdfe/_data",
                  "Name": "b4142b75c47d5a45f2088219a84305e33905dfbef5dce9da9f1d1888bd47cdfe",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-15T01:33:48Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/02fe67a3005d2a69e71e7279efa709493911a2d803ec2e37857375d996c96091/_data",
                  "Name": "02fe67a3005d2a69e71e7279efa709493911a2d803ec2e37857375d996c96091",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T04:22:19Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/87ed3d5182176d057c52064c58f5b58a4a5898db0278b660a9b797e0c72091a0/_data",
                  "Name": "87ed3d5182176d057c52064c58f5b58a4a5898db0278b660a9b797e0c72091a0",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T23:35:39Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/c819d79e880de66c96099672f5e437738988ce6332e9a28ef1b1f638401b1b81/_data",
                  "Name": "c819d79e880de66c96099672f5e437738988ce6332e9a28ef1b1f638401b1b81",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T05:27:02Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/418e3ee6eb5469dda968e8e0b41f7cd35525876e201c7e7390728806d1b61dcb/_data",
                  "Name": "418e3ee6eb5469dda968e8e0b41f7cd35525876e201c7e7390728806d1b61dcb",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T21:41:49Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/4e06c151b3004705c69bdff2ee1196563e23df77317f20ca6c9f0d558999f74d/_data",
                  "Name": "4e06c151b3004705c69bdff2ee1196563e23df77317f20ca6c9f0d558999f74d",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:00:43Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/bb5fe82207dea3852bacdb24907c74529dcd63ec237f453f9c3a5aeacbcbf165/_data",
                  "Name": "bb5fe82207dea3852bacdb24907c74529dcd63ec237f453f9c3a5aeacbcbf165",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T05:27:19Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/df69b5c7444a894334993e202d8f7455584fbbb75a983c5542445b819184c82c/_data",
                  "Name": "df69b5c7444a894334993e202d8f7455584fbbb75a983c5542445b819184c82c",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-10T03:12:35Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/b9cc9c551fcfe8f05464c727991fa1e926ba65ca81cff97fabd5e3711f06bded/_data",
                  "Name": "b9cc9c551fcfe8f05464c727991fa1e926ba65ca81cff97fabd5e3711f06bded",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:09:36Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/d0ee82381337eb4df44be683efdf7f05a89fc15d76208aa118a127e6d443b890/_data",
                  "Name": "d0ee82381337eb4df44be683efdf7f05a89fc15d76208aa118a127e6d443b890",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-28T03:28:10Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/12b79d8415763672e7d45a74a7538d6f078d5c8e71bd4095985cf564d64030a0/_data",
                  "Name": "12b79d8415763672e7d45a74a7538d6f078d5c8e71bd4095985cf564d64030a0",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T03:22:16Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/316bfc289ed87d0f2b950a04e2a55f09a7089cc4213378fa9471619da68a4e41/_data",
                  "Name": "316bfc289ed87d0f2b950a04e2a55f09a7089cc4213378fa9471619da68a4e41",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T23:35:39Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/5826f0826e419134624318cf3e6f417f056e3fe2dfca5050ff0671367b850223/_data",
                  "Name": "5826f0826e419134624318cf3e6f417f056e3fe2dfca5050ff0671367b850223",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-02T00:25:23Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/7b753f5d65541fad21a132144053a54855d2aa7e5a37fe82ea301af0787890cd/_data",
                  "Name": "7b753f5d65541fad21a132144053a54855d2aa7e5a37fe82ea301af0787890cd",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-27T05:32:15Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/8068d801bdebccbebca44f92ed534f2f29d0acadfe32a75c9ca88a9cfc2d44ad/_data",
                  "Name": "8068d801bdebccbebca44f92ed534f2f29d0acadfe32a75c9ca88a9cfc2d44ad",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T04:19:21Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/8ad4051341b86633257e56505ee4033eeb13c79bceb3953458f41eb0278294fe/_data",
                  "Name": "8ad4051341b86633257e56505ee4033eeb13c79bceb3953458f41eb0278294fe",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T21:37:39Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/98c46e355b2ac5e0d8bc9a5f787f4ad9ce62130e9ef291c4db8a5d51141fe800/_data",
                  "Name": "98c46e355b2ac5e0d8bc9a5f787f4ad9ce62130e9ef291c4db8a5d51141fe800",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-20T03:02:03Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/0bbe0c920c05b0382f66d8aa60f8121ce97436217fe8e1601d6eed419fa3c7e3/_data",
                  "Name": "0bbe0c920c05b0382f66d8aa60f8121ce97436217fe8e1601d6eed419fa3c7e3",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T21:22:17Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/20a48fc295154f5f5cc04d43e6a634c9d9d2036ed105e93023147cb353d2f723/_data",
                  "Name": "20a48fc295154f5f5cc04d43e6a634c9d9d2036ed105e93023147cb353d2f723",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:04:43Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/558619f86e842aaa04e01492ea536099a94d4db737b5294c31447d7f5e223968/_data",
                  "Name": "558619f86e842aaa04e01492ea536099a94d4db737b5294c31447d7f5e223968",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T04:37:20Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/700f50dade990b1a00a996df9eb0b55de4345999307bbcf4c17846643b23b890/_data",
                  "Name": "700f50dade990b1a00a996df9eb0b55de4345999307bbcf4c17846643b23b890",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-15T01:33:41Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/a11142b1676b4593e8627a282cf872536504eacfd8445bb2a176be0bd70c84a3/_data",
                  "Name": "a11142b1676b4593e8627a282cf872536504eacfd8445bb2a176be0bd70c84a3",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-15T01:33:48Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/e3a993043a5dfd29ae5ced28f244f8b8dd53ae740097cea9fce5d465f487d7d2/_data",
                  "Name": "e3a993043a5dfd29ae5ced28f244f8b8dd53ae740097cea9fce5d465f487d7d2",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T06:20:11Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/5a72257019a3ff107085fed9e90fad29295cd77a1c9b8f4f6d6446fdba4ebe21/_data",
                  "Name": "5a72257019a3ff107085fed9e90fad29295cd77a1c9b8f4f6d6446fdba4ebe21",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-01T20:41:42Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/b1e16aaf8f8dc6faa3bd75c3929b387bed223dfa2091ff4ecddf80f742cf70d7/_data",
                  "Name": "b1e16aaf8f8dc6faa3bd75c3929b387bed223dfa2091ff4ecddf80f742cf70d7",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-06T01:49:16Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/de8e0822725e0078b496a4ab5ab9623b5499a1b25a0a32cfc428a558dd7955ae/_data",
                  "Name": "de8e0822725e0078b496a4ab5ab9623b5499a1b25a0a32cfc428a558dd7955ae",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-20T03:37:17Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/f0232eaaf30919ceeeb7716b6e216e59a13e52dcfa031bd08aeba622fe43f4eb/_data",
                  "Name": "f0232eaaf30919ceeeb7716b6e216e59a13e52dcfa031bd08aeba622fe43f4eb",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-02T00:55:11Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/3d505cd000fbd4876b21e3cc77863a13df5938d5cfbaabeb44a448d2b48139ee/_data",
                  "Name": "3d505cd000fbd4876b21e3cc77863a13df5938d5cfbaabeb44a448d2b48139ee",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-06T01:38:22Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/45a036e87158afa83dbb5c2aa9c6271f414ba736836b2a4597a4feaa4711fca3/_data",
                  "Name": "45a036e87158afa83dbb5c2aa9c6271f414ba736836b2a4597a4feaa4711fca3",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-06T01:47:32Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/4aec2a66baee0452d08cc560fde09239449703dbb2cbf8f21c4a222e99cd7ad8/_data",
                  "Name": "4aec2a66baee0452d08cc560fde09239449703dbb2cbf8f21c4a222e99cd7ad8",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-20T02:48:02Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/4bbf80ad000a9ac150b7cebf3bc3164431436679c10cb22281ca365e8951d785/_data",
                  "Name": "4bbf80ad000a9ac150b7cebf3bc3164431436679c10cb22281ca365e8951d785",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-15T01:34:13Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/79a601e244f792c7e3717d2c7481ef85d1df155898414ba2d9a518073fee25a7/_data",
                  "Name": "79a601e244f792c7e3717d2c7481ef85d1df155898414ba2d9a518073fee25a7",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-21T00:45:05Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/06888cd087fa4d13d5e5759993ea8c98acacf8c8f46a685f74e0a92d160d980e/_data",
                  "Name": "06888cd087fa4d13d5e5759993ea8c98acacf8c8f46a685f74e0a92d160d980e",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T21:32:06Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/94b9056aa5c4813c1a0a1e08a742b628549c6628a34cc8f75338c2c3ac1062dc/_data",
                  "Name": "94b9056aa5c4813c1a0a1e08a742b628549c6628a34cc8f75338c2c3ac1062dc",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T06:20:11Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/98d1d2ec2ac57f717682e7e42902e71b8ec5ed25b8427e9a258acdc172ca19c5/_data",
                  "Name": "98d1d2ec2ac57f717682e7e42902e71b8ec5ed25b8427e9a258acdc172ca19c5",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:09:36Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/f34f0fae99467583fd586e1787d76aa846952dd5f51a5a66fb485de5ddd82dc0/_data",
                  "Name": "f34f0fae99467583fd586e1787d76aa846952dd5f51a5a66fb485de5ddd82dc0",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-21T00:44:55Z",
                  "Driver": "local",
                  "Labels": {
                    "app": "k3d",
                    "k3d.cluster": "test",
                    "k3d.version": "v5.0.3"
                  },
                  "Mountpoint": "/var/lib/docker/volumes/k3d-test-images/_data",
                  "Name": "k3d-test-images",
                  "Options": {},
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T05:30:08Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/59cd72b5d80883c88887e7fd2e2505e3488b320b53074a1f537d7264682a4b09/_data",
                  "Name": "59cd72b5d80883c88887e7fd2e2505e3488b320b53074a1f537d7264682a4b09",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:22:40Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/7532ab70a8aa4765b2836c15945ddcd42b5754365fb14dab74d59ca620eeab9e/_data",
                  "Name": "7532ab70a8aa4765b2836c15945ddcd42b5754365fb14dab74d59ca620eeab9e",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T23:35:33Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/88e9af6185c3b2cac10dc8165e544eb9b744c577ec3d379566c7fdcfdc200a2d/_data",
                  "Name": "88e9af6185c3b2cac10dc8165e544eb9b744c577ec3d379566c7fdcfdc200a2d",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T21:22:17Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/7e20b911090309c6d44c27c5a0a11c26c5093cbed7732be44c5ee0d206388072/_data",
                  "Name": "7e20b911090309c6d44c27c5a0a11c26c5093cbed7732be44c5ee0d206388072",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T23:36:03Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/f812c2e7319fc3cafcc38446524eca9f1b19694e51986432efb7b153cf53bcb7/_data",
                  "Name": "f812c2e7319fc3cafcc38446524eca9f1b19694e51986432efb7b153cf53bcb7",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-20T03:37:18Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/ba346fb23b342e2ed50ce4960cb7d34e1b20a492c62c7b4d90754d201f5c3958/_data",
                  "Name": "ba346fb23b342e2ed50ce4960cb7d34e1b20a492c62c7b4d90754d201f5c3958",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T04:54:49Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/d600655f69c05f30ad6eda8e6e949e78afbf3b58bc67f0ca06672fa35768986a/_data",
                  "Name": "d600655f69c05f30ad6eda8e6e949e78afbf3b58bc67f0ca06672fa35768986a",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:14:17Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/ed27716740a39556975b1424aff8976e72a5357a5d165818ac2a53974f1385d4/_data",
                  "Name": "ed27716740a39556975b1424aff8976e72a5357a5d165818ac2a53974f1385d4",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:14:17Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/3d9875f461de31a5228317c86f21d0ba4c3bd59bf7c429f8664d1db79b278a89/_data",
                  "Name": "3d9875f461de31a5228317c86f21d0ba4c3bd59bf7c429f8664d1db79b278a89",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T04:13:25Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/6ea370f629192d8a44f5fe73e298a2d557e1b99b0ff10279aed842a20ce50d16/_data",
                  "Name": "6ea370f629192d8a44f5fe73e298a2d557e1b99b0ff10279aed842a20ce50d16",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T21:29:22Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/91cf84b3b151f5963bd6025b3fe5891376da0f133f9fe1dd3ce33b72f5ccc342/_data",
                  "Name": "91cf84b3b151f5963bd6025b3fe5891376da0f133f9fe1dd3ce33b72f5ccc342",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:00:43Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/20c1d9e4949b7b55605b7ff43498ec910e0dbcb6d75dfc5728561af026f82e4f/_data",
                  "Name": "20c1d9e4949b7b55605b7ff43498ec910e0dbcb6d75dfc5728561af026f82e4f",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T04:37:20Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/9e9da4ffc5fac2ed917196b4bdcbbbd78505a0d7c1e3baefdd91199fa15f7684/_data",
                  "Name": "9e9da4ffc5fac2ed917196b4bdcbbbd78505a0d7c1e3baefdd91199fa15f7684",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T06:19:30Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/ba10d87e38c862587b400f7549481879cc87d4f907f49aefa9f96839b6dd4439/_data",
                  "Name": "ba10d87e38c862587b400f7549481879cc87d4f907f49aefa9f96839b6dd4439",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-26T13:47:41Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/6c129dfee72b08aea3df9d06e0bc4d36039c102a03f19453558f958bf51bc3cd/_data",
                  "Name": "6c129dfee72b08aea3df9d06e0bc4d36039c102a03f19453558f958bf51bc3cd",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-02T00:22:25Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/8b5d369a665f6d44e601d16a604dacd345a0553fc342e9ae8692ee0a1ce05b5c/_data",
                  "Name": "8b5d369a665f6d44e601d16a604dacd345a0553fc342e9ae8692ee0a1ce05b5c",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-14T05:30:08Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/8bd3ee5f2ca833c3c1aa07f47249a545caa4aad50f6c6b53a072c2462dd48271/_data",
                  "Name": "8bd3ee5f2ca833c3c1aa07f47249a545caa4aad50f6c6b53a072c2462dd48271",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-21T00:44:59Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/9927f21458f270e6e425514ea9e97e6eb97c569c664e780dabdd8b01e4315e3f/_data",
                  "Name": "9927f21458f270e6e425514ea9e97e6eb97c569c664e780dabdd8b01e4315e3f",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-30T04:23:48Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/31cb2a74b10070d8e5d917ec39e4dbc72624a5feb4ff16b46bd80e54e76b0242/_data",
                  "Name": "31cb2a74b10070d8e5d917ec39e4dbc72624a5feb4ff16b46bd80e54e76b0242",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-11-29T01:22:40Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/f6997f6430442603a6f4ef106eeb1c2ae64cd0d4014a20b2782044fe7f401b70/_data",
                  "Name": "f6997f6430442603a6f4ef106eeb1c2ae64cd0d4014a20b2782044fe7f401b70",
                  "Options": null,
                  "Scope": "local"
                },
                {
                  "CreatedAt": "2021-12-21T00:45:05Z",
                  "Driver": "local",
                  "Labels": null,
                  "Mountpoint": "/var/lib/docker/volumes/b9c016d325d2aac0cc8501c8160b3482d0612183770544be2d13a71e30026653/_data",
                  "Name": "b9c016d325d2aac0cc8501c8160b3482d0612183770544be2d13a71e30026653",
                  "Options": null,
                  "Scope": "local"
                }
              ],
              "Warnings": null
            }
          },
          "DockerVersion": "20.10.11",
          "HealthyContainerCount": 0,
          "ImageCount": 23,
          "NodeCount": 0,
          "RunningContainerCount": 2,
          "ServiceCount": 0,
          "StackCount": 0,
          "StoppedContainerCount": 0,
          "Swarm": false,
          "Time": 1640056322,
          "TotalCPU": 5,
          "TotalMemory": 2085158912,
          "UnhealthyContainerCount": 0,
          "VolumeCount": 67
        }
      ],
      "Status": 1,
      "TLSConfig": {
        "TLS": false,
        "TLSSkipVerify": false
      },
      "TagIds": [],
      "Tags": null,
      "TeamAccessPolicies": {},
      "Type": 1,
      "URL": "unix:///var/run/docker.sock",
      "UserAccessPolicies": {}
    }
  ],
  "settings": {
    "AllowBindMountsForRegularUsers": false,
    "AllowContainerCapabilitiesForRegularUsers": false,
    "AllowDeviceMappingForRegularUsers": false,
    "AllowHostNamespaceForRegularUsers": false,
    "AllowPrivilegedModeForRegularUsers": false,
    "AllowStackManagementForRegularUsers": false,
    "AllowVolumeBrowserForRegularUsers": false,
    "AuthenticationMethod": 1,
    "BlackListedLabels": [],
    "DisplayDonationHeader": false,
    "DisplayExternalContributors": false,
    "EdgeAgentCheckinInterval": 5,
    "EnableEdgeComputeFeatures": false,
    "EnableHostManagementFeatures": false,
    "EnableTelemetry": false,
    "FeatureFlagSettings": {
      "db-seed": true
    },
    "HelmRepositoryURL": "",
    "KubeconfigExpiry": "0",
    "KubectlShellImage": "portainer/kubectl-shell",
    "LDAPSettings": {
      "AnonymousMode": true,
      "AutoCreateUsers": true,
      "GroupSearchSettings": [
        {
          "GroupAttribute": "",
          "GroupBaseDN": "",
          "GroupFilter": ""
        }
      ],
      "ReaderDN": "",
      "SearchSettings": [
        {
          "BaseDN": "",
          "Filter": "",
          "UserNameAttribute": ""
        }
      ],
      "StartTLS": false,
      "TLSConfig": {
        "TLS": false,
        "TLSSkipVerify": false
      },
      "URL": ""
    },
    "LogoURL": "",
    "OAuthSettings": {
      "AccessTokenURI": "",
      "AuthorizationURI": "",
      "ClientID": "",
      "DefaultTeamID": 0,
      "KubeSecretKey": "DJvtAc+j1qrfnlmfvb3sbiohN3Kts/yKu2ufY+Yfmhg=",
      "LogoutURI": "",
      "OAuthAutoCreateUsers": false,
      "RedirectURI": "",
      "ResourceURI": "",
      "SSO": true,
      "Scopes": "",
      "UserIdentifier": ""
    },
    "OpenAMTConfiguration": {
      "Credentials": {
        "MPSPassword": "",
        "MPSToken": "",
        "MPSUser": ""
      },
      "DomainConfiguration": {
        "CertFileText": "",
        "CertPassword": "",
        "DomainName": ""
      },
      "Enabled": false,
      "MPSServer": "",
      "WirelessConfiguration": null
    },
    "SnapshotInterval": "5m",
    "TemplatesURL": "https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json",
    "UserSessionTimeout": "8h"
  },
  "ssl": {
    "certPath": "../data/certs/cert.pem",
    "httpEnabled": true,
    "keyPath": "../data/certs/key.pem",
    "selfSigned": true
  },
  "tunnel_server": {
    "PrivateKeySeed": "lrD1IrrIsadBchwB"
  },
  "users": [
    {
      "EndpointAuthorizations": null,
      "Id": 1,
      "Password": "$2a$10$UJUAINxGXN2Gdd7ayfgjL.Ww5tYdxl48NsRTfU85fz7laIJFppuHG",
      "PortainerAuthorizations": null,
      "Role": 1,
      "UserTheme": "",
      "Username": "admin"
    }
  ],
  "version": {
    "DB_VERSION": 35,
    "INSTANCE_ID": "59c8ce7e-a3d9-495b-b8f7-764c4d4738ba"
  }
}
``` 
</details>

## Notes
- Do not enable this endpoint in production
- The endpoint can only be hit by admin users
- Posting/Uploading an incorrect/invalid JSON db payload will corrupt the database