### PR TITLE
fix(docker): add config getter from omit-able fields (#6294)

### DIFF
--- a/app/docker/models/imageDetails.js
+++ b/app/docker/models/imageDetails.js
@@ -12,9 +12,28 @@ export function ImageDetailsViewModel(data) {
   this.Architecture = data.Architecture;
   this.Author = data.Author;
   this.Command = data.Config.Cmd;
-  this.Entrypoint = data.ContainerConfig.Entrypoint ? data.ContainerConfig.Entrypoint : '';
-  this.ExposedPorts = data.ContainerConfig.ExposedPorts ? Object.keys(data.ContainerConfig.ExposedPorts) : [];
-  this.Volumes = data.ContainerConfig.Volumes ? Object.keys(data.ContainerConfig.Volumes) : [];
-  this.Env = data.ContainerConfig.Env ? data.ContainerConfig.Env : [];
-  this.Labels = data.ContainerConfig.Labels;
+  
+  var config = null;
+  // See Api-Spec: https://github.com/moby/moby/blob/master/image/image.go
+  if ("Config" in data && data.Config != null) {
+    // First try get image configuration received from the client
+    config = data.Config;
+  } else if ("ContainerConfig" in data && data.ContainerConfig != null) {
+    // Second try get image configuration that is committed into the image
+    config = data.ContainerConfig;
+  }
+  
+  if (config) {
+    this.Entrypoint = config.Entrypoint ? config.Entrypoint : '';
+    this.ExposedPorts = config.ExposedPorts ? Object.keys(config.ExposedPorts) : [];
+    this.Volumes = config.Volumes ? Object.keys(config.Volumes) : [];
+    this.Env = config.Env ? config.Env : [];
+    this.Labels = config.Labels;
+  } else {
+    this.Entrypoint = '';
+    this.ExposedPorts = [];
+    this.Volumes = [];
+    this.Env = [];
+    this.Labels = null;
+  }
 }


### PR DESCRIPTION
Try get the omit-able fields `Config` and `ContainerConfig` in the image inspect response and safely construct the image details.

### Context
Portainer doesn't follow the mobi API spec for image inspection response: https://github.com/moby/moby/blob/master/image/image.go
The fields Config and ContainerConfig can be ommited (null).