### PR TITLE
Set static `DOCKER_VERSION` for `ppc64le` and `s390x`

### DIFF
--- a/build/download_docker_binary.sh
+++ b/build/download_docker_binary.sh
@@ -21,6 +21,10 @@ elif [[ ${ARCH} == "arm" ]]; then
     ARCH="armhf"
 elif [[ ${ARCH} == "arm64" ]]; then
     ARCH="aarch64"
+elif [[ ${ARCH} == "ppc64le" ]]; then
+    DOCKER_VERSION="18.06.3"
+elif [[ ${ARCH} == "s390x" ]]; then
+    DOCKER_VERSION="18.06.3"
 fi
 
 rm -rf "${DOWNLOAD_FOLDER}"


### PR DESCRIPTION
Set static `DOCKER_VERSION` for `ppc64le` and `s390x` due to missing `20.x.x` binary.