### PR TITLE
fix(settings): clear helm url if requested [EE-2494]

### DIFF
--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -116,18 +116,21 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.HelmRepositoryURL != nil {
-		newHelmRepo := strings.TrimSuffix(strings.ToLower(*payload.HelmRepositoryURL), "/")
+		if *payload.HelmRepositoryURL != "" {
+			newHelmRepo := strings.TrimSuffix(strings.ToLower(*payload.HelmRepositoryURL), "/")
 
-		if newHelmRepo != settings.HelmRepositoryURL && newHelmRepo != portainer.DefaultHelmRepositoryURL {
-			err := libhelm.ValidateHelmRepositoryURL(*payload.HelmRepositoryURL)
-			if err != nil {
-				return &httperror.HandlerError{http.StatusBadRequest, "Invalid Helm repository URL. Must correspond to a valid URL format", err}
+			if newHelmRepo != settings.HelmRepositoryURL && newHelmRepo != portainer.DefaultHelmRepositoryURL {
+				err := libhelm.ValidateHelmRepositoryURL(*payload.HelmRepositoryURL)
+				if err != nil {
+					return &httperror.HandlerError{http.StatusBadRequest, "Invalid Helm repository URL. Must correspond to a valid URL format", err}
+				}
+
+				settings.HelmRepositoryURL = newHelmRepo
 			}
-		}
 
-		settings.HelmRepositoryURL = newHelmRepo
-	} else {
-		settings.HelmRepositoryURL = ""
+		} else {
+			settings.HelmRepositoryURL = ""
+		}
 	}
 
 	if payload.BlackListedLabels != nil {

--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -117,6 +117,7 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 
 	if payload.HelmRepositoryURL != nil {
 		if *payload.HelmRepositoryURL != "" {
+
 			newHelmRepo := strings.TrimSuffix(strings.ToLower(*payload.HelmRepositoryURL), "/")
 
 			if newHelmRepo != settings.HelmRepositoryURL && newHelmRepo != portainer.DefaultHelmRepositoryURL {
@@ -125,9 +126,9 @@ func (handler *Handler) settingsUpdate(w http.ResponseWriter, r *http.Request) *
 					return &httperror.HandlerError{http.StatusBadRequest, "Invalid Helm repository URL. Must correspond to a valid URL format", err}
 				}
 
-				settings.HelmRepositoryURL = newHelmRepo
 			}
 
+			settings.HelmRepositoryURL = newHelmRepo
 		} else {
 			settings.HelmRepositoryURL = ""
 		}

--- a/app/portainer/views/settings/settings.html
+++ b/app/portainer/views/settings/settings.html
@@ -85,7 +85,7 @@
             <div class="form-group">
               <label for="helmrepository_url" class="col-sm-1 control-label text-left"> URL </label>
               <div class="col-sm-11">
-                <input type="text" class="form-control" ng-model="settings.HelmRepositoryURL" id="helmrepository_url" placeholder="https://charts.bitnami.com/bitnami" required />
+                <input type="text" class="form-control" ng-model="settings.HelmRepositoryURL" id="helmrepository_url" placeholder="https://charts.bitnami.com/bitnami" />
               </div>
             </div>
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4547,6 +4547,7 @@ angular-moment-picker@^0.10.2:
   dependencies:
     angular-mocks "1.6.1"
     angular-sanitize "1.6.1"
+    lodash-es "^4.17.15"
 
 angular-resource@1.8.2:
   version "1.8.2"
@@ -12597,7 +12598,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.15, lodash-es@^4.17.21:
+lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
fix [EE-2494]

before this PR, helm url would clear when updating settings, if the helm url key wasn't provided.
in this PR, it will be changed only if required

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:


[EE-2494]: https://portainer.atlassian.net/browse/EE-2494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ