### PR TITLE
fix(datastore): fix test for EdgePortainerUrl [EE-2967]

### DIFF
--- a/api/datastore/backup_test.go
+++ b/api/datastore/backup_test.go
@@ -86,7 +86,7 @@ func TestRemoveWithOptions(t *testing.T) {
 
 		err = store.removeWithOptions(options)
 		if err != nil {
-			t.Errorf("RemoveWithOptions should successfully remove file; err=%w", err)
+			t.Errorf("RemoveWithOptions should successfully remove file; err=%v", err)
 		}
 
 		if isFileExist(f.Name()) {

--- a/api/datastore/test_data/output_35.json
+++ b/api/datastore/test_data/output_35.json
@@ -591,6 +591,7 @@
     "DisplayDonationHeader": false,
     "DisplayExternalContributors": false,
     "EdgeAgentCheckinInterval": 5,
+    "EdgePortainerUrl": "",
     "EnableEdgeComputeFeatures": false,
     "EnableHostManagementFeatures": false,
     "EnableTelemetry": true,


### PR DESCRIPTION
fix [EE-2967]

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:


[EE-2967]: https://portainer.atlassian.net/browse/EE-2967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ