### PR TITLE
fix(extension): extend JWT auth token expiration for extension EE-3065

### DIFF
--- a/api/jwt/jwt.go
+++ b/api/jwt/jwt.go
@@ -168,7 +168,7 @@ func (service *Service) generateSignedToken(data *portainer.TokenData, expiresAt
 
 	if _, ok := os.LookupEnv("DOCKER_EXTENSION"); ok {
 		// Set expiration to 99 years for docker desktop extension.
-		log.Infof("[message: using 99 year JWT expiration time for docker desktop extension environment]")
+		log.Infof("[message: detected docker desktop extension mode]")
 		expiresAt = time.Now().Add(time.Hour * 8760 * 99).Unix()
 	}
 

--- a/api/jwt/jwt.go
+++ b/api/jwt/jwt.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt"
@@ -165,11 +166,7 @@ func (service *Service) generateSignedToken(data *portainer.TokenData, expiresAt
 		return "", fmt.Errorf("invalid scope: %v", scope)
 	}
 
-	settings, err := service.dataStore.Settings().Settings()
-	if err != nil {
-		return "", fmt.Errorf("failed looking up settings")
-	}
-	if settings.FeatureFlagSettings["docker-extension"] {
+	if _, ok := os.LookupEnv("DOCKER_EXTENSION"); ok {
 		// Set expiration to 99 years for docker desktop extension.
 		log.Infof("[message: using 99 year JWT expiration time for docker desktop extension environment]")
 		expiresAt = time.Now().Add(time.Hour * 8760 * 99).Unix()

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1391,9 +1391,7 @@ const (
 )
 
 // List of supported features
-var SupportedFeatureFlags = []Feature{
-	"docker-extension",
-}
+var SupportedFeatureFlags = []Feature{}
 
 const (
 	_ AuthenticationMethod = iota

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1391,7 +1391,9 @@ const (
 )
 
 // List of supported features
-var SupportedFeatureFlags = []Feature{}
+var SupportedFeatureFlags = []Feature{
+	"docker-extension",
+}
 
 const (
 	_ AuthenticationMethod = iota

--- a/build/docker-extension/docker-compose.yml
+++ b/build/docker-extension/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   portainer:
     image: ${DESKTOP_PLUGIN_IMAGE}
-    command: ['--admin-password', '$$$$2y$$$$05$$$$bsb.XmF.r2DU6/9oVUaDxu3.Lxhmg1R8M0NMLK6JJKUiqUcaNjvdu']
+    command: ['--admin-password', '$$$$2y$$$$05$$$$bsb.XmF.r2DU6/9oVUaDxu3.Lxhmg1R8M0NMLK6JJKUiqUcaNjvdu', '--feat', 'docker-extension']
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/build/docker-extension/docker-compose.yml
+++ b/build/docker-extension/docker-compose.yml
@@ -3,8 +3,10 @@ version: '3'
 services:
   portainer:
     image: ${DESKTOP_PLUGIN_IMAGE}
-    command: ['--admin-password', '$$$$2y$$$$05$$$$bsb.XmF.r2DU6/9oVUaDxu3.Lxhmg1R8M0NMLK6JJKUiqUcaNjvdu', '--feat', 'docker-extension']
+    command: ['--admin-password', '$$$$2y$$$$05$$$$bsb.XmF.r2DU6/9oVUaDxu3.Lxhmg1R8M0NMLK6JJKUiqUcaNjvdu']
     restart: unless-stopped
+    environment:
+      - DOCKER_EXTENSION=1
     security_opt:
       - no-new-privileges:true
     volumes:


### PR DESCRIPTION
The default expiration time of 8 hours does not make sense in the
context of the docker desktop extension. This adds an env var `DOCKER_EXTENSION=1` and when present will set the expiration time to 99 years. 