### PR TITLE
feat(docker/container):  Support for --shm-size when creating/editing a container

### DIFF
--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -83,6 +83,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       CpuLimit: 0,
       MemoryLimit: 0,
       MemoryReservation: 0,
+      ShmSize: 64,
       CmdMode: 'default',
       EntrypointMode: 'default',
       Env: [],
@@ -365,6 +366,13 @@ angular.module('portainer.docker').controller('CreateContainerController', [
     }
 
     function prepareResources(config) {
+      // Shared Memory Size - Round to 0.125
+      if ($scope.formValues.ShmSize >= 0) {
+        var shmSize = (Math.round($scope.formValues.ShmSize * 8) / 8).toFixed(3);
+        shmSize *= 1024 * 1024;
+        config.HostConfig.ShmSize = shmSize;
+      }
+
       // Memory Limit - Round to 0.125
       if ($scope.formValues.MemoryLimit >= 0) {
         var memoryLimit = (Math.round($scope.formValues.MemoryLimit * 8) / 8).toFixed(3);
@@ -598,6 +606,9 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       }
       if (d.HostConfig.MemoryReservation) {
         $scope.formValues.MemoryReservation = d.HostConfig.MemoryReservation / 1024 / 1024;
+      }
+      if (d.HostConfig.ShmSize) {
+        $scope.formValues.ShmSize = d.HostConfig.ShmSize / 1024 / 1024;
       }
     }
 

--- a/app/docker/views/containers/create/createcontainer.html
+++ b/app/docker/views/containers/create/createcontainer.html
@@ -703,6 +703,17 @@
                 <!-- !sysctls-input-list -->
               </div>
               <!-- !sysctls -->
+              <!-- shm-size-input -->
+              <div class="form-group">
+                    <label for="shm-size" class="col-sm-2 control-label text-left"> Shared memory size </label>
+                  <div class="col-sm-2">
+                    <input type="number" min="1" class="form-control" ng-model="formValues.ShmSize" id="shm-size" />
+                  </div>
+                  <div class="col-sm-2">
+                    <p class="small text-muted mt-2"> Size of /dev/shm (<b>MB</b>) </p>
+                  </div>
+              </div>
+              <!-- !shm-size-input -->
               <div ng-class="{ 'edit-resources': state.mode == 'duplicate' }">
                 <div class="col-sm-12 form-section-title"> Resources </div>
                 <!-- memory-reservation-input -->


### PR DESCRIPTION
closes #4992  

### Changes:
Under the Runtime area: 
<img width="558" alt="image" src="https://user-images.githubusercontent.com/28103567/170877173-7a053d46-6ee5-4c4e-a0bf-3f8111530eab.png">
The default value is 64, and the min value is 1.
