### PR TITLE
feat(dashboard) remove environment url from dashboard's environment summary page for edge agents EE-2849

### DIFF
--- a/app/docker/views/dashboard/dashboard.html
+++ b/app/docker/views/dashboard/dashboard.html
@@ -51,6 +51,10 @@
                 >
               </td>
             </tr>
+            <tr ng-if="showEnvUrl">
+              <td>URL</td>
+              <td>{{ endpoint.URL | stripprotocol }}</td>
+            </tr>
             <tr>
               <td>Tags</td>
               <td>{{ endpointTags }}</td>

--- a/app/docker/views/dashboard/dashboard.html
+++ b/app/docker/views/dashboard/dashboard.html
@@ -52,10 +52,6 @@
               </td>
             </tr>
             <tr>
-              <td>URL</td>
-              <td>{{ endpoint.URL | stripprotocol }}</td>
-            </tr>
-            <tr>
               <td>Tags</td>
               <td>{{ endpointTags }}</td>
             </tr>

--- a/app/docker/views/dashboard/dashboardController.js
+++ b/app/docker/views/dashboard/dashboardController.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import _ from 'lodash';
 
 import { isOfflineEndpoint } from '@/portainer/helpers/endpointHelper';
+import { PortainerEndpointTypes } from 'Portainer/models/endpoint/models';
 
 angular.module('portainer.docker').controller('DashboardController', [
   '$scope',
@@ -46,7 +47,10 @@ angular.module('portainer.docker').controller('DashboardController', [
       $scope.endpoint = endpoint;
 
       $scope.showStacks = await shouldShowStacks();
-
+      $scope.showEnvUrl = endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnDockerEnvironment && endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnKubernetesEnvironment;
+      console.log($scope.showEnvUrl);
+      // $scope.showEnvUrl = endpoint.;
+      console.log(endpoint);
       $q.all({
         containers: ContainerService.containers(1),
         images: ImageService.images(false),

--- a/app/docker/views/dashboard/dashboardController.js
+++ b/app/docker/views/dashboard/dashboardController.js
@@ -48,9 +48,6 @@ angular.module('portainer.docker').controller('DashboardController', [
 
       $scope.showStacks = await shouldShowStacks();
       $scope.showEnvUrl = endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnDockerEnvironment && endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnKubernetesEnvironment;
-      console.log($scope.showEnvUrl);
-      // $scope.showEnvUrl = endpoint.;
-      console.log(endpoint);
       $q.all({
         containers: ContainerService.containers(1),
         images: ImageService.images(false),

--- a/app/kubernetes/views/dashboard/dashboard.html
+++ b/app/kubernetes/views/dashboard/dashboard.html
@@ -17,10 +17,6 @@
                 </td>
               </tr>
               <tr>
-                <td>URL</td>
-                <td>{{ ctrl.endpoint.URL | stripprotocol }}</td>
-              </tr>
-              <tr>
                 <td>Tags</td>
                 <td>{{ ctrl.endpointTags }}</td>
               </tr>

--- a/app/kubernetes/views/dashboard/dashboard.html
+++ b/app/kubernetes/views/dashboard/dashboard.html
@@ -16,6 +16,10 @@
                   {{ ctrl.endpoint.Name }}
                 </td>
               </tr>
+              <tr ng-if="ctrl.showEnvUrl">
+                <td>URL</td>
+                <td>{{ ctrl.endpoint.URL | stripprotocol }}</td>
+              </tr>
               <tr>
                 <td>Tags</td>
                 <td>{{ ctrl.endpointTags }}</td>

--- a/app/kubernetes/views/dashboard/dashboardController.js
+++ b/app/kubernetes/views/dashboard/dashboardController.js
@@ -36,7 +36,7 @@ class KubernetesDashboardController {
     const isAdmin = this.Authentication.isAdmin();
     const storageClasses = this.endpoint.Kubernetes.Configuration.StorageClasses;
     this.showEnvUrl = this.endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnDockerEnvironment && this.endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnKubernetesEnvironment;
-    console.log(this.showEnvUrl);
+
     try {
       const [pools, applications, configurations, volumes, tags] = await Promise.all([
         this.KubernetesResourcePoolService.get(),

--- a/app/kubernetes/views/dashboard/dashboardController.js
+++ b/app/kubernetes/views/dashboard/dashboardController.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import _ from 'lodash-es';
 import KubernetesConfigurationHelper from 'Kubernetes/helpers/configurationHelper';
 import KubernetesNamespaceHelper from 'Kubernetes/helpers/namespaceHelper';
+import { PortainerEndpointTypes } from 'Portainer/models/endpoint/models';
 
 class KubernetesDashboardController {
   /* @ngInject */
@@ -34,7 +35,8 @@ class KubernetesDashboardController {
   async getAllAsync() {
     const isAdmin = this.Authentication.isAdmin();
     const storageClasses = this.endpoint.Kubernetes.Configuration.StorageClasses;
-
+    this.showEnvUrl = this.endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnDockerEnvironment && this.endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnKubernetesEnvironment;
+    console.log(this.showEnvUrl);
     try {
       const [pools, applications, configurations, volumes, tags] = await Promise.all([
         this.KubernetesResourcePoolService.get(),


### PR DESCRIPTION
### Changes:
remove environment url from dashboard's environment summary page - only for edge agents.