### PR TITLE
wizard-docker.controller.js fix win socket command

### DIFF
--- a/app/portainer/views/wizard/wizard-endpoints/wizard-endpoint-docker/wizard-docker.controller.js
+++ b/app/portainer/views/wizard/wizard-endpoints/wizard-endpoint-docker/wizard-docker.controller.js
@@ -230,7 +230,7 @@ export default class WizardDockerController {
         linuxCommand: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}.yml -o agent-stack.yml && docker stack deploy --compose-file=agent-stack.yml portainer-agent `,
         winCommand: `curl -L https://downloads.portainer.io/agent-stack-ce${agentShortVersion}-windows.yml -o agent-stack-windows.yml && docker stack deploy --compose-file=agent-stack-windows.yml portainer-agent `,
         linuxSocket: `-v "/var/run/docker.sock:/var/run/docker.sock" `,
-        winSocket: `-v \.\pipe\docker_engine:\.\pipe\docker_engine `,
+        winSocket: `-v \\.\\pipe\\docker_engine:\\.\\pipe\\docker_engine `,
       };
     });
   }


### PR DESCRIPTION
Fix backslash being cut from winSocket command line

### Changes:

https://127.0.0.1:9443/#!/wizard/endpoints

![image](https://user-images.githubusercontent.com/3586205/152630334-63840806-3156-4fa0-9482-ae4fe4fd37c8.png)

where it should be

![image](https://user-images.githubusercontent.com/3586205/152630378-af1d82a0-ada4-470a-8dac-5ad9a56dd9a4.png)
