### PR TITLE
fix(kube): Can't pull and redeploy an application from a git repository [EE-2443] 

### DIFF
--- a/api/http/handler/stacks/stack_update_git_redeploy.go
+++ b/api/http/handler/stacks/stack_update_git_redeploy.go
@@ -211,9 +211,6 @@ func (handler *Handler) deployStack(r *http.Request, stack *portainer.Stack, end
 		}
 
 	case portainer.KubernetesStack:
-		if stack.Namespace == "" {
-			return &httperror.HandlerError{StatusCode: http.StatusInternalServerError, Message: "Invalid namespace", Err: errors.New("Namespace must not be empty when redeploying kubernetes stacks")}
-		}
 		tokenData, err := security.RetrieveTokenData(r)
 		if err != nil {
 			return &httperror.HandlerError{StatusCode: http.StatusBadRequest, Message: "Failed to retrieve user token data", Err: err}


### PR DESCRIPTION
Closes [EE-2443](https://portainer.atlassian.net/browse/EE-2443)

Tested it locally and the current code correctly parses the namespace from git and uses that to redeploy the stack.