### PR TITLE
fix(home): axios base url fix

### DIFF
--- a/app/portainer/services/axios.ts
+++ b/app/portainer/services/axios.ts
@@ -8,7 +8,7 @@ import {
   portainerAgentTargetHeader,
 } from './http-request.helper';
 
-const axiosApiInstance = axios.create({ baseURL: '/api' });
+const axiosApiInstance = axios.create({ baseURL: 'api' });
 
 export default axiosApiInstance;
 


### PR DESCRIPTION
To support portainer running under a subdirectory such as  `https://xyz.com/portainer`, fixed API base URL in axios.ts