### PR TITLE
fix(stack/swarm): update tooltip component reference [EE-2678] 

### DIFF
--- a/app/portainer/components/forms/stack-redeploy-git-form/index.js
+++ b/app/portainer/components/forms/stack-redeploy-git-form/index.js
@@ -7,6 +7,7 @@ export const stackRedeployGitForm = {
   bindings: {
     model: '<',
     stack: '<',
+    endpoint: '<',
   },
 };
 

--- a/app/portainer/components/forms/stack-redeploy-git-form/stack-redeploy-git-form.html
+++ b/app/portainer/components/forms/stack-redeploy-git-form/stack-redeploy-git-form.html
@@ -36,7 +36,7 @@
     explanation="These values will be used as substitutions in the stack file"
     on-change="($ctrl.onChangeEnvVar)"
   ></environment-variables-panel>
-  <option-panel ng-model="$ctrl.formValues.Option" on-change="($ctrl.onChangeOption)"></option-panel>
+  <option-panel ng-if="$ctrl.stack.Type === 1 && $ctrl.endpoint.apiVersion >= 1.27" ng-model="$ctrl.formValues.Option" on-change="($ctrl.onChangeOption)"></option-panel>
   <button
     class="btn btn-sm btn-primary"
     ng-click="$ctrl.submit()"

--- a/app/portainer/components/option-panel/option-panel.html
+++ b/app/portainer/components/option-panel/option-panel.html
@@ -6,7 +6,7 @@
     <div class="col-sm-12">
       <label class="control-label text-left">
         Prune services
-        <portainer-tooltip position="top" message="Prune services that are no longer referenced."></portainer-tooltip>
+        <portainer-tooltip position="'top'" message="'Prune services that are no longer referenced.'"></portainer-tooltip>
       </label>
       <label class="switch" style="margin-left: 20px"> <input type="checkbox" ng-model="$ctrl.ngModel.Prune" ng-change="$ctrl.switchPruneService()" /><i></i> </label>
     </div>

--- a/app/portainer/views/stacks/edit/stack.html
+++ b/app/portainer/views/stacks/edit/stack.html
@@ -118,6 +118,7 @@
                 model="stack.GitConfig"
                 stack="stack"
                 authorization="PortainerStackUpdate"
+                endpoint="applicationState.endpoint"
               >
               </stack-redeploy-git-form>
               <stack-duplication-form
@@ -196,7 +197,7 @@
                   <div class="col-sm-12">
                     <label for="prune" class="control-label text-left">
                       Prune services
-                      <portainer-tooltip message="'Prune services that are no longer referenced.'"></portainer-tooltip>
+                      <portainer-tooltip position="'top'" message="'Prune services that are no longer referenced.'"></portainer-tooltip>
                     </label>
                     <label class="switch" style="margin-left: 20px"> <input name="prune" type="checkbox" ng-model="formValues.Prune" /><i></i> </label>
                   </div>


### PR DESCRIPTION
closes [EE-2678]

- show the `prune` option only in the swarm stack 
- update tooltip component reference

[EE-2678]: https://portainer.atlassian.net/browse/EE-2678?