### PR TITLE
fix(edge/aeec): add explanation about PORTAINER_EDGE_ID [EE-3056]

### DIFF
--- a/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
+++ b/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
@@ -2,6 +2,7 @@ import { FormControl } from '@/portainer/components/form-components/FormControl'
 import { Input } from '@/portainer/components/form-components/Input';
 import { FormSectionTitle } from '@/portainer/components/form-components/FormSectionTitle';
 import { SwitchField } from '@/portainer/components/form-components/SwitchField';
+import { TextTip } from '@/portainer/components/Tip/TextTip';
 
 import { OsSelector } from './OsSelector';
 import { EdgeProperties } from './types';
@@ -27,19 +28,26 @@ export function EdgePropertiesForm({
       />
 
       {!hideIdGetter && (
-        <FormControl
-          label="Edge ID Generator"
-          tooltip="A bash script one liner that will generate the edge id"
-          inputId="edge-id-generator-input"
-        >
-          <Input
-            type="text"
-            name="edgeIdGenerator"
-            value={values.edgeIdGenerator}
-            id="edge-id-generator-input"
-            onChange={(e) => setFieldValue(e.target.name, e.target.value)}
-          />
-        </FormControl>
+        <>
+          <FormControl
+            label="Edge ID Generator"
+            tooltip="A bash script one liner that will generate the edge id"
+            inputId="edge-id-generator-input"
+          >
+            <Input
+              type="text"
+              name="edgeIdGenerator"
+              value={values.edgeIdGenerator}
+              id="edge-id-generator-input"
+              onChange={(e) => setFieldValue(e.target.name, e.target.value)}
+            />
+          </FormControl>
+
+          <TextTip color="blue">
+            <code>PORTAINER_EDGE_ID</code> environment variable is required to
+            successfully connect the edge agent to Portainer
+          </TextTip>
+        </>
       )}
 
       <div className="form-group">

--- a/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
+++ b/app/edge/components/EdgeScriptForm/EdgePropertiesForm.tsx
@@ -31,7 +31,7 @@ export function EdgePropertiesForm({
         <>
           <FormControl
             label="Edge ID Generator"
-            tooltip="A bash script one liner that will generate the edge id"
+            tooltip="A bash script one liner that will generate the edge id and will be assigned to the PORTAINER_EDGE_ID environment variable"
             inputId="edge-id-generator-input"
           >
             <Input


### PR DESCRIPTION
fix [EE-3056]

- added text tip explanation for the env var
- changed the tooltip for the edge field generator to
   refer to the env var


[EE-3056]: https://portainer.atlassian.net/browse/EE-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ