### PR TITLE
fix(modals): upgrade jquery versions [EE-2179]

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "webpack-merge": "^5.8.0"
   },
   "resolutions": {
-    "jquery": "^3.5.1",
+    "**/jquery": "^3.6.0",
     "decompress": "^4.2.1",
     "lodash": "^4.17.21",
     "js-yaml": "^3.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11172,12 +11172,7 @@ jest@^27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.4.5"
 
-jquery@>=1.12.0, jquery@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
-jquery@^3.6.0:
+jquery@>=1.12.0, jquery@^3.5.1, jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
fixes [EE-2179]

since plugins of jquery rely on an existing instance of jquery, if we have more than one instance (as happend in our case), plugins won't necesarilly work. we need to keep jquery installed once (and hopefully soon enough, removed)

[EE-2179]: https://portainer.atlassian.net/browse/EE-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ