### PR TITLE
fix(k8s): misspelling in Kube namespace EE-3073

### DIFF
--- a/app/kubernetes/views/deploy/deploy.html
+++ b/app/kubernetes/views/deploy/deploy.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="form-group" ng-if="ctrl.formValues.Namespace">
                   <div class="col-sm-12">
-                    <label for="toggle_logo" class="control-label text-left"> Use namespace(s) specificed from manifest </label>
+                    <label for="toggle_logo" class="control-label text-left"> Use namespace(s) specified from manifest </label>
                     <portainer-tooltip
                       position="bottom"
                       message="If you have defined namespaces in your deployment file turning this on will enforce the use of those only in the deployment"


### PR DESCRIPTION
closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
