### PR TITLE
fix(settings): allow empty edge url [EE-3151]

### DIFF
--- a/api/http/handler/settings/settings_update.go
+++ b/api/http/handler/settings/settings_update.go
@@ -77,7 +77,7 @@ func (payload *settingsUpdatePayload) Validate(r *http.Request) error {
 		}
 	}
 
-	if payload.EdgePortainerURL != nil {
+	if payload.EdgePortainerURL != nil && *payload.EdgePortainerURL != "" {
 		_, err := edge.ParseHostForEdge(*payload.EdgePortainerURL)
 		if err != nil {
 			return err


### PR DESCRIPTION
closes #6899
closes [EE-3151]


[EE-3151]: https://portainer.atlassian.net/browse/EE-3151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ