### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/api/archive/zip_test.go
+++ b/api/archive/zip_test.go
@@ -1,17 +1,14 @@
 package archive
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnzipFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "unzip-test-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	/*
 		Archive structure.
 		├── 0
@@ -21,7 +18,7 @@ func TestUnzipFile(t *testing.T) {
 		└── 0.txt
 	*/
 
-	err = UnzipFile("./testdata/sample_archive.zip", dir)
+	err := UnzipFile("./testdata/sample_archive.zip", dir)
 
 	assert.NoError(t, err)
 	archiveDir := dir + "/sample_archive"

--- a/api/filesystem/copy_test.go
+++ b/api/filesystem/copy_test.go
@@ -11,16 +11,14 @@ import (
 )
 
 func Test_copyFile_returnsError_whenSourceDoesNotExist(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "backup")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	err := copyFile("does-not-exist", tmpdir)
 	assert.Error(t, err)
 }
 
 func Test_copyFile_shouldMakeAbackup(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "backup")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	content := []byte("content")
 	ioutil.WriteFile(path.Join(tmpdir, "origin"), content, 0600)
@@ -33,8 +31,7 @@ func Test_copyFile_shouldMakeAbackup(t *testing.T) {
 }
 
 func Test_CopyDir_shouldCopyAllFilesAndDirectories(t *testing.T) {
-	destination, _ := ioutil.TempDir("", "destination")
-	defer os.RemoveAll(destination)
+	destination := t.TempDir()
 	err := CopyDir("./testdata/copy_test", destination, true)
 	assert.NoError(t, err)
 
@@ -44,8 +41,7 @@ func Test_CopyDir_shouldCopyAllFilesAndDirectories(t *testing.T) {
 }
 
 func Test_CopyDir_shouldCopyOnlyDirContents(t *testing.T) {
-	destination, _ := ioutil.TempDir("", "destination")
-	defer os.RemoveAll(destination)
+	destination := t.TempDir()
 	err := CopyDir("./testdata/copy_test", destination, false)
 	assert.NoError(t, err)
 
@@ -55,8 +51,7 @@ func Test_CopyDir_shouldCopyOnlyDirContents(t *testing.T) {
 }
 
 func Test_CopyPath_shouldSkipWhenNotExist(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "backup")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	err := CopyPath("does-not-exists", tmpdir)
 	assert.NoError(t, err)
@@ -65,8 +60,7 @@ func Test_CopyPath_shouldSkipWhenNotExist(t *testing.T) {
 }
 
 func Test_CopyPath_shouldCopyFile(t *testing.T) {
-	tmpdir, _ := ioutil.TempDir("", "backup")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	content := []byte("content")
 	ioutil.WriteFile(path.Join(tmpdir, "file"), content, 0600)
@@ -81,8 +75,7 @@ func Test_CopyPath_shouldCopyFile(t *testing.T) {
 }
 
 func Test_CopyPath_shouldCopyDir(t *testing.T) {
-	destination, _ := ioutil.TempDir("", "destination")
-	defer os.RemoveAll(destination)
+	destination := t.TempDir()
 	err := CopyPath("./testdata/copy_test", destination)
 	assert.NoError(t, err)
 

--- a/api/git/git_test.go
+++ b/api/git/git_test.go
@@ -52,15 +52,10 @@ func Test_ClonePublicRepository_Shallow(t *testing.T) {
 	service := Service{git: gitClient{preserveGitDirectory: true}} // no need for http client since the test access the repo via file system.
 	repositoryURL := bareRepoDir
 	referenceName := "refs/heads/main"
-	destination := "shallow"
 
-	dir, err := ioutil.TempDir("", destination)
-	if err != nil {
-		t.Fatalf("failed to create a temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	t.Logf("Cloning into %s", dir)
-	err = service.CloneRepository(dir, repositoryURL, referenceName, "", "")
+	err := service.CloneRepository(dir, repositoryURL, referenceName, "", "")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, getCommitHistoryLength(t, err, dir), "cloned repo has incorrect depth")
 }
@@ -69,17 +64,11 @@ func Test_ClonePublicRepository_NoGitDirectory(t *testing.T) {
 	service := Service{git: gitClient{preserveGitDirectory: false}} // no need for http client since the test access the repo via file system.
 	repositoryURL := bareRepoDir
 	referenceName := "refs/heads/main"
-	destination := "shallow"
 
-	dir, err := ioutil.TempDir("", destination)
-	if err != nil {
-		t.Fatalf("failed to create a temp dir")
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	t.Logf("Cloning into %s", dir)
-	err = service.CloneRepository(dir, repositoryURL, referenceName, "", "")
+	err := service.CloneRepository(dir, repositoryURL, referenceName, "", "")
 	assert.NoError(t, err)
 	assert.NoDirExists(t, filepath.Join(dir, ".git"))
 }
@@ -89,16 +78,11 @@ func Test_cloneRepository(t *testing.T) {
 
 	repositoryURL := bareRepoDir
 	referenceName := "refs/heads/main"
-	destination := "shallow"
 
-	dir, err := ioutil.TempDir("", destination)
-	if err != nil {
-		t.Fatalf("failed to create a temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	t.Logf("Cloning into %s", dir)
 
-	err = service.cloneRepository(dir, cloneOptions{
+	err := service.cloneRepository(dir, cloneOptions{
 		repositoryUrl: repositoryURL,
 		referenceName: referenceName,
 		depth:         10,

--- a/api/kubernetes/kubeclusteraccess_service_test.go
+++ b/api/kubernetes/kubeclusteraccess_service_test.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -36,14 +35,12 @@ iuViiuhTPJkxKOzCmv52cxf15B0/+cgcImoX4zc9Z0NxKthBmIe00ojexE0ZBOFi
 // string within the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` without linebreaks
 const certDataString = "MIIC5TCCAc2gAwIBAgIJAJ+poiEBdsplMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0yMTA4MDQwNDM0MTZaFw0yMTA5MDMwNDM0MTZaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKQ0HStP34FY/lSDIfMG9MV/lKNUkiLZcMXepbyhPit4ND/w9kOA4WTJ+oP0B2IYklRvLkneZOfQiPweGAPwZl3CjwII6gL6NCkhcXXAJ4JQ9duL5Q6pL//95OcvX+qMTssyS1DcH88F6v+gifACLpvG86G9V0DeSGS2fqqfOJngrOCgum1DsWi3XsewB3A7GkPRjYmckU3t4iHgcMb+6lGQAxtnllSM9DpqGnjXRs4mnQHKgufaeW5nvHXioa5l0aHIhN6MQS99QwKwfml7UtWAYhSJksMrrTovB6rThYpp2ID/iU9MGfkpxubToA6scv8alFa8Bo+NEKo255dxsScCAwEAAaM6MDgwFAYDVR0RBA0wC4IJbG9jYWxob3N0MAsGA1UdDwQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEALFBHW/r79KOj5bhoDtHs8h/ESAlD5DJI/kzc1RajA8AuWPsaagG/S0Bqiq2ApMA6Tr3t9An8peaLCaUapWw59kyQcwwPXm9vxhEEfoBRtk8po8XblsUSQ5Ku07ycSg5NBGEW2rCLsvjQFuQiAt8sW4jGCCN+ph/GQF9XC8ir+ssiqiMEkbm/JaK7sTi5kZ/GsSK8bJ+9N/ztoFr89YYEWjjOuIS3HNMdBcuQXIel7siEFdNjbzMoiuViiuhTPJkxKOzCmv52cxf15B0/+cgcImoX4zc9Z0NxKthBmIe00ojexE0ZBOFi4PxB7Ou6y/c9OvJb7gJv3z08+xuhOaFXwQ=="
 
-func createTempFile(filename, content string) (string, func()) {
-	tempPath, _ := ioutil.TempDir("", "temp")
+func createTempFile(t *testing.T, filename, content string) string {
+	tempPath := t.TempDir()
 	filePath := fmt.Sprintf("%s/%s", tempPath, filename)
 	ioutil.WriteFile(filePath, []byte(content), 0644)
 
-	teardown := func() { os.RemoveAll(tempPath) }
-
-	return filePath, teardown
+	return filePath
 }
 
 func Test_getCertificateAuthorityData(t *testing.T) {
@@ -60,16 +57,14 @@ func Test_getCertificateAuthorityData(t *testing.T) {
 	})
 
 	t.Run("getCertificateAuthorityData fails on tls cert provided but invalid file data", func(t *testing.T) {
-		filePath, teardown := createTempFile("invalid-cert.crt", "hello\ngo\n")
-		defer teardown()
+		filePath := createTempFile(t, "invalid-cert.crt", "hello\ngo\n")
 
 		_, err := getCertificateAuthorityData(filePath)
 		is.ErrorIs(err, errTLSCertIncorrectType, "getCertificateAuthorityData should fail with %w", errTLSCertIncorrectType)
 	})
 
 	t.Run("getCertificateAuthorityData succeeds on valid tls cert provided", func(t *testing.T) {
-		filePath, teardown := createTempFile("valid-cert.crt", certData)
-		defer teardown()
+		filePath := createTempFile(t, "valid-cert.crt", certData)
 
 		certificateAuthorityData, err := getCertificateAuthorityData(filePath)
 		is.NoError(err, "getCertificateAuthorityData succeed with valid cert; err=%w", errTLSCertIncorrectType)
@@ -87,8 +82,7 @@ func TestKubeClusterAccessService_IsSecure(t *testing.T) {
 	})
 
 	t.Run("IsSecure should be false", func(t *testing.T) {
-		filePath, teardown := createTempFile("valid-cert.crt", certData)
-		defer teardown()
+		filePath := createTempFile(t, "valid-cert.crt", certData)
 
 		kcs := NewKubeClusterAccessService("", "", filePath)
 		is.True(kcs.IsSecure(), "should be true if valid TLS cert (path and content) provided")
@@ -124,8 +118,7 @@ func TestKubeClusterAccessService_GetKubeConfigInternal(t *testing.T) {
 	})
 
 	t.Run("GetData returns secure cluster access config", func(t *testing.T) {
-		filePath, teardown := createTempFile("valid-cert.crt", certData)
-		defer teardown()
+		filePath := createTempFile(t, "valid-cert.crt", certData)
 
 		kcs := NewKubeClusterAccessService("/", "", filePath)
 		clusterAccessDetails := kcs.GetData("localhost", 1)

--- a/api/stacks/deploy_test.go
+++ b/api/stacks/deploy_test.go
@@ -2,7 +2,6 @@ package stacks
 
 import (
 	"errors"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -68,7 +67,7 @@ func Test_redeployWhenChanged_DoesNothingWhenNoGitChanges(t *testing.T) {
 	_, store, teardown := datastore.MustNewTestStore(true, true)
 	defer teardown()
 
-	tmpDir, _ := ioutil.TempDir("", "stack")
+	tmpDir := t.TempDir()
 
 	admin := &portainer.User{ID: 1, Username: "admin"}
 	err := store.User().Create(admin)
@@ -117,7 +116,7 @@ func Test_redeployWhenChanged(t *testing.T) {
 	_, store, teardown := datastore.MustNewTestStore(true, true)
 	defer teardown()
 
-	tmpDir, _ := ioutil.TempDir("", "stack")
+	tmpDir := t.TempDir()
 
 	err := store.Endpoint().Create(&portainer.Endpoint{ID: 1})
 	assert.NoError(t, err, "error creating environment")


### PR DESCRIPTION
### Changes:
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

---

This pull request also refactors the teardown logic in `edgestack_test.go` and `endpoint_edgestatus_inspect_test.go` to use `t.Cleanup` instead of `defer`.