### PR TITLE
fix(k8s): update error msg of adding agent to k8s with AGENT_SECRET (EE-2463)

### DIFF
--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -470,7 +470,7 @@ func (handler *Handler) createTLSSecuredEndpoint(payload *endpointCreatePayload,
 func (handler *Handler) snapshotAndPersistEndpoint(endpoint *portainer.Endpoint) *httperror.HandlerError {
 	err := handler.SnapshotService.SnapshotEndpoint(endpoint)
 	if err != nil {
-		if strings.Contains(err.Error(), "Invalid request signature") {
+		if strings.Contains(err.Error(), "Invalid request signature") || strings.Contains(err.Error(), "unknown") {
 			err = errors.New("agent already paired with another Portainer instance")
 		}
 		return &httperror.HandlerError{http.StatusInternalServerError, "Unable to initiate communications with environment", err}


### PR DESCRIPTION
When adding agent to k8s with AGENT_SECRET, AGENT_SECRET should be configured on both side. otherwise, it will get unknown error. 
The error code is 403 forbidden, but it discard by k8s client. We only get unknown error. Let's use "agent already paired with another Portainer instance" to instead it.

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
