### PR TITLE
fix(vscode-settings): remove go linter settings which breaks intellisense

### DIFF
--- a/.vscode.example/settings.json
+++ b/.vscode.example/settings.json
@@ -1,8 +1,3 @@
 {
-  "go.lintTool": "golangci-lint",
-  "go.lintFlags": ["--fast", "-E", "exportloopref"],
-  "gopls": {
-    "build.expandWorkspaceToModule": false
-  },
   "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }


### PR DESCRIPTION
Removing the go linter settings which breaks vscode intellisense unless you open the api folder directly.
Without these settings intellisense for go works properly from the project root.   

The breaking setting seems to be this one: 
```
"gopls": {
    "build.expandWorkspaceToModule": false
 },
```
However, it doesn't seem like any of the other go linter settings are needed either.  And also the --fast and -F options do not appear to be correct flags to pass to `golangci-lint`

Therefore I've removed them all and the correct behavior is now restored.