### PR TITLE
feat(database): add encryption support EE-1983

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -57,7 +57,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		Logo:                      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
 		Templates:                 kingpin.Flag("templates", "URL to the templates definitions.").Short('t').String(),
 		BaseURL:                   kingpin.Flag("base-url", "Base URL parameter such as portainer if running portainer as http://yourdomain.com/portainer/.").Short('b').Default(defaultBaseURL).String(),
-		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption").Default(defaultSecretKeyName).String(),
+		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption and will be used as /run/secrets/<secret-key-name>.").Default(defaultSecretKeyName).String(),
 	}
 
 	kingpin.Parse()

--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -57,6 +57,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		Logo:                      kingpin.Flag("logo", "URL for the logo displayed in the UI").String(),
 		Templates:                 kingpin.Flag("templates", "URL to the templates definitions.").Short('t').String(),
 		BaseURL:                   kingpin.Flag("base-url", "Base URL parameter such as portainer if running portainer as http://yourdomain.com/portainer/.").Short('b').Default(defaultBaseURL).String(),
+		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption").Default(defaultSecretKeyName).String(),
 	}
 
 	kingpin.Parse()

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -16,7 +16,7 @@ const (
 	defaultTLSCertPath         = "/certs/cert.pem"
 	defaultTLSKeyPath          = "/certs/key.pem"
 	defaultHTTPDisabled        = "false"
-	defaultHTTPEnabled         = "false"
+	defaultHTTPEnabled         = "true"
 	defaultSSL                 = "false"
 	defaultSSLCertPath         = "/certs/portainer.crt"
 	defaultSSLKeyPath          = "/certs/portainer.key"

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -22,4 +22,5 @@ const (
 	defaultSSLKeyPath          = "/certs/portainer.key"
 	defaultSnapshotInterval    = "5m"
 	defaultBaseURL             = "/"
+	defaultSecretKeyName       = "portainer"
 )

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -19,4 +19,5 @@ const (
 	defaultSSLKeyPath          = "C:\\certs\\portainer.key"
 	defaultSnapshotInterval    = "5m"
 	defaultBaseURL             = "/"
+	defaultSecretKeyName       = "portainer"
 )

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -13,7 +13,7 @@ const (
 	defaultTLSCertPath         = "C:\\certs\\cert.pem"
 	defaultTLSKeyPath          = "C:\\certs\\key.pem"
 	defaultHTTPDisabled        = "false"
-	defaultHTTPEnabled         = "false"
+	defaultHTTPEnabled         = "true"
 	defaultSSL                 = "false"
 	defaultSSLCertPath         = "C:\\certs\\portainer.crt"
 	defaultSSLKeyPath          = "C:\\certs\\portainer.key"

--- a/api/cmd/portainer/import.go
+++ b/api/cmd/portainer/import.go
@@ -13,7 +13,7 @@ func importFromJson(fileService portainer.FileService, store *datastore.Store) {
 	importFile := "/data/import.json"
 	if exists, _ := fileService.FileExists(importFile); exists {
 		if err := store.Import(importFile); err != nil {
-			logrus.WithError(err).Debugf("import %s failed", importFile)
+			logrus.WithError(err).Debugf("Import %s failed", importFile)
 
 			// TODO: should really rollback on failure, but then we have nothing.
 		} else {
@@ -23,7 +23,7 @@ func importFromJson(fileService portainer.FileService, store *datastore.Store) {
 		// I also suspect that everything from "Init to Init" is potentially a migration
 		err := store.Init()
 		if err != nil {
-			log.Fatalf("failed initializing data store: %v", err)
+			log.Fatalf("Failed initializing data store: %v", err)
 		}
 	}
 }

--- a/api/cmd/portainer/log.go
+++ b/api/cmd/portainer/log.go
@@ -1,18 +1,41 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
+
+type portainerFormatter struct {
+	logrus.TextFormatter
+}
+
+func (f *portainerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var levelColor int
+	switch entry.Level {
+	case logrus.DebugLevel, logrus.TraceLevel:
+		levelColor = 31 // gray
+	case logrus.WarnLevel:
+		levelColor = 33 // yellow
+	case logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
+		levelColor = 31 // red
+	default:
+		levelColor = 36 // blue
+	}
+	return []byte(fmt.Sprintf("\x1b[%dm%s\x1b[0m %s %s\n", levelColor, strings.ToUpper(entry.Level.String()), entry.Time.Format(f.TimestampFormat), entry.Message)), nil
+}
 
 func configureLogger() {
 	logger := logrus.New() // logger is to implicitly substitute stdlib's log
 	log.SetOutput(logger.Writer())
 
 	formatter := &logrus.TextFormatter{DisableTimestamp: true, DisableLevelTruncation: true}
+	formatterLogrus := &portainerFormatter{logrus.TextFormatter{DisableTimestamp: false, DisableLevelTruncation: true, TimestampFormat: "2006/01/02 15:04:05", FullTimestamp: true}}
+
 	logger.SetFormatter(formatter)
-	logrus.SetFormatter(formatter)
+	logrus.SetFormatter(formatterLogrus)
 
 	logger.SetLevel(logrus.DebugLevel)
 	logrus.SetLevel(logrus.DebugLevel)

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -65,8 +65,8 @@ func initFileService(dataStorePath string) portainer.FileService {
 	return fileService
 }
 
-func initDataStore(flags *portainer.CLIFlags, fileService portainer.FileService, shutdownCtx context.Context) dataservices.DataStore {
-	connection, err := database.NewDatabase("boltdb", *flags.Data)
+func initDataStore(flags *portainer.CLIFlags, fileService portainer.FileService, secretkey string, shutdownCtx context.Context) dataservices.DataStore {
+	connection, err := database.NewDatabase("boltdb", *flags.Data, secretkey)
 	if err != nil {
 		panic(err)
 	}
@@ -516,7 +516,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 		log.Println("proceeding without encryption key")
 	}
 
-	dataStore := initDataStore(flags, fileService, shutdownCtx)
+	dataStore := initDataStore(flags, fileService, encryptionKey, shutdownCtx)
 
 	if err := dataStore.CheckCurrentEdition(); err != nil {
 		log.Fatal(err)

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -491,10 +491,30 @@ func initEndpoint(flags *portainer.CLIFlags, dataStore dataservices.DataStore, s
 	return createUnsecuredEndpoint(*flags.EndpointURL, dataStore, snapshotService)
 }
 
+func initSecretKey(fileName string) string {
+	ok, _ := filesystem.FileExists("/run/secrets/" + fileName)
+	if !ok {
+		log.Println(fmt.Sprintf("encryption secret file `%s` does not exists", fileName))
+		return ""
+	}
+
+	content, err := os.ReadFile("/run/secrets/" + fileName)
+	if err != nil {
+		log.Println(fmt.Sprintf("error reading encryption key file: %s", err.Error()))
+		return ""
+	}
+
+	return string(content)
+}
+
 func buildServer(flags *portainer.CLIFlags) portainer.Server {
 	shutdownCtx, shutdownTrigger := context.WithCancel(context.Background())
 
 	fileService := initFileService(*flags.Data)
+	encryptionKey := initSecretKey(*flags.SecretKeyName)
+	if encryptionKey == "" {
+		log.Println("proceeding without encryption key")
+	}
 
 	dataStore := initDataStore(flags, fileService, shutdownCtx)
 

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -504,7 +504,7 @@ func initSecretKey(fileName string) string {
 		return ""
 	}
 
-	return string(content)
+	return strings.TrimSuffix(string(content), "\n")
 }
 
 func buildServer(flags *portainer.CLIFlags) portainer.Server {

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -48,12 +48,12 @@ func initCLI() *portainer.CLIFlags {
 	var cliService portainer.CLIService = &cli.Service{}
 	flags, err := cliService.ParseFlags(portainer.APIVersion)
 	if err != nil {
-		log.Fatalf("failed parsing flags: %v", err)
+		log.Fatalf("Failed parsing flags: %v", err)
 	}
 
 	err = cliService.ValidateFlags(flags)
 	if err != nil {
-		log.Fatalf("failed validating flags:%v", err)
+		log.Fatalf("Failed validating flags:%v", err)
 	}
 	return flags
 }
@@ -61,7 +61,7 @@ func initCLI() *portainer.CLIFlags {
 func initFileService(dataStorePath string) portainer.FileService {
 	fileService, err := filesystem.NewService(dataStorePath, "")
 	if err != nil {
-		log.Fatalf("failed creating file service: %v", err)
+		log.Fatalf("Failed creating file service: %v", err)
 	}
 	return fileService
 }
@@ -74,13 +74,13 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 	store := datastore.NewStore(*flags.Data, fileService, connection)
 	isNew, err := store.Open()
 	if err != nil {
-		log.Fatalf("failed opening store: %v", err)
+		log.Fatalf("Failed opening store: %v", err)
 	}
 
 	if *flags.Rollback {
 		err := store.Rollback(false)
 		if err != nil {
-			log.Fatalf("failed rolling back: %s", err)
+			log.Fatalf("Failed rolling back: %v", err)
 		}
 
 		log.Println("Exiting rollback")
@@ -91,7 +91,7 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 	// Init sets some defaults - its basically a migration
 	err = store.Init()
 	if err != nil {
-		log.Fatalf("failed initializing data store: %v", err)
+		log.Fatalf("Failed initializing data store: %v", err)
 	}
 
 	if isNew {
@@ -100,17 +100,17 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 
 		err := updateSettingsFromFlags(store, flags)
 		if err != nil {
-			log.Fatalf("failed updating settings from flags: %v", err)
+			log.Fatalf("Failed updating settings from flags: %v", err)
 		}
 	} else {
 		storedVersion, err := store.VersionService.DBVersion()
 		if err != nil {
-			log.Fatalf("Something failed during creation of new database: %v", err)
+			log.Fatalf("Something Failed during creation of new database: %v", err)
 		}
 		if storedVersion != portainer.DBVersion {
 			err = store.MigrateData()
 			if err != nil {
-				log.Fatalf("failed migration: %v", err)
+				log.Fatalf("Failed migration: %v", err)
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 
 		err := store.Export(exportFilename)
 		if err != nil {
-			logrus.WithError(err).Debugf("failed to export to %s", exportFilename)
+			logrus.WithError(err).Debugf("Failed to export to %s", exportFilename)
 		} else {
 			logrus.Debugf("exported to %s", exportFilename)
 		}
@@ -136,7 +136,7 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 func initComposeStackManager(assetsPath string, configPath string, reverseTunnelService portainer.ReverseTunnelService, proxyManager *proxy.Manager) portainer.ComposeStackManager {
 	composeWrapper, err := exec.NewComposeStackManager(assetsPath, configPath, proxyManager)
 	if err != nil {
-		log.Fatalf("failed creating compose manager: %s", err)
+		log.Fatalf("Failed creating compose manager: %v", err)
 	}
 
 	return composeWrapper
@@ -344,7 +344,7 @@ func generateAndStoreKeyPair(fileService portainer.FileService, signatureService
 func initKeyPair(fileService portainer.FileService, signatureService portainer.DigitalSignatureService) error {
 	existingKeyPair, err := fileService.KeyPairFilesExist()
 	if err != nil {
-		log.Fatalf("failed checking for existing key pair: %v", err)
+		log.Fatalf("Failed checking for existing key pair: %v", err)
 	}
 
 	if existingKeyPair {
@@ -494,7 +494,7 @@ func loadEncryptionSecretKey(keyfilename string) []byte {
 		if os.IsNotExist(err) {
 			log.Printf("Encryption key file `%s` not present", keyfilename)
 		} else {
-			log.Printf("Error reading encryption key file: %s", err.Error())
+			log.Printf("Error reading encryption key file: %v", err)
 		}
 
 		return nil
@@ -521,7 +521,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 	}
 	instanceID, err := dataStore.Version().InstanceID()
 	if err != nil {
-		log.Fatalf("failed getting instance id: %v", err)
+		log.Fatalf("Failed getting instance id: %v", err)
 	}
 
 	apiKeyService := initAPIKeyService(dataStore)
@@ -532,12 +532,12 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 	}
 	jwtService, err := initJWTService(settings.UserSessionTimeout, dataStore)
 	if err != nil {
-		log.Fatalf("failed initializing JWT service: %v", err)
+		log.Fatalf("Failed initializing JWT service: %v", err)
 	}
 
 	err = enableFeaturesFromFlags(dataStore, flags)
 	if err != nil {
-		log.Fatalf("failed enabling feature flag: %v", err)
+		log.Fatalf("Failed enabling feature flag: %v", err)
 	}
 
 	ldapService := initLDAPService()
@@ -556,12 +556,12 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 
 	sslSettings, err := sslService.GetSSLSettings()
 	if err != nil {
-		log.Fatalf("failed to get ssl settings: %s", err)
+		log.Fatalf("Failed to get ssl settings: %s", err)
 	}
 
 	err = initKeyPair(fileService, digitalSignatureService)
 	if err != nil {
-		log.Fatalf("failed initializing key pair: %v", err)
+		log.Fatalf("Failed initializing key pair: %v", err)
 	}
 
 	reverseTunnelService := chisel.NewService(dataStore, shutdownCtx)
@@ -571,7 +571,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 
 	snapshotService, err := initSnapshotService(*flags.SnapshotInterval, dataStore, dockerClientFactory, kubernetesClientFactory, shutdownCtx)
 	if err != nil {
-		log.Fatalf("failed initializing snapshot service: %v", err)
+		log.Fatalf("Failed initializing snapshot service: %v", err)
 	}
 	snapshotService.Start()
 
@@ -592,37 +592,37 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 
 	swarmStackManager, err := initSwarmStackManager(*flags.Assets, dockerConfigPath, digitalSignatureService, fileService, reverseTunnelService, dataStore)
 	if err != nil {
-		log.Fatalf("failed initializing swarm stack manager: %s", err)
+		log.Fatalf("Failed initializing swarm stack manager: %v", err)
 	}
 
 	kubernetesDeployer := initKubernetesDeployer(kubernetesTokenCacheManager, kubernetesClientFactory, dataStore, reverseTunnelService, digitalSignatureService, proxyManager, *flags.Assets)
 
 	helmPackageManager, err := initHelmPackageManager(*flags.Assets)
 	if err != nil {
-		log.Fatalf("failed initializing helm package manager: %s", err)
+		log.Fatalf("Failed initializing helm package manager: %v", err)
 	}
 
 	err = edge.LoadEdgeJobs(dataStore, reverseTunnelService)
 	if err != nil {
-		log.Fatalf("failed loading edge jobs from database: %v", err)
+		log.Fatalf("Failed loading edge jobs from database: %v", err)
 	}
 
 	applicationStatus := initStatus(instanceID)
 
 	err = initEndpoint(flags, dataStore, snapshotService)
 	if err != nil {
-		log.Fatalf("failed initializing environment: %v", err)
+		log.Fatalf("Failed initializing environment: %v", err)
 	}
 
 	adminPasswordHash := ""
 	if *flags.AdminPasswordFile != "" {
 		content, err := fileService.GetFileContent(*flags.AdminPasswordFile, "")
 		if err != nil {
-			log.Fatalf("failed getting admin password file: %v", err)
+			log.Fatalf("Failed getting admin password file: %v", err)
 		}
 		adminPasswordHash, err = cryptoService.Hash(strings.TrimSuffix(string(content), "\n"))
 		if err != nil {
-			log.Fatalf("failed hashing admin password: %v", err)
+			log.Fatalf("Failed hashing admin password: %v", err)
 		}
 	} else if *flags.AdminPassword != "" {
 		adminPasswordHash = *flags.AdminPassword
@@ -631,7 +631,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 	if adminPasswordHash != "" {
 		users, err := dataStore.User().UsersByRole(portainer.AdministratorRole)
 		if err != nil {
-			log.Fatalf("failed getting admin user: %v", err)
+			log.Fatalf("Failed getting admin user: %v", err)
 		}
 
 		if len(users) == 0 {
@@ -643,7 +643,7 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 			}
 			err := dataStore.User().Create(user)
 			if err != nil {
-				log.Fatalf("failed creating admin user: %v", err)
+				log.Fatalf("Failed creating admin user: %v", err)
 			}
 		} else {
 			log.Println("Instance already has an administrator user defined. Skipping admin password related flags.")
@@ -652,12 +652,12 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 
 	err = reverseTunnelService.StartTunnelServer(*flags.TunnelAddr, *flags.TunnelPort, snapshotService)
 	if err != nil {
-		log.Fatalf("failed starting tunnel server: %s", err)
+		log.Fatalf("Failed starting tunnel server: %v", err)
 	}
 
 	sslDBSettings, err := dataStore.SSLSettings().Settings()
 	if err != nil {
-		log.Fatalf("failed to fetch ssl settings from DB")
+		log.Fatalf("Failed to fetch ssl settings from DB")
 	}
 
 	scheduler := scheduler.NewScheduler(shutdownCtx)
@@ -710,6 +710,6 @@ func main() {
 		server := buildServer(flags)
 		log.Printf("[INFO] [cmd,main] Starting Portainer version %s\n", portainer.APIVersion)
 		err := server.Start()
-		log.Printf("[INFO] [cmd,main] Http server exited: %s\n", err)
+		log.Printf("[INFO] [cmd,main] Http server exited: %v\n", err)
 	}
 }

--- a/api/connection.go
+++ b/api/connection.go
@@ -13,7 +13,8 @@ type Connection interface {
 
 	// TODO: this one is very database specific atm
 	BackupTo(w io.Writer) error
-	GetDatabaseFilename(fullpath bool) string
+	GetDatabaseFileName() string
+	GetDatabaseFilePath() string
 	GetStorePath() string
 
 	IsEncryptedStore() bool

--- a/api/connection.go
+++ b/api/connection.go
@@ -13,8 +13,11 @@ type Connection interface {
 
 	// TODO: this one is very database specific atm
 	BackupTo(w io.Writer) error
-	GetDatabaseFilename() string
+	GetDatabaseFilename(fullpath bool) string
 	GetStorePath() string
+
+	IsEncryptedStore() bool
+	SetEncrypted(encrypted bool)
 
 	SetServiceName(bucketName string) error
 	GetObject(bucketName string, key []byte, object interface{}) error
@@ -28,7 +31,4 @@ type Connection interface {
 	GetAll(bucketName string, obj interface{}, append func(o interface{}) (interface{}, error)) error
 	GetAllWithJsoniter(bucketName string, obj interface{}, append func(o interface{}) (interface{}, error)) error
 	ConvertToKey(v int) []byte
-
-	IsEncryptionRequired() (bool, error)
-	SetIsEncryptedFlag(bool)
 }

--- a/api/connection.go
+++ b/api/connection.go
@@ -18,7 +18,7 @@ type Connection interface {
 	GetStorePath() string
 
 	IsEncryptedStore() bool
-	DoesStoreNeedEncryption() bool
+	NeedsEncryptionMigration() bool
 	SetEncrypted(encrypted bool)
 
 	SetServiceName(bucketName string) error

--- a/api/connection.go
+++ b/api/connection.go
@@ -11,9 +11,6 @@ type Connection interface {
 	// write the db contents to filename as json (the schema needs defining)
 	ExportRaw(filename string) error
 
-	//Rollback(force bool) error
-	//MigrateData(migratorParams *database.MigratorParameters, force bool) error
-
 	// TODO: this one is very database specific atm
 	BackupTo(w io.Writer) error
 	GetDatabaseFilename() string
@@ -33,5 +30,5 @@ type Connection interface {
 	ConvertToKey(v int) []byte
 
 	IsEncryptionRequired() (bool, error)
-	SetIsDBEncryptedFlag(bool)
+	SetIsEncryptedFlag(bool)
 }

--- a/api/connection.go
+++ b/api/connection.go
@@ -18,6 +18,7 @@ type Connection interface {
 	GetStorePath() string
 
 	IsEncryptedStore() bool
+	DoesStoreNeedEncryption() bool
 	SetEncrypted(encrypted bool)
 
 	SetServiceName(bucketName string) error

--- a/api/connection.go
+++ b/api/connection.go
@@ -31,4 +31,7 @@ type Connection interface {
 	GetAll(bucketName string, obj interface{}, append func(o interface{}) (interface{}, error)) error
 	GetAllWithJsoniter(bucketName string, obj interface{}, append func(o interface{}) (interface{}, error)) error
 	ConvertToKey(v int) []byte
+
+	IsEncryptionRequired() (bool, error)
+	SetIsDBEncryptedFlag(bool)
 }

--- a/api/database/boltdb/db.go
+++ b/api/database/boltdb/db.go
@@ -41,8 +41,8 @@ func (connection *DbConnection) GetStorePath() string {
 	return connection.Path
 }
 
-// SetIsDBEncryptedFlag
-func (connection *DbConnection) SetIsDBEncryptedFlag(flag bool) {
+// SetIsEncryptedFlag
+func (connection *DbConnection) SetIsEncryptedFlag(flag bool) {
 	connection.IsDBEncrypted = flag
 }
 
@@ -50,7 +50,7 @@ func (connection *DbConnection) SetIsDBEncryptedFlag(flag bool) {
 func (connection *DbConnection) IsEncryptionRequired() (bool, error) {
 	if connection.EncryptionKey != "" {
 		// set it back to true as encryption key exists
-		defer connection.SetIsDBEncryptedFlag(true)
+		defer connection.SetIsEncryptedFlag(true)
 
 		// set IsDBEncrypted to false and get the version
 		connection.IsDBEncrypted = false

--- a/api/database/boltdb/db.go
+++ b/api/database/boltdb/db.go
@@ -71,7 +71,7 @@ func (connection *DbConnection) DoesStoreNeedEncryption() bool {
 	if encryptedDbFile {
 		connection.SetEncrypted(true)
 		if connection.EncryptionKey == nil {
-			panic("Portainer database is encrypted, but no encryption key was loaded")
+			logrus.Fatal("Portainer database is encrypted, but no encryption key was loaded")
 		}
 
 		// DB is already encrypted and everything checks out. Nothing to migrate

--- a/api/database/boltdb/db.go
+++ b/api/database/boltdb/db.go
@@ -27,21 +27,22 @@ type DbConnection struct {
 	*bolt.DB
 }
 
-func (connection *DbConnection) GetDatabaseFilename(fullpath bool) string {
-
-	if fullpath {
-		if connection.IsEncryptedStore() {
-			return path.Join(connection.Path, EncryptedDatabaseFileName)
-		}
-
-		return path.Join(connection.Path, DatabaseFileName)
-	}
-
+// GetDatabaseFileName get the database filename
+func (connection *DbConnection) GetDatabaseFileName() string {
 	if connection.IsEncryptedStore() {
 		return EncryptedDatabaseFileName
 	}
 
 	return DatabaseFileName
+}
+
+// GetDataseFilePath get the path + filename for the database file
+func (connection *DbConnection) GetDatabaseFilePath() string {
+	if connection.IsEncryptedStore() {
+		return path.Join(connection.Path, EncryptedDatabaseFileName)
+	}
+
+	return path.Join(connection.Path, DatabaseFileName)
 }
 
 // GetStorePath get the filename and path for the database file
@@ -91,10 +92,10 @@ func (connection *DbConnection) Open() error {
 	// 	log.Printf("raw export to %s success", databaseExportPath)
 	// }
 
-	logrus.Infof("Loading PortainerDB: %s", connection.GetDatabaseFilename(false))
+	logrus.Infof("Loading PortainerDB: %s", connection.GetDatabaseFileName())
 
 	// Now we open the db
-	databasePath := connection.GetDatabaseFilename(true)
+	databasePath := connection.GetDatabaseFilePath()
 	db, err := bolt.Open(databasePath, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return err
@@ -122,7 +123,7 @@ func (connection *DbConnection) BackupTo(w io.Writer) error {
 }
 
 func (connection *DbConnection) ExportRaw(filename string) error {
-	databasePath := connection.GetDatabaseFilename(true)
+	databasePath := connection.GetDatabaseFilePath()
 	if _, err := os.Stat(databasePath); err != nil {
 		return fmt.Errorf("stat on %s failed: %s", databasePath, err)
 	}

--- a/api/database/boltdb/export.go
+++ b/api/database/boltdb/export.go
@@ -11,7 +11,9 @@ import (
 // inspired by github.com/konoui/boltdb-exporter (which has no license)
 // but very much simplified, based on how we use boltdb
 
-func exportJson(databasePath string) ([]byte, error) {
+func exportJson(databasePath, passphrase string) ([]byte, error) {
+	logrus.WithField("databasePath", databasePath).Infof("exportJson")
+
 	connection, err := bolt.Open(databasePath, 0600, &bolt.Options{Timeout: 1 * time.Second, ReadOnly: true})
 	if err != nil {
 		return []byte("{}"), err
@@ -31,7 +33,7 @@ func exportJson(databasePath string) ([]byte, error) {
 					continue
 				}
 				var obj interface{}
-				err := UnmarshalObject(v, &obj)
+				err := UnmarshalObject(v, &obj, passphrase)
 				if err != nil {
 					logrus.WithError(err).Errorf("Failed to unmarshal (bucket %s): %v", bucketName, string(v))
 					obj = v

--- a/api/database/boltdb/export.go
+++ b/api/database/boltdb/export.go
@@ -10,8 +10,7 @@ import (
 
 // inspired by github.com/konoui/boltdb-exporter (which has no license)
 // but very much simplified, based on how we use boltdb
-
-func exportJson(databasePath, passphrase string) ([]byte, error) {
+func exportJson(databasePath string, encryptionKey []byte) ([]byte, error) {
 	logrus.WithField("databasePath", databasePath).Infof("exportJson")
 
 	connection, err := bolt.Open(databasePath, 0600, &bolt.Options{Timeout: 1 * time.Second, ReadOnly: true})
@@ -33,7 +32,7 @@ func exportJson(databasePath, passphrase string) ([]byte, error) {
 					continue
 				}
 				var obj interface{}
-				err := UnmarshalObject(v, &obj, passphrase)
+				err := UnmarshalObject(v, &obj, encryptionKey)
 				if err != nil {
 					logrus.WithError(err).Errorf("Failed to unmarshal (bucket %s): %v", bucketName, string(v))
 					obj = v

--- a/api/database/boltdb/export.go
+++ b/api/database/boltdb/export.go
@@ -10,7 +10,7 @@ import (
 
 // inspired by github.com/konoui/boltdb-exporter (which has no license)
 // but very much simplified, based on how we use boltdb
-func exportJson(databasePath string, encryptionKey []byte) ([]byte, error) {
+func (c *DbConnection) exportJson(databasePath string) ([]byte, error) {
 	logrus.WithField("databasePath", databasePath).Infof("exportJson")
 
 	connection, err := bolt.Open(databasePath, 0600, &bolt.Options{Timeout: 1 * time.Second, ReadOnly: true})
@@ -32,7 +32,7 @@ func exportJson(databasePath string, encryptionKey []byte) ([]byte, error) {
 					continue
 				}
 				var obj interface{}
-				err := UnmarshalObject(v, &obj, encryptionKey)
+				err := c.UnmarshalObject(v, &obj)
 				if err != nil {
 					logrus.WithError(err).Errorf("Failed to unmarshal (bucket %s): %v", bucketName, string(v))
 					obj = v

--- a/api/database/boltdb/json.go
+++ b/api/database/boltdb/json.go
@@ -8,117 +8,118 @@ import (
 	"fmt"
 	"io"
 
+	"log"
+
 	jsoniter "github.com/json-iterator/go"
-	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
-var encryptedStringTooShort = fmt.Errorf("encrypted string too short")
+var errEncryptedStringTooShort = fmt.Errorf("encrypted string too short")
 
 // MarshalObject encodes an object to binary format
-func MarshalObject(object interface{}, encryptionKey []byte) (data []byte, err error) {
-
+func (connection *DbConnection) MarshalObject(object interface{}) (data []byte, err error) {
 	// Special case for the VERSION bucket. Here we're not using json
 	if v, ok := object.(string); ok {
 		data = []byte(v)
 	} else {
 		data, err = json.Marshal(object)
 		if err != nil {
-			logrus.WithError(err).Errorf("failed marshaling object")
 			return data, err
 		}
 	}
-
-	if encryptionKey == nil {
+	if connection.getEncryptionKey() == nil {
 		return data, nil
 	}
-
-	return encrypt(data, encryptionKey)
+	return encrypt(data, connection.getEncryptionKey())
 }
 
 // UnmarshalObject decodes an object from binary data
-func UnmarshalObject(data []byte, object interface{}, encryptionKey []byte) error {
-
-	if encryptionKey != nil {
-		var err error
-		data, err = decrypt(data, encryptionKey)
+func (connection *DbConnection) UnmarshalObject(data []byte, object interface{}) error {
+	var err error
+	if connection.getEncryptionKey() != nil {
+		data, err = decrypt(data, connection.getEncryptionKey())
 		if err != nil {
-			logrus.WithError(err).Errorf("failed decrypting object")
-			return err
+			log.Println("failed decrypting object")
 		}
 	}
-
-	err := json.Unmarshal(data, object)
-	if err != nil {
+	e := json.Unmarshal(data, object)
+	if e != nil {
 		// Special case for the VERSION bucket. Here we're not using json
 		// So we need to return it as a string
 		s, ok := object.(*string)
 		if !ok {
-			return err
+			return errors.Wrap(err, e.Error())
 		}
 
 		*s = string(data)
 	}
-
-	return nil
+	return err
 }
 
 // UnmarshalObjectWithJsoniter decodes an object from binary data
 // using the jsoniter library. It is mainly used to accelerate environment(endpoint)
 // decoding at the moment.
-func UnmarshalObjectWithJsoniter(data []byte, object interface{}, encryptionKey []byte) error {
-
-	if encryptionKey != nil {
+func (connection *DbConnection) UnmarshalObjectWithJsoniter(data []byte, object interface{}) error {
+	if connection.getEncryptionKey() != nil {
 		var err error
-		data, err = decrypt(data, encryptionKey)
+		data, err = decrypt(data, connection.getEncryptionKey())
 		if err != nil {
-			logrus.WithError(err).Errorf("failed decrypting object")
 			return err
 		}
 	}
-
 	var jsoni = jsoniter.ConfigCompatibleWithStandardLibrary
 	return jsoni.Unmarshal(data, &object)
 }
 
-// We don't have a KMS... aes GCM seems the most likely from
+// mmm, don't have a KMS .... aes GCM seems the most likely from
 // https://gist.github.com/atoponce/07d8d4c833873be2f68c34f9afc5a78a#symmetric-encryption
-func encrypt(plaintext []byte, encryptionKey []byte) (encrypted []byte, err error) {
-	block, _ := aes.NewCipher([]byte(encryptionKey))
+
+func encrypt(plaintext []byte, passphrase []byte) (encrypted []byte, err error) {
+	block, _ := aes.NewCipher(passphrase)
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return encrypted, err
 	}
-
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
 		return encrypted, err
 	}
-
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+	ciphertextByte := gcm.Seal(
+		nonce,
+		nonce,
+		plaintext,
+		nil)
+	return ciphertextByte, nil
 }
 
-// On error, return the original byte array - it might be unencrypted...
-func decrypt(encrypted []byte, encryptionKey []byte) (plaintextByte []byte, err error) {
-	block, err := aes.NewCipher(encryptionKey)
+func decrypt(encrypted []byte, passphrase []byte) (plaintextByte []byte, err error) {
+	if string(encrypted) == "false" {
+		return []byte("false"), nil
+	}
+	block, err := aes.NewCipher(passphrase)
 	if err != nil {
-		return encrypted, err
+		return encrypted, errors.Wrap(err, "Error creating cypher block")
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return encrypted, err
+		return encrypted, errors.Wrap(err, "Error creating GCM")
 	}
 
 	nonceSize := gcm.NonceSize()
 	if len(encrypted) < nonceSize {
-		return encrypted, encryptedStringTooShort
+		return encrypted, errEncryptedStringTooShort
 	}
 
 	nonce, ciphertextByteClean := encrypted[:nonceSize], encrypted[nonceSize:]
-	plaintextByte, err = gcm.Open(nil, nonce, ciphertextByteClean, nil)
+	plaintextByte, err = gcm.Open(
+		nil,
+		nonce,
+		ciphertextByteClean,
+		nil)
 	if err != nil {
-		return encrypted, err
+		return encrypted, errors.Wrap(err, "Error decrypting text")
 	}
-
+	
 	return plaintextByte, err
 }

--- a/api/database/boltdb/json.go
+++ b/api/database/boltdb/json.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io"
 
-	"log"
-
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -39,7 +37,7 @@ func (connection *DbConnection) UnmarshalObject(data []byte, object interface{})
 	if connection.getEncryptionKey() != nil {
 		data, err = decrypt(data, connection.getEncryptionKey())
 		if err != nil {
-			log.Println("failed decrypting object")
+			errors.Wrapf(err, "Failed decrypting object")
 		}
 	}
 	e := json.Unmarshal(data, object)
@@ -120,6 +118,6 @@ func decrypt(encrypted []byte, passphrase []byte) (plaintextByte []byte, err err
 	if err != nil {
 		return encrypted, errors.Wrap(err, "Error decrypting text")
 	}
-	
+
 	return plaintextByte, err
 }

--- a/api/database/boltdb/json_test.go
+++ b/api/database/boltdb/json_test.go
@@ -82,9 +82,11 @@ func Test_MarshalObjectUnencrypted(t *testing.T) {
 		},
 	}
 
+	conn := DbConnection{}
+
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s -> %s", test.object, test.expected), func(t *testing.T) {
-			data, err := MarshalObject(test.object, nil)
+			data, err := conn.MarshalObject(test.object)
 			is.NoError(err)
 			is.Equal(test.expected, string(data))
 		})
@@ -120,10 +122,12 @@ func Test_UnMarshalObjectUnencrypted(t *testing.T) {
 		},
 	}
 
+	conn := DbConnection{}
+
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s -> %s", test.object, test.expected), func(t *testing.T) {
 			var object string
-			err := UnmarshalObject(test.object, &object, nil)
+			err := conn.UnmarshalObject(test.object, &object)
 			is.NoError(err)
 			is.Equal(test.expected, string(object))
 		})
@@ -156,14 +160,15 @@ func Test_ObjectMarshallingEncrypted(t *testing.T) {
 	}
 
 	key := secretToEncryptionKey(passphrase)
+	conn := DbConnection{EncryptionKey: key}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s -> %s", test.object, test.expected), func(t *testing.T) {
 
-			data, err := MarshalObject(test.object, key)
+			data, err := conn.MarshalObject(test.object)
 			is.NoError(err)
 
 			var object []byte
-			err = UnmarshalObject(data, &object, key)
+			err = conn.UnmarshalObject(data, &object)
 
 			is.NoError(err)
 			is.Equal(test.object, object)

--- a/api/database/boltdb/json_test.go
+++ b/api/database/boltdb/json_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const jsonobject = `{"LogoURL":"","BlackListedLabels":[],"AuthenticationMethod":1,"LDAPSettings":{"AnonymousMode":true,"ReaderDN":"","URL":"","TLSConfig":{"TLS":false,"TLSSkipVerify":false},"StartTLS":false,"SearchSettings":[{"BaseDN":"","Filter":"","UserNameAttribute":""}],"GroupSearchSettings":[{"GroupBaseDN":"","GroupFilter":"","GroupAttribute":""}],"AutoCreateUsers":true},"OAuthSettings":{"ClientID":"","AccessTokenURI":"","AuthorizationURI":"","ResourceURI":"","RedirectURI":"","UserIdentifier":"","Scopes":"","OAuthAutoCreateUsers":false,"DefaultTeamID":0,"SSO":true,"LogoutURI":"","KubeSecretKey":"j0zLVtY/lAWBk62ByyF0uP80SOXaitsABP0TTJX8MhI="},"OpenAMTConfiguration":{"Enabled":false,"MPSServer":"","Credentials":{"MPSUser":"","MPSPassword":"","MPSToken":""},"DomainConfiguration":{"CertFileText":"","CertPassword":"","DomainName":""},"WirelessConfiguration":null},"FeatureFlagSettings":{},"SnapshotInterval":"5m","TemplatesURL":"https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json","EdgeAgentCheckinInterval":5,"EnableEdgeComputeFeatures":false,"UserSessionTimeout":"8h","KubeconfigExpiry":"0","EnableTelemetry":true,"HelmRepositoryURL":"https://charts.bitnami.com/bitnami","KubectlShellImage":"portainer/kubectl-shell","DisplayDonationHeader":false,"DisplayExternalContributors":false,"EnableHostManagementFeatures":false,"AllowVolumeBrowserForRegularUsers":false,"AllowBindMountsForRegularUsers":false,"AllowPrivilegedModeForRegularUsers":false,"AllowHostNamespaceForRegularUsers":false,"AllowStackManagementForRegularUsers":false,"AllowDeviceMappingForRegularUsers":false,"AllowContainerCapabilitiesForRegularUsers":false}`
+const (
+	jsonobject = `{"LogoURL":"","BlackListedLabels":[],"AuthenticationMethod":1,"LDAPSettings":{"AnonymousMode":true,"ReaderDN":"","URL":"","TLSConfig":{"TLS":false,"TLSSkipVerify":false},"StartTLS":false,"SearchSettings":[{"BaseDN":"","Filter":"","UserNameAttribute":""}],"GroupSearchSettings":[{"GroupBaseDN":"","GroupFilter":"","GroupAttribute":""}],"AutoCreateUsers":true},"OAuthSettings":{"ClientID":"","AccessTokenURI":"","AuthorizationURI":"","ResourceURI":"","RedirectURI":"","UserIdentifier":"","Scopes":"","OAuthAutoCreateUsers":false,"DefaultTeamID":0,"SSO":true,"LogoutURI":"","KubeSecretKey":"j0zLVtY/lAWBk62ByyF0uP80SOXaitsABP0TTJX8MhI="},"OpenAMTConfiguration":{"Enabled":false,"MPSServer":"","Credentials":{"MPSUser":"","MPSPassword":"","MPSToken":""},"DomainConfiguration":{"CertFileText":"","CertPassword":"","DomainName":""},"WirelessConfiguration":null},"FeatureFlagSettings":{},"SnapshotInterval":"5m","TemplatesURL":"https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json","EdgeAgentCheckinInterval":5,"EnableEdgeComputeFeatures":false,"UserSessionTimeout":"8h","KubeconfigExpiry":"0","EnableTelemetry":true,"HelmRepositoryURL":"https://charts.bitnami.com/bitnami","KubectlShellImage":"portainer/kubectl-shell","DisplayDonationHeader":false,"DisplayExternalContributors":false,"EnableHostManagementFeatures":false,"AllowVolumeBrowserForRegularUsers":false,"AllowBindMountsForRegularUsers":false,"AllowPrivilegedModeForRegularUsers":false,"AllowHostNamespaceForRegularUsers":false,"AllowStackManagementForRegularUsers":false,"AllowDeviceMappingForRegularUsers":false,"AllowContainerCapabilitiesForRegularUsers":false}`
+	passphrase = "apassphrasewhichneedstobe32bytes"
+)
 
 func Test_MarshalObject(t *testing.T) {
 	is := assert.New(t)
@@ -75,7 +78,7 @@ func Test_MarshalObject(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s -> %s", test.object, test.expected), func(t *testing.T) {
-			data, err := MarshalObject(test.object)
+			data, err := MarshalObject(test.object, passphrase)
 			is.NoError(err)
 			is.Equal(test.expected, string(data))
 		})
@@ -114,7 +117,7 @@ func Test_UnMarshalObject(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s -> %s", test.object, test.expected), func(t *testing.T) {
 			var object string
-			err := UnmarshalObject(test.object, &object)
+			err := UnmarshalObject(test.object, &object, passphrase)
 			is.NoError(err)
 			is.Equal(test.expected, string(object))
 		})

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -2,15 +2,19 @@ package database
 
 import (
 	"fmt"
+
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/database/boltdb"
 )
 
 // NewDatabase should use config options to return a connection to the requested database
-func NewDatabase(storeType, storePath string) (connection portainer.Connection, err error) {
+func NewDatabase(storeType, storePath, encryptionKey string) (connection portainer.Connection, err error) {
 	switch storeType {
 	case "boltdb":
-		return &boltdb.DbConnection{Path: storePath}, nil
+		return &boltdb.DbConnection{
+			Path:          storePath,
+			EncryptionKey: encryptionKey,
+		}, nil
 	}
-	return nil, fmt.Errorf("Unknown storage database: %s", storeType)
+	return nil, fmt.Errorf("unknown storage database: %s", storeType)
 }

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewDatabase should use config options to return a connection to the requested database
-func NewDatabase(storeType, storePath, encryptionKey string) (connection portainer.Connection, err error) {
+func NewDatabase(storeType, storePath string, encryptionKey []byte) (connection portainer.Connection, err error) {
 	switch storeType {
 	case "boltdb":
 		return &boltdb.DbConnection{

--- a/api/dataservices/endpoint/endpoint.go
+++ b/api/dataservices/endpoint/endpoint.go
@@ -69,7 +69,7 @@ func (service *Service) Endpoints() ([]portainer.Endpoint, error) {
 			endpoint, ok := obj.(*portainer.Endpoint)
 			if !ok {
 				logrus.WithField("obj", obj).Errorf("Failed to convert to Endpoint object")
-				return nil, fmt.Errorf("Failed to convert to Endpoint object: %s", obj)
+				return nil, fmt.Errorf("failed to convert to Endpoint object: %s", obj)
 			}
 			endpoints = append(endpoints, *endpoint)
 			return &portainer.Endpoint{}, nil

--- a/api/dataservices/errors/errors.go
+++ b/api/dataservices/errors/errors.go
@@ -4,6 +4,7 @@ import "errors"
 
 var (
 	// TODO: i'm pretty sure this needs wrapping at several levels
-	ErrObjectNotFound = errors.New("Object not found inside the database")
-	ErrWrongDBEdition = errors.New("The Portainer database is set for Portainer Business Edition, please follow the instructions in our documentation to downgrade it: https://documentation.portainer.io/v2.0-be/downgrade/be-to-ce/")
+	ErrObjectNotFound = errors.New("object not found inside the database")
+	ErrWrongDBEdition = errors.New("the Portainer database is set for Portainer Business Edition, please follow the instructions in our documentation to downgrade it: https://documentation.portainer.io/v2.0-be/downgrade/be-to-ce/")
+	ErrDBImportFailed = errors.New("importing backup failed")
 )

--- a/api/dataservices/helmuserrepository/helmuserrepository.go
+++ b/api/dataservices/helmuserrepository/helmuserrepository.go
@@ -34,7 +34,7 @@ func NewService(connection portainer.Connection) (*Service, error) {
 }
 
 //HelmUserRepository returns an array of all HelmUserRepository
-func (service *Service) HelmUserRepositorys() ([]portainer.HelmUserRepository, error) {
+func (service *Service) HelmUserRepositories() ([]portainer.HelmUserRepository, error) {
 	var repos = make([]portainer.HelmUserRepository, 0)
 
 	err := service.connection.GetAll(

--- a/api/dataservices/interface.go
+++ b/api/dataservices/interface.go
@@ -124,7 +124,7 @@ type (
 
 	// HelmUserRepositoryService represents a service to manage HelmUserRepositories
 	HelmUserRepositoryService interface {
-		HelmUserRepositorys() ([]portainer.HelmUserRepository, error)
+		HelmUserRepositories() ([]portainer.HelmUserRepository, error)
 		HelmUserRepositoryByUserID(userID portainer.UserID) ([]portainer.HelmUserRepository, error)
 		Create(record *portainer.HelmUserRepository) error
 		UpdateHelmUserRepository(ID portainer.HelmUserRepositoryID, repository *portainer.HelmUserRepository) error

--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -35,7 +35,7 @@ func (store *Store) createBackupFolders() {
 }
 
 func (store *Store) databasePath() string {
-	return path.Join(store.connection.GetStorePath(), store.connection.GetDatabaseFilename())
+	return store.connection.GetDatabaseFilename(true)
 }
 
 func (store *Store) commonBackupDir() string {
@@ -84,7 +84,7 @@ func (store *Store) setupOptions(options *BackupOptions) *BackupOptions {
 		options.BackupDir = store.commonBackupDir()
 	}
 	if options.BackupFileName == "" {
-		options.BackupFileName = fmt.Sprintf("%s.%s.%s", store.connection.GetDatabaseFilename(), fmt.Sprintf("%03d", options.Version), time.Now().Format("20060102150405"))
+		options.BackupFileName = fmt.Sprintf("%s.%s.%s", store.connection.GetDatabaseFilename(false), fmt.Sprintf("%03d", options.Version), time.Now().Format("20060102150405"))
 	}
 	if options.BackupPath == "" {
 		options.BackupPath = path.Join(options.BackupDir, options.BackupFileName)

--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -35,7 +35,7 @@ func (store *Store) createBackupFolders() {
 }
 
 func (store *Store) databasePath() string {
-	return store.connection.GetDatabaseFilename(true)
+	return store.connection.GetDatabaseFilePath()
 }
 
 func (store *Store) commonBackupDir() string {
@@ -84,7 +84,7 @@ func (store *Store) setupOptions(options *BackupOptions) *BackupOptions {
 		options.BackupDir = store.commonBackupDir()
 	}
 	if options.BackupFileName == "" {
-		options.BackupFileName = fmt.Sprintf("%s.%s.%s", store.connection.GetDatabaseFilename(false), fmt.Sprintf("%03d", options.Version), time.Now().Format("20060102150405"))
+		options.BackupFileName = fmt.Sprintf("%s.%s.%s", store.connection.GetDatabaseFileName(), fmt.Sprintf("%03d", options.Version), time.Now().Format("20060102150405"))
 	}
 	if options.BackupPath == "" {
 		options.BackupPath = path.Join(options.BackupDir, options.BackupFileName)

--- a/api/datastore/backup_test.go
+++ b/api/datastore/backup_test.go
@@ -48,7 +48,7 @@ func TestBackup(t *testing.T) {
 		store.VersionService.StoreDBVersion(portainer.DBVersion)
 		store.backupWithOptions(nil)
 
-		backupFileName := path.Join(connection.GetStorePath(), "backups", "common", fmt.Sprintf("portainer.db.%03d.*", portainer.DBVersion))
+		backupFileName := path.Join(connection.GetStorePath(), "backups", "common", fmt.Sprintf("portainer.edb.%03d.*", portainer.DBVersion))
 		if !isFileExist(backupFileName) {
 			t.Errorf("Expect backup file to be created %s", backupFileName)
 		}

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -111,7 +111,7 @@ func (store *Store) encryptDB() error {
 
 	// The DB is not currently encrypted.  First save the encrypted db filename
 	oldFilename := store.connection.GetDatabaseFilePath()
-	logrus.Infof("Encrypting database...")
+	logrus.Infof("Encrypting database")
 
 	// export file path for backup
 	exportFilename := path.Join(store.databasePath() + "." + fmt.Sprintf("backup-%d.json", time.Now().Unix()))
@@ -119,7 +119,7 @@ func (store *Store) encryptDB() error {
 	logrus.Infof("Exporting database backup to %s", exportFilename)
 	err = store.Export(exportFilename)
 	if err != nil {
-		logrus.WithError(err).Debugf("failed to export to %s", exportFilename)
+		logrus.WithError(err).Debugf("Failed to export to %s", exportFilename)
 		return err
 	}
 
@@ -147,7 +147,12 @@ func (store *Store) encryptDB() error {
 
 	err = os.Remove(oldFilename)
 	if err != nil {
-		logrus.Errorf("failed to remove the un-encrypted db file")
+		logrus.Errorf("Failed to remove the un-encrypted db file")
+	}
+
+	err = os.Remove(exportFilename)
+	if err != nil {
+		logrus.Errorf("Failed to remove the json backup file")
 	}
 
 	// Close db connection

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -92,7 +92,7 @@ func (store *Store) Rollback(force bool) error {
 
 func (store *Store) encryptDB() error {
 	// The DB is not currently encrypted.  First save the encrypted db filename
-	oldFilename := store.connection.GetDatabaseFilename(true)
+	oldFilename := store.connection.GetDatabaseFilePath()
 	logrus.Infof("Encrypting database...")
 
 	// export file path for backup
@@ -123,7 +123,7 @@ func (store *Store) encryptDB() error {
 	err = store.Import(exportFilename)
 	if err != nil {
 		// Remove the new encrypted file that we failed to import
-		os.Remove(store.connection.GetDatabaseFilename(true))
+		os.Remove(store.connection.GetDatabaseFilePath())
 		logrus.Fatal(errors.ErrDBImportFailed.Error())
 	}
 

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -99,7 +99,7 @@ func (store *Store) encryptDB() error {
 	// Since database is not encrypted so
 	// settings this flag to false will not
 	// allow connection to use encryption key
-	store.connection.SetIsDBEncryptedFlag(false)
+	store.connection.SetIsEncryptedFlag(false)
 	err := store.initServices()
 	if err != nil {
 		logrus.Fatal("init services failed")
@@ -118,7 +118,7 @@ func (store *Store) encryptDB() error {
 	logrus.Infof("database backup exported")
 
 	// Set isDBEncryptedFlag to true to import JSON in the encrypted format
-	store.connection.SetIsDBEncryptedFlag(true)
+	store.connection.SetIsEncryptedFlag(true)
 	err = store.Import(exportFilename)
 	if err != nil {
 		logrus.Fatal(errors.ErrDBImportFailed.Error()) // TODO: Rollback?

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -130,13 +130,11 @@ func (store *Store) encryptDB() error {
 		os.Remove(store.connection.GetDatabaseFilename(true))
 	}
 
-	logrus.Info("Database successfully encrypted")
-
-	// TODO: Delete the unencrypted db file
 	err = os.Remove(oldFilename)
 	if err != nil {
 		logrus.Errorf("failed to remove the un-encrypted db file")
 	}
 
+	logrus.Info("Database successfully encrypted")
 	return nil
 }

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -40,7 +40,7 @@ func NewStore(storePath string, fileService portainer.FileService, connection po
 func (store *Store) Open() (newStore bool, err error) {
 	newStore = true
 
-	encryptionReq := store.connection.DoesStoreNeedEncryption()
+	encryptionReq := store.connection.NeedsEncryptionMigration()
 	if encryptionReq {
 		store.encryptDB()
 	}
@@ -102,9 +102,12 @@ func (store *Store) Rollback(force bool) error {
 
 func (store *Store) encryptDB() error {
 	store.connection.SetEncrypted(false)
-	store.connection.Open()
+	err := store.connection.Open()
+	if err != nil {
+		return err
+	}
 
-	err := store.initServices()
+	err = store.initServices()
 	if err != nil {
 		return err
 	}

--- a/api/datastore/services.go
+++ b/api/datastore/services.go
@@ -426,7 +426,7 @@ func (store *Store) Export(filename string) (err error) {
 		backup.Extensions = r
 	}
 
-	if r, err := store.HelmUserRepository().HelmUserRepositorys(); err != nil {
+	if r, err := store.HelmUserRepository().HelmUserRepositories(); err != nil {
 		if !store.IsErrObjectNotFound(err) {
 			logrus.WithError(err).Errorf("Exporting Helm User Repositories")
 		}

--- a/api/datastore/services.go
+++ b/api/datastore/services.go
@@ -363,118 +363,184 @@ func (store *Store) Export(filename string) (err error) {
 	backup := storeExport{}
 
 	if c, err := store.CustomTemplate().CustomTemplates(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Custom Templates")
+		}
 	} else {
 		backup.CustomTemplate = c
 	}
+
 	if e, err := store.EdgeGroup().EdgeGroups(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Edge Groups")
+		}
 	} else {
 		backup.EdgeGroup = e
 	}
+
 	if e, err := store.EdgeJob().EdgeJobs(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Edge Jobs")
+		}
 	} else {
 		backup.EdgeJob = e
 	}
+
 	if e, err := store.EdgeStack().EdgeStacks(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Edge Stacks")
+		}
 	} else {
 		backup.EdgeStack = e
 	}
+
 	if e, err := store.Endpoint().Endpoints(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Endpoints")
+		}
 	} else {
 		backup.Endpoint = e
 	}
+
 	if e, err := store.EndpointGroup().EndpointGroups(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Endpoint Groups")
+		}
 	} else {
 		backup.EndpointGroup = e
 	}
+
 	if r, err := store.EndpointRelation().EndpointRelations(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Endpoint Relations")
+		}
 	} else {
 		backup.EndpointRelation = r
 	}
+
 	if r, err := store.ExtensionService.Extensions(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Extensions")
+		}
 	} else {
 		backup.Extensions = r
 	}
+
 	if r, err := store.HelmUserRepository().HelmUserRepositorys(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Helm User Repositories")
+		}
 	} else {
 		backup.HelmUserRepository = r
 	}
+
 	if r, err := store.Registry().Registries(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Registries")
+		}
 	} else {
 		backup.Registry = r
 	}
+
 	if c, err := store.ResourceControl().ResourceControls(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Resource Controls")
+		}
 	} else {
 		backup.ResourceControl = c
 	}
+
 	if role, err := store.Role().Roles(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Roles")
+		}
 	} else {
 		backup.Role = role
 	}
+
 	if r, err := store.ScheduleService.Schedules(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Schedules")
+		}
 	} else {
 		backup.Schedules = r
 	}
+
 	if settings, err := store.Settings().Settings(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Settings")
+		}
 	} else {
 		backup.Settings = *settings
 	}
+
 	if settings, err := store.SSLSettings().Settings(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting SSL Settings")
+		}
 	} else {
 		backup.SSLSettings = *settings
 	}
+
 	if t, err := store.Stack().Stacks(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Stacks")
+		}
 	} else {
 		backup.Stack = t
 	}
+
 	if t, err := store.Tag().Tags(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Tags")
+		}
 	} else {
 		backup.Tag = t
 	}
+
 	if t, err := store.TeamMembership().TeamMemberships(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Team Memberships")
+		}
 	} else {
 		backup.TeamMembership = t
 	}
+
 	if t, err := store.Team().Teams(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Teams")
+		}
 	} else {
 		backup.Team = t
 	}
+
 	if info, err := store.TunnelServer().Info(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Tunnel Server")
+		}
 	} else {
 		backup.TunnelServer = *info
 	}
+
 	if users, err := store.User().Users(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Users")
+		}
 	} else {
 		backup.User = users
 	}
+
 	if webhooks, err := store.Webhook().Webhooks(); err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+		if !store.IsErrObjectNotFound(err) {
+			logrus.WithError(err).Errorf("Exporting Webhooks")
+		}
 	} else {
 		backup.Webhook = webhooks
 	}
+
 	v, err := store.Version().DBVersion()
-	if err != nil {
-		logrus.WithError(err).Debugf("Export boom")
+	if err != nil && !store.IsErrObjectNotFound(err) {
+		logrus.WithError(err).Errorf("Exporting DB version")
 	}
 	instance, _ := store.Version().InstanceID()
 	backup.Version = map[string]string{
@@ -518,50 +584,66 @@ func (store *Store) Import(filename string) (err error) {
 	for _, v := range backup.CustomTemplate {
 		store.CustomTemplate().UpdateCustomTemplate(v.ID, &v)
 	}
+
 	for _, v := range backup.EdgeGroup {
 		store.EdgeGroup().UpdateEdgeGroup(v.ID, &v)
 	}
+
 	for _, v := range backup.EdgeJob {
 		store.EdgeJob().UpdateEdgeJob(v.ID, &v)
 	}
+
 	for _, v := range backup.EdgeStack {
 		store.EdgeStack().UpdateEdgeStack(v.ID, &v)
 	}
+
 	for _, v := range backup.Endpoint {
 		store.Endpoint().UpdateEndpoint(v.ID, &v)
 	}
+
 	for _, v := range backup.EndpointGroup {
 		store.EndpointGroup().UpdateEndpointGroup(v.ID, &v)
 	}
+
 	for _, v := range backup.EndpointRelation {
 		store.EndpointRelation().UpdateEndpointRelation(v.EndpointID, &v)
 	}
+
 	for _, v := range backup.HelmUserRepository {
 		store.HelmUserRepository().UpdateHelmUserRepository(v.ID, &v)
 	}
+
 	for _, v := range backup.Registry {
 		store.Registry().UpdateRegistry(v.ID, &v)
 	}
+
 	for _, v := range backup.ResourceControl {
 		store.ResourceControl().UpdateResourceControl(v.ID, &v)
 	}
+
 	for _, v := range backup.Role {
 		store.Role().UpdateRole(v.ID, &v)
 	}
+
 	store.Settings().UpdateSettings(&backup.Settings)
 	store.SSLSettings().UpdateSettings(&backup.SSLSettings)
+
 	for _, v := range backup.Stack {
 		store.Stack().UpdateStack(v.ID, &v)
 	}
+
 	for _, v := range backup.Tag {
 		store.Tag().UpdateTag(v.ID, &v)
 	}
+
 	for _, v := range backup.TeamMembership {
 		store.TeamMembership().UpdateTeamMembership(v.ID, &v)
 	}
+
 	for _, v := range backup.Team {
 		store.Team().UpdateTeam(v.ID, &v)
 	}
+
 	store.TunnelServer().UpdateInfo(&backup.TunnelServer)
 
 	for _, user := range backup.User {
@@ -570,10 +652,9 @@ func (store *Store) Import(filename string) (err error) {
 		}
 	}
 
-	// backup[store.Webhook().BucketName()], err = store.Webhook().Webhooks()
-	// if err != nil {
-	// 	logrus.WithError(err).Debugf("Export boom")
-	// }
+	for _, v := range backup.Webhook {
+		store.Webhook().UpdateWebhook(v.ID, &v)
+	}
 
 	return nil
 }

--- a/api/datastore/teststore.go
+++ b/api/datastore/teststore.go
@@ -42,7 +42,7 @@ func NewTestStore(init bool) (bool, *Store, func(), error) {
 		return false, nil, nil, err
 	}
 
-	connection, err := database.NewDatabase("boltdb", storePath, "apassphrasewhichneedstobe32bytes")
+	connection, err := database.NewDatabase("boltdb", storePath, []byte("apassphrasewhichneedstobe32bytes"))
 	if err != nil {
 		panic(err)
 	}

--- a/api/datastore/teststore.go
+++ b/api/datastore/teststore.go
@@ -42,7 +42,7 @@ func NewTestStore(init bool) (bool, *Store, func(), error) {
 		return false, nil, nil, err
 	}
 
-	connection, err := database.NewDatabase("boltdb", storePath)
+	connection, err := database.NewDatabase("boltdb", storePath, "apassphrasewhichneedstobe32bytes")
 	if err != nil {
 		panic(err)
 	}

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -97,6 +97,7 @@ type (
 		Rollback                  *bool
 		SnapshotInterval          *string
 		BaseURL                   *string
+		SecretKeyName             *string
 	}
 
 	// CustomTemplate represents a custom template


### PR DESCRIPTION
Working implementation of [EE-1852](https://portainer.atlassian.net/browse/EE-1852) - portainer.db encryption

Supports:
  - Portainer secret is loaded from `/run/secrets/portainer`
  - Bootstrapping directly to a new encrypted db if the secret is present and Portainer started for the first time
  - Migrating an unencrypted db to an encrypted `portainer.edb` by creating a secret.

