### PR TITLE
Feat(docker pull): allow lazy image pulling (copy paste ghcr.io or dockerhub command)

### DIFF
--- a/app/docker/services/imageService.js
+++ b/app/docker/services/imageService.js
@@ -156,6 +156,13 @@ angular.module('portainer.docker').factory('ImageService', [
      * @param {bool} ignoreErrors
      */
     function pullImage(registry, ignoreErrors) {
+      // note trailing space!
+      var dockerPullTxt = 'docker pull ';
+      const indexDockerPullTxt = registry.Image.indexOf(dockerPullTxt);
+      if (indexDockerPullTxt == 0) {
+        registry.Image = registry.Image.split(dockerPullTxt)[1];
+      }
+      
       var authenticationDetails = registry.Registry.Authentication ? RegistryService.encodedCredentials(registry.Registry) : '';
       HttpRequestHelper.setRegistryAuthenticationHeader(authenticationDetails);
 


### PR DESCRIPTION
Allows the user to enter 'docker pull image:ver' in the "Image" input box on the 'images' page.

Dockerhub and ghcr.io provide easy links to copy the ```docker pull image:ver``` to the clipboard.

This pull request allows the user to lazy copy:
![Screenshot from 2022-05-28 22-26-25](https://user-images.githubusercontent.com/845292/170841798-88037a33-04a8-48ea-8dfa-2e675d691f84.png)

note: my build environment is acting strange, hope this passes on your end!