### PR TITLE
feat(endpoints): enable env vars on kube edge deploy [EE-2542]

### DIFF
--- a/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
+++ b/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
@@ -55,21 +55,19 @@ export function EdgePropertiesForm({
         </div>
       </div>
 
-      {values.platform !== 'k8s' && (
-        <FormControl
-          label="Environment variables"
-          tooltip="Comma separated list of environment variables that will be sourced from the host where the agent is deployed."
-          inputId="env-vars-input"
-        >
-          <Input
-            type="text"
-            name="envVars"
-            value={values.envVars}
-            id="env-vars-input"
-            onChange={(e) => setFieldValue(e.target.name, e.target.value)}
-          />
-        </FormControl>
-      )}
+      <FormControl
+        label="Environment variables"
+        tooltip="Comma separated list of environment variables that will be sourced from the host where the agent is deployed."
+        inputId="env-vars-input"
+      >
+        <Input
+          type="text"
+          name="envVars"
+          value={values.envVars}
+          id="env-vars-input"
+          onChange={(e) => setFieldValue(e.target.name, e.target.value)}
+        />
+      </FormControl>
     </form>
   );
 }

--- a/app/edge/components/EdgeScriptForm/Scripts.tsx
+++ b/app/edge/components/EdgeScriptForm/Scripts.tsx
@@ -262,7 +262,7 @@ function buildKubernetesCommand(
   edgeIdScript: string,
   edgeKey: string,
   allowSelfSignedCerts: boolean,
-  _envVars: string,
+  envVars: string,
   edgeId?: string,
   agentSecret = ''
 ) {
@@ -270,11 +270,13 @@ function buildKubernetesCommand(
   const idEnvVar = edgeIdScript
     ? `PORTAINER_EDGE_ID=$(${edgeIdScript}) \n\n`
     : '';
+  const edgeIdVar = !edgeIdScript && edgeId ? edgeId : '$PORTAINER_EDGE_ID';
+  const selfSigned = allowSelfSignedCerts ? '1' : '0';
 
   return `${idEnvVar}curl https://downloads.portainer.io/ce${agentShortVersion}/portainer-edge-agent-setup.sh | 
-  bash -s -- "${
-    !edgeIdScript && edgeId ? edgeId : '$PORTAINER_EDGE_ID'
-  }" "${edgeKey}" "${allowSelfSignedCerts ? '1' : '0'}" "${agentSecret}"`;
+  bash -s -- "${edgeIdVar}" \\
+    "${edgeKey}" \\
+    "${selfSigned}" "${agentSecret}" "${envVars}"`;
 }
 
 function buildDefaultEnvVars(


### PR DESCRIPTION
fix [EE-2542]

### Changes:
- display env vars field in kube edge endpoint view
- add the env vars to the kube deploy script

## Todos:
- replace url for deploy script from githubraw to `downloads.portainer.io`

[EE-2542]: https://portainer.atlassian.net/browse/EE-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ