### PR TITLE
Set static `DOCKER_VERSION` for `ppc64le` and `s390x`

### DIFF
--- a/build/download_docker_binary.sh
+++ b/build/download_docker_binary.sh
@@ -22,9 +22,9 @@ elif [[ ${ARCH} == "arm" ]]; then
 elif [[ ${ARCH} == "arm64" ]]; then
     ARCH="aarch64"
 elif [[ ${ARCH} == "ppc64le" ]]; then
-    DOCKER_VERSION="18.06.3"
+    DOCKER_VERSION="18.06.3-ce"
 elif [[ ${ARCH} == "s390x" ]]; then
-    DOCKER_VERSION="18.06.3"
+    DOCKER_VERSION="18.06.3-ce"
 fi
 
 rm -rf "${DOWNLOAD_FOLDER}"


### PR DESCRIPTION
Added missing `-ce` that other platforms have...