### PR TITLE
feat(editor): enable search feature in the code editor [EE-2649]

### DIFF
--- a/app/portainer/services/codeMirror.js
+++ b/app/portainer/services/codeMirror.js
@@ -4,6 +4,11 @@ import 'codemirror/mode/yaml/yaml.js';
 import 'codemirror/addon/lint/lint.js';
 import 'codemirror/addon/lint/yaml-lint.js';
 import 'codemirror/addon/display/placeholder.js';
+import 'codemirror/addon/search/search.js';
+import 'codemirror/addon/search/searchcursor.js';
+import 'codemirror/addon/search/jump-to-line.js';
+import 'codemirror/addon/dialog/dialog.js';
+import 'codemirror/addon/dialog/dialog.css';
 
 angular.module('portainer.app').factory('CodeMirrorService', function CodeMirrorService() {
   'use strict';
@@ -12,6 +17,9 @@ angular.module('portainer.app').factory('CodeMirrorService', function CodeMirror
 
   var codeMirrorGenericOptions = {
     lineNumbers: true,
+    extraKeys: {
+      "Alt-F": "findPersistent"
+    }
   };
 
   var codeMirrorYAMLOptions = {
@@ -19,6 +27,7 @@ angular.module('portainer.app').factory('CodeMirrorService', function CodeMirror
     gutters: ['CodeMirror-lint-markers'],
     lint: true,
     extraKeys: {
+      "Alt-F": "findPersistent",
       Tab: function (cm) {
         var spaces = Array(cm.getOption('indentUnit') + 1).join(' ');
         cm.replaceSelection(spaces);


### PR DESCRIPTION
Closes #6537 and [EE-2649](https://portainer.atlassian.net/browse/EE-2649)
This PR adds advanced search function to all editors, allowing to search and replace, even with regex.

Commands:
* `Ctrl-F / Cmd-F` -> Start searching
* `Ctrl-G / Cmd-G` -> Find next
* `Shift-Ctrl-G / Shift-Cmd-G` -> Find previous
* `Shift-Ctrl-F / Cmd-Option-F` -> Replace
* `Shift-Ctrl-R / Shift-Cmd-Option-F` -> Replace all
* `Alt-F` -> Persistent search (dialog doesn't autoclose, enter to find next, Shift-Enter to find previous)
* `Alt-G` -> Jump to line

### Changes:
* Import addon from CodeMirror package
* set in default CodeMirror option a custom key bind for permanent search bar