### PR TITLE
fix(docker): delete docker resources [EE-2411]

### DIFF
--- a/api/http/proxy/factory/docker/transport.go
+++ b/api/http/proxy/factory/docker/transport.go
@@ -16,6 +16,7 @@ import (
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/dataservices"
+	dataerrors "github.com/portainer/portainer/api/dataservices/errors"
 	"github.com/portainer/portainer/api/docker"
 	"github.com/portainer/portainer/api/http/proxy/factory/utils"
 	"github.com/portainer/portainer/api/http/security"
@@ -601,6 +602,10 @@ func (transport *Transport) executeGenericResourceDeletionOperation(request *htt
 	if response.StatusCode == http.StatusNoContent || response.StatusCode == http.StatusOK {
 		resourceControl, err := transport.dataStore.ResourceControl().ResourceControlByResourceIDAndType(resourceIdentifierAttribute, resourceType)
 		if err != nil {
+			if err == dataerrors.ErrObjectNotFound {
+				return response, nil
+			}
+
 			return response, err
 		}
 


### PR DESCRIPTION
fixes [EE-2411]

ignore resource control object not found when deleting a docker resource

[EE-2411]: https://portainer.atlassian.net/browse/EE-2411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ