### PR TITLE
fix(settings): updateSettingsFromFlags only if dataStore is new [EE-2397]

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -50,7 +50,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		SSLCert:                   kingpin.Flag("sslcert", "Path to the SSL certificate used to secure the Portainer instance").String(),
 		SSLKey:                    kingpin.Flag("sslkey", "Path to the SSL key used to secure the Portainer instance").String(),
 		Rollback:                  kingpin.Flag("rollback", "Rollback the database store to the previous version").Bool(),
-		SnapshotInterval:          kingpin.Flag("snapshot-interval", "Duration between each environment snapshot job").Default(defaultSnapshotInterval).String(),
+		SnapshotInterval:          kingpin.Flag("snapshot-interval", "Duration between each environment snapshot job").String(),
 		AdminPassword:             kingpin.Flag("admin-password", "Hashed admin password").String(),
 		AdminPasswordFile:         kingpin.Flag("admin-password-file", "Path to the file containing the password for the admin user").String(),
 		Labels:                    pairs(kingpin.Flag("hide-label", "Hide containers with a specific label in the UI").Short('l')),
@@ -129,7 +129,7 @@ func validateEndpointURL(endpointURL string) error {
 }
 
 func validateSnapshotInterval(snapshotInterval string) error {
-	if snapshotInterval != defaultSnapshotInterval {
+	if snapshotInterval != "" {
 		_, err := time.ParseDuration(snapshotInterval)
 		if err != nil {
 			return errInvalidSnapshotInterval

--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -20,7 +20,6 @@ const (
 	defaultSSL                 = "false"
 	defaultSSLCertPath         = "/certs/portainer.crt"
 	defaultSSLKeyPath          = "/certs/portainer.key"
-	defaultSnapshotInterval    = "5m"
 	defaultBaseURL             = "/"
 	defaultSecretKeyName       = "portainer"
 )

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -95,7 +95,7 @@ func initDataStore(flags *portainer.CLIFlags, secretKey []byte, fileService port
 		return nil
 	}
 
-	// Init sets some defaults - its basically a migration
+	// Init sets some defaults - it's basically a migration
 	err = store.Init()
 	if err != nil {
 		logrus.Fatalf("Failed initializing data store: %v", err)
@@ -209,11 +209,11 @@ func initKubernetesClientFactory(signatureService portainer.DigitalSignatureServ
 	return kubecli.NewClientFactory(signatureService, reverseTunnelService, instanceID, dataStore)
 }
 
-func initSnapshotService(snapshotInterval string, dataStore dataservices.DataStore, dockerClientFactory *docker.ClientFactory, kubernetesClientFactory *kubecli.ClientFactory, shutdownCtx context.Context) (portainer.SnapshotService, error) {
+func initSnapshotService(snapshotIntervalFromFlag string, dataStore dataservices.DataStore, dockerClientFactory *docker.ClientFactory, kubernetesClientFactory *kubecli.ClientFactory, shutdownCtx context.Context) (portainer.SnapshotService, error) {
 	dockerSnapshotter := docker.NewSnapshotter(dockerClientFactory)
 	kubernetesSnapshotter := kubernetes.NewSnapshotter(kubernetesClientFactory)
 
-	snapshotService, err := snapshot.NewService(snapshotInterval, dataStore, dockerSnapshotter, kubernetesSnapshotter, shutdownCtx)
+	snapshotService, err := snapshot.NewService(snapshotIntervalFromFlag, dataStore, dockerSnapshotter, kubernetesSnapshotter, shutdownCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -234,11 +234,17 @@ func updateSettingsFromFlags(dataStore dataservices.DataStore, flags *portainer.
 		return err
 	}
 
-	settings.LogoURL = *flags.Logo
-	settings.SnapshotInterval = *flags.SnapshotInterval
-	settings.EnableEdgeComputeFeatures = *flags.EnableEdgeComputeFeatures
-	settings.EnableTelemetry = true
-	settings.OAuthSettings.SSO = true
+	if *flags.SnapshotInterval != "" {
+		settings.SnapshotInterval = *flags.SnapshotInterval
+	}
+
+	if *flags.Logo != "" {
+		settings.LogoURL = *flags.Logo
+	}
+
+	if *flags.EnableEdgeComputeFeatures {
+		settings.EnableEdgeComputeFeatures = *flags.EnableEdgeComputeFeatures
+	}
 
 	if *flags.Templates != "" {
 		settings.TemplatesURL = *flags.Templates

--- a/api/internal/snapshot/snapshot.go
+++ b/api/internal/snapshot/snapshot.go
@@ -23,19 +23,37 @@ type Service struct {
 }
 
 // NewService creates a new instance of a service
-func NewService(snapshotInterval string, dataStore dataservices.DataStore, dockerSnapshotter portainer.DockerSnapshotter, kubernetesSnapshotter portainer.KubernetesSnapshotter, shutdownCtx context.Context) (*Service, error) {
-	snapshotFrequency, err := time.ParseDuration(snapshotInterval)
+func NewService(snapshotIntervalFromFlag string, dataStore dataservices.DataStore, dockerSnapshotter portainer.DockerSnapshotter, kubernetesSnapshotter portainer.KubernetesSnapshotter, shutdownCtx context.Context) (*Service, error) {
+	snapshotFrequency, err := parseSnapshotFrequency(snapshotIntervalFromFlag, dataStore)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Service{
 		dataStore:                 dataStore,
-		snapshotIntervalInSeconds: snapshotFrequency.Seconds(),
+		snapshotIntervalInSeconds: snapshotFrequency,
 		dockerSnapshotter:         dockerSnapshotter,
 		kubernetesSnapshotter:     kubernetesSnapshotter,
 		shutdownCtx:               shutdownCtx,
 	}, nil
+}
+
+func parseSnapshotFrequency(snapshotInterval string, dataStore dataservices.DataStore) (float64, error) {
+	if snapshotInterval == "" {
+		settings, err := dataStore.Settings().Settings()
+		if err != nil {
+			return 0, err
+		}
+		snapshotInterval = settings.SnapshotInterval
+		if snapshotInterval == "" {
+			snapshotInterval = portainer.DefaultSnapshotInterval
+		}
+	}
+	snapshotFrequency, err := time.ParseDuration(snapshotInterval)
+	if err != nil {
+		return 0, err
+	}
+	return snapshotFrequency.Seconds(), nil
 }
 
 // Start will start a background routine to execute periodic snapshots of environments(endpoints)

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1375,6 +1375,8 @@ const (
 	// PortainerAgentSignatureMessage represents the message used to create a digital signature
 	// to be used when communicating with an agent
 	PortainerAgentSignatureMessage = "Portainer-App"
+	// DefaultSnapshotInterval represents the default interval between each environment snapshot job
+	DefaultSnapshotInterval = "5m"
 	// DefaultEdgeAgentCheckinIntervalInSeconds represents the default interval (in seconds) used by Edge agents to checkin with the Portainer instance
 	DefaultEdgeAgentCheckinIntervalInSeconds = 5
 	// DefaultTemplatesURL represents the URL to the official templates supported by Portainer


### PR DESCRIPTION
Closes [EE-2397](https://portainer.atlassian.net/browse/EE-2397)

- Set default values for settings values (EnableTelemetry, SSO, SnapshotInterval) in `Init` method, only allow override `updateSettingsFromFlags` with cli flags.
- Move `DefaultSnapshotInterval` from cli flags defaults to portainer defaults, and reuse it in `SnapshotService`.
- Remove default value for `SnapshotInterval` flag, which would override the value stored in datastore.
- Small refactor in `bolt.Init()` for better code readability.