### PR TITLE
fix(registries): sync code with ee [EE-2176]

### DIFF
--- a/api/http/proxy/factory/gitlab/transport.go
+++ b/api/http/proxy/factory/gitlab/transport.go
@@ -24,7 +24,7 @@ func (transport *Transport) RoundTrip(request *http.Request) (*http.Response, er
 		return nil, errors.New("no gitlab token provided")
 	}
 
-	r, err := http.NewRequest(request.Method, request.URL.String(), nil)
+	r, err := http.NewRequest(request.Method, request.URL.String(), request.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes [EE-2176]

this passes the request body to gitlab registry proxy.

for QA: need to check that gitlab registry is still working right on CE

[EE-2176]: https://portainer.atlassian.net/browse/EE-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ