### PR TITLE
fix(edge): show edge environment in edge views [EE-2997]

### DIFF
--- a/api/datastore/migrator/migrate_ce.go
+++ b/api/datastore/migrator/migrate_ce.go
@@ -97,6 +97,9 @@ func (m *Migrator) Migrate() error {
 		newMigration(35, m.migrateDBVersionToDB35),
 
 		newMigration(36, m.migrateDBVersionToDB36),
+
+		// Portainer 2.13
+		newMigration(40, m.migrateDBVersionToDB40),
 	}
 
 	var lastDbVersion int

--- a/api/datastore/migrator/migrate_dbversion40.go
+++ b/api/datastore/migrator/migrate_dbversion40.go
@@ -1,0 +1,31 @@
+package migrator
+
+import "github.com/portainer/portainer/api/internal/endpointutils"
+
+func (m *Migrator) migrateDBVersionToDB40() error {
+	if err := m.trustCurrentEdgeEndpointsDB40(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Migrator) trustCurrentEdgeEndpointsDB40() error {
+	migrateLog.Info("- trusting current edge endpoints")
+	endpoints, err := m.endpointService.Endpoints()
+	if err != nil {
+		return err
+	}
+
+	for _, endpoint := range endpoints {
+		if endpointutils.IsEdgeEndpoint(&endpoint) {
+			endpoint.UserTrusted = true
+			err = m.endpointService.UpdateEndpoint(endpoint.ID, &endpoint)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/app/edge/views/edge-devices/edgeDevicesView/edgeDevicesViewController.js
+++ b/app/edge/views/edge-devices/edgeDevicesView/edgeDevicesViewController.js
@@ -10,7 +10,12 @@ export function EdgeDevicesViewController($q, $async, EndpointService, GroupServ
   this.getEnvironments = function () {
     return $async(async () => {
       try {
-        const [endpointsResponse, groups] = await Promise.all([getEndpoints(0, 100, { edgeDeviceFilter: 'trusted' }), GroupService.groups()]);
+        const [endpointsResponse, groups] = await Promise.all([
+          getEndpoints(0, 100, {
+            edgeDeviceFilter: 'trusted',
+          }),
+          GroupService.groups(),
+        ]);
         ctrl.groups = groups;
         ctrl.edgeDevices = endpointsResponse.value;
       } catch (err) {

--- a/app/portainer/environments/environment.service/index.ts
+++ b/app/portainer/environments/environment.service/index.ts
@@ -21,10 +21,10 @@ export interface EnvironmentsQueryParams {
   endpointIds?: EnvironmentId[];
   tagsPartialMatch?: boolean;
   groupIds?: EnvironmentGroupId[];
-  edgeDeviceFilter?: 'all' | 'trusted' | 'untrusted';
   status?: EnvironmentStatus[];
   sort?: string;
   order?: 'asc' | 'desc';
+  edgeDeviceFilter?: 'all' | 'trusted' | 'untrusted' | 'none';
 }
 
 export async function getEndpoints(

--- a/app/portainer/home/EnvironmentList/EnvironmentList.tsx
+++ b/app/portainer/home/EnvironmentList/EnvironmentList.tsx
@@ -132,6 +132,7 @@ export function EnvironmentList({ onClickItem, onRefresh }: Props) {
         groupIds: groupFilter,
         sort: sortByFilter,
         order: sortByDescending ? 'desc' : 'asc',
+        edgeDeviceFilter: 'none',
       },
       true
     );

--- a/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
+++ b/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
@@ -19,7 +19,7 @@ interface FormValues {
   TrustOnFirstConnect: boolean;
 }
 const validation = yup.object({
-  TrustOnFirstConnect: yup.boolean().required('This field is required.'),
+  TrustOnFirstConnect: yup.boolean(),
   EdgePortainerUrl: yup
     .string()
     .test(
@@ -63,10 +63,10 @@ export function AutoEnvCreationSettingsForm({ settings }: Props) {
   );
 
   useEffect(() => {
-    if (!url && validation.isValidSync({ url: defaultUrl })) {
-      handleSubmit({ EdgePortainerUrl: defaultUrl });
+    if (!url && validation.isValidSync({ EdgePortainerUrl: defaultUrl })) {
+      updateSettings({ EdgePortainerUrl: defaultUrl });
     }
-  }, [handleSubmit, url]);
+  }, [updateSettings, url]);
 
   return (
     <Formik<FormValues>


### PR DESCRIPTION
fixes [EE-2997]
- show all edge when filtering with edge device filter
- add filter to filter out edge devices
- add db migration to change current edge endpoints to be trusted
- hide edge devices from home view


[EE-2997]: https://portainer.atlassian.net/browse/EE-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ