### PR TITLE
fix(api/endpoint): refresh kubernetes client cache on endpoint update

### DIFF
--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -257,6 +257,7 @@ func (handler *Handler) endpointUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.URL != nil || payload.TLS != nil || endpoint.Type == portainer.AzureEnvironment {
+		handler.ProxyManager.DeleteEndpointProxy(endpoint.ID)
 		_, err = handler.ProxyManager.CreateAndRegisterEndpointProxy(endpoint)
 		if err != nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "Unable to register HTTP proxy for the environment", err}

--- a/api/http/proxy/manager.go
+++ b/api/http/proxy/manager.go
@@ -63,7 +63,7 @@ func (manager *Manager) GetEndpointProxy(endpoint *portainer.Endpoint) http.Hand
 
 // DeleteEndpointProxy deletes the proxy associated to a key
 // and cleans the k8s environment(endpoint) client cache. DeleteEndpointProxy
-// is currently only called for edge connection clean up.
+// is currently only called for edge connection clean up and when endpoint is updated
 func (manager *Manager) DeleteEndpointProxy(endpointID portainer.EndpointID) {
 	manager.endpointProxies.Remove(fmt.Sprint(endpointID))
 	manager.k8sClientFactory.RemoveKubeClient(endpointID)


### PR DESCRIPTION
Close [EE-2524]

[EE-2524]: https://portainer.atlassian.net/browse/EE-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ