### PR TITLE
fix(backup) use correct backup db file name EE-2413

### DIFF
--- a/api/backup/backup.go
+++ b/api/backup/backup.go
@@ -80,7 +80,8 @@ func CreateBackupArchive(password string, gate *offlinegate.OfflineGate, datasto
 }
 
 func backupDb(backupDirPath string, datastore dataservices.DataStore) error {
-	backupWriter, err := os.Create(filepath.Join(backupDirPath, "portainer.db"))
+	dbFileName := datastore.Connection().GetDatabaseFileName()
+	backupWriter, err := os.Create(filepath.Join(backupDirPath, dbFileName))
 	if err != nil {
 		return err
 	}

--- a/api/backup/restore.go
+++ b/api/backup/restore.go
@@ -15,7 +15,7 @@ import (
 	"github.com/portainer/portainer/api/http/offlinegate"
 )
 
-var filesToRestore = append(filesToBackup, "portainer.db")
+var filesToRestore = filesToBackup
 
 // Restores system state from backup archive, will trigger system shutdown, when finished.
 func RestoreArchive(archive io.Reader, password string, filestorePath string, gate *offlinegate.OfflineGate, datastore dataservices.DataStore, shutdownTrigger context.CancelFunc) error {

--- a/api/backup/restore.go
+++ b/api/backup/restore.go
@@ -42,7 +42,8 @@ func RestoreArchive(archive io.Reader, password string, filestorePath string, ga
 		return errors.Wrap(err, "Failed to stop db")
 	}
 
-	if err = restoreFiles(restorePath, filestorePath); err != nil {
+	dbFile := datastore.Connection().GetDatabaseFileName()
+	if err = restoreFiles(restorePath, filestorePath, dbFile); err != nil {
 		return errors.Wrap(err, "failed to restore the system state")
 	}
 
@@ -58,12 +59,13 @@ func extractArchive(r io.Reader, destinationDirPath string) error {
 	return archive.ExtractTarGz(r, destinationDirPath)
 }
 
-func restoreFiles(srcDir string, destinationDir string) error {
+func restoreFiles(srcDir string, destinationDir string, databaseFile string) error {
 	for _, filename := range filesToRestore {
 		err := filesystem.CopyPath(filepath.Join(srcDir, filename), destinationDir)
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+
+	return filesystem.CopyPath(filepath.Join(srcDir, databaseFile), destinationDir)
 }

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -9,9 +9,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/portainer/libhelm"
 	portainer "github.com/portainer/portainer/api"
@@ -129,16 +126,6 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 	go func() {
 		<-shutdownCtx.Done()
 		defer connection.Close()
-
-		exportFilename := path.Join(*flags.Data, fmt.Sprintf("export-%d.json", time.Now().Unix()))
-
-		err := store.Export(exportFilename)
-		if err != nil {
-			logrus.WithError(err).Debugf("Failed to export to %s", exportFilename)
-		} else {
-			logrus.Debugf("exported to %s", exportFilename)
-		}
-		connection.Close()
 	}()
 	return store
 }

--- a/api/dataservices/interface.go
+++ b/api/dataservices/interface.go
@@ -23,6 +23,7 @@ type (
 		BackupTo(w io.Writer) error
 		Export(filename string) (err error)
 		IsErrObjectNotFound(err error) bool
+		Connection() portainer.Connection
 
 		CustomTemplate() CustomTemplateService
 		EdgeGroup() EdgeGroupService

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -96,6 +96,10 @@ func (store *Store) IsErrObjectNotFound(e error) bool {
 	return e == portainerErrors.ErrObjectNotFound
 }
 
+func (store *Store) Connection() portainer.Connection {
+	return store.connection
+}
+
 func (store *Store) Rollback(force bool) error {
 	return store.connectionRollback(force)
 }

--- a/api/internal/testhelpers/datastore.go
+++ b/api/internal/testhelpers/datastore.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/database"
 	"github.com/portainer/portainer/api/dataservices"
 	"github.com/portainer/portainer/api/dataservices/errors"
 )
@@ -31,6 +32,7 @@ type testDatastore struct {
 	user                    dataservices.UserService
 	version                 dataservices.VersionService
 	webhook                 dataservices.WebhookService
+	connection              portainer.Connection
 }
 
 func (d *testDatastore) BackupTo(io.Writer) error                           { return nil }
@@ -75,6 +77,10 @@ func (d *testDatastore) IsErrObjectNotFound(e error) bool {
 	return false
 }
 
+func (d *testDatastore) Connection() portainer.Connection {
+	return d.connection
+}
+
 func (d *testDatastore) Export(filename string) (err error) {
 	return nil
 }
@@ -87,10 +93,12 @@ type datastoreOption = func(d *testDatastore)
 // NewDatastore creates new instance of testDatastore.
 // Will apply options before returning, opts will be applied from left to right.
 func NewDatastore(options ...datastoreOption) *testDatastore {
-	d := testDatastore{}
+	conn, _ := database.NewDatabase("boltdb", "", nil)
+	d := testDatastore{connection: conn}
 	for _, o := range options {
 		o(&d)
 	}
+
 	return &d
 }
 


### PR DESCRIPTION
Resolves [EE-2413](https://portainer.atlassian.net/browse/EE-2413)

Exposes the connection object to the data services layer so that we can query the correct db filename for creating the backup