### PR TITLE
fix(timeout): change the url of the documentation link on timeout page [EE-2908]

### DIFF
--- a/app/timeout.ejs
+++ b/app/timeout.ejs
@@ -45,7 +45,7 @@
                   </span>
                   <br /><br />
                   <span class="text-muted small" style="margin-left: 2px">
-                    For further information, view our <a href="https://docs.portainer.io/v/ce-2.11/start/install" target="_blank">documentation</a>.
+                    For further information, view our <a href="https://documentation.portainer.io/r/ce-restart-portainer" target="_blank">documentation</a>.
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
closes [EE-2908]

### Changes:

- change the url of documentation link on timeout page to https://documentation.portainer.io/r/ce-restart-portainer 


[EE-2908]: https://portainer.atlassian.net/browse/EE-2908?
