### PR TITLE
chore(git): ignore prettier commits on git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,5 @@
 # prettier
 cf5056d9c03b62d91a25c3b9127caac838695f98
 
-# prettier v2 (put here after fix/EE-2344/fix-eslint-issues is merged)
+# prettier v2
+42e7db0ae7897d3cb72b0ea1ecf57ee2dd694169

--- a/.vscode.example/launch.json
+++ b/.vscode.example/launch.json
@@ -9,7 +9,7 @@
       "type": "go",
       "request": "launch",
       "mode": "debug",
-      "program": "${workspaceRoot}/api/cmd/portainer/main.go",
+      "program": "${workspaceRoot}/api/cmd/portainer",
       "cwd": "${workspaceRoot}",
       "env": {},
       "showLog": true,

--- a/.vscode.example/settings.json
+++ b/.vscode.example/settings.json
@@ -4,5 +4,5 @@
   "gopls": {
     "build.expandWorkspaceToModule": false
   },
-  "gitlens.advanced.blame.customArguments": ["–ignore-revs-file", ".git-blame-ignore-revs"]
+  "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }


### PR DESCRIPTION
- to setup for git, should run: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
- to setup in vscode should copy example settings to .vscode folder

- also fixes the issue with debug failing