### PR TITLE
fix(migration): close the database before running backups EE-3627

### DIFF
--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -104,6 +104,9 @@ func (store *Store) backupWithOptions(options *BackupOptions) (string, error) {
 
 	options = store.setupOptions(options)
 
+	store.Close()
+	defer store.Open()
+
 	return options.BackupPath, store.copyDBFile(store.databasePath(), options.BackupPath)
 }
 

--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -103,6 +103,7 @@ func (store *Store) backupWithOptions(options *BackupOptions) (string, error) {
 	store.createBackupFolders()
 
 	options = store.setupOptions(options)
+	dbPath := store.databasePath()
 
 	if err := store.Close(); err != nil {
 		return options.BackupPath, fmt.Errorf(
@@ -111,15 +112,17 @@ func (store *Store) backupWithOptions(options *BackupOptions) (string, error) {
 		)
 	}
 
-	if err := store.copyDBFile(store.databasePath(), options.BackupPath); err != nil {
-		return options.BackupDir, err
+	if err := store.copyDBFile(dbPath, options.BackupPath); err != nil {
+		return options.BackupPath, err
 	}
 
-	_, err := store.Open()
-	return options.BackupDir, fmt.Errorf(
-		"error opening datastore after creating backup: %v",
-		err,
-	)
+	if _, err := store.Open(); err != nil {
+		return options.BackupPath, fmt.Errorf(
+			"error opening datastore after creating backup: %v",
+			err,
+		)
+	}
+	return options.BackupPath, nil
 }
 
 // RestoreWithOptions previously saved backup for the current Edition  with options

--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -104,10 +104,22 @@ func (store *Store) backupWithOptions(options *BackupOptions) (string, error) {
 
 	options = store.setupOptions(options)
 
-	store.Close()
-	defer store.Open()
+	if err := store.Close(); err != nil {
+		return options.BackupPath, fmt.Errorf(
+			"error closing datastore before creating backup: %v",
+			err,
+		)
+	}
 
-	return options.BackupPath, store.copyDBFile(store.databasePath(), options.BackupPath)
+	if err := store.copyDBFile(store.databasePath(), options.BackupPath); err != nil {
+		return options.BackupDir, err
+	}
+
+	_, err := store.Open()
+	return options.BackupDir, fmt.Errorf(
+		"error opening datastore after creating backup: %v",
+		err,
+	)
 }
 
 // RestoreWithOptions previously saved backup for the current Edition  with options


### PR DESCRIPTION
On certain filesystems, particuarly NTFS when a network mounted windows
file server is used to store portainer's database, you are unable to
copy the database while it is open. To fix this we simply close the
database and then re-open it after a backup.