### PR TITLE
fix(edge): allow more options for url [EE-2975]

### DIFF
--- a/api/internal/edge/url.go
+++ b/api/internal/edge/url.go
@@ -19,6 +19,10 @@ func ParseHostForEdge(portainerURL string) (string, error) {
 		portainerHost = parsedURL.Host
 	}
 
+	if portainerHost == "" {
+		return "", errors.New("hostname cannot be empty")
+	}
+
 	if portainerHost == "localhost" {
 		return "", errors.New("cannot use localhost as environment URL")
 	}

--- a/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
+++ b/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
@@ -23,11 +23,20 @@ const validation = yup.object({
   EdgePortainerUrl: yup
     .string()
     .test(
-      'not-local',
-      'Cannot use localhost as environment URL',
-      (value) => !value?.includes('localhost')
+      'url',
+      'URL should be a valid URI and cannot include localhost',
+      (value) => {
+        if (!value) {
+          return false;
+        }
+        try {
+          const url = new URL(value);
+          return url.hostname !== 'localhost';
+        } catch {
+          return false;
+        }
+      }
     )
-    .url('URL should be a valid URI')
     .required('URL is required'),
 });
 

--- a/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
+++ b/app/portainer/settings/edge-compute/AutomaticEdgeEnvCreation/AutoEnvCreationSettingsForm.tsx
@@ -31,7 +31,7 @@ const validation = yup.object({
         }
         try {
           const url = new URL(value);
-          return url.hostname !== 'localhost';
+          return !!url.hostname && url.hostname !== 'localhost';
         } catch {
           return false;
         }


### PR DESCRIPTION
fixes [EE-2975]

uses custom url validation using `new URL`

[EE-2975]: https://portainer.atlassian.net/browse/EE-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ