### PR TITLE
fix(ssl): default httpEnabled to false [EE-2465]

### DIFF
--- a/api/cli/defaults.go
+++ b/api/cli/defaults.go
@@ -16,7 +16,7 @@ const (
 	defaultTLSCertPath         = "/certs/cert.pem"
 	defaultTLSKeyPath          = "/certs/key.pem"
 	defaultHTTPDisabled        = "false"
-	defaultHTTPEnabled         = "true"
+	defaultHTTPEnabled         = "false"
 	defaultSSL                 = "false"
 	defaultSSLCertPath         = "/certs/portainer.crt"
 	defaultSSLKeyPath          = "/certs/portainer.key"

--- a/api/cli/defaults_windows.go
+++ b/api/cli/defaults_windows.go
@@ -13,7 +13,7 @@ const (
 	defaultTLSCertPath         = "C:\\certs\\cert.pem"
 	defaultTLSKeyPath          = "C:\\certs\\key.pem"
 	defaultHTTPDisabled        = "false"
-	defaultHTTPEnabled         = "true"
+	defaultHTTPEnabled         = "false"
 	defaultSSL                 = "false"
 	defaultSSLCertPath         = "C:\\certs\\portainer.crt"
 	defaultSSLKeyPath          = "C:\\certs\\portainer.key"

--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -267,8 +267,8 @@ func updateSettingsFromFlags(dataStore dataservices.DataStore, flags *portainer.
 
 	if *flags.HTTPDisabled {
 		sslSettings.HTTPEnabled = false
-	} else {
-		sslSettings.HTTPEnabled = *flags.HTTPEnabled || sslSettings.HTTPEnabled
+	} else if *flags.HTTPEnabled {
+		sslSettings.HTTPEnabled = true
 	}
 
 	err = dataStore.SSLSettings().UpdateSettings(sslSettings)


### PR DESCRIPTION
Closes [EE-2465](https://portainer.atlassian.net/browse/EE-2465)

### Changes:
- Change default value for `HTTPEnabled` to `false`, having it set as `true` as default results in it being impossible to pass value `false` to the flag
- Adjust `updateSettingsFromFlags` logic to only tamper with `sslSettings.HTTPEnabled` if either: 
     - `http-disabled` is passed (set setting to `false`)
     - `http-enabled` is passed (set setting to `true`) 
    - use stored settings otherwise

The second change doesn't really modify the behaviour, it's just for cleaner code