### PR TITLE
fix(kubeconfig): fix kubeconfig url EE-3455

### DIFF
--- a/api/http/handler/helm/handler.go
+++ b/api/http/handler/helm/handler.go
@@ -100,7 +100,15 @@ func (handler *Handler) getHelmClusterAccess(r *http.Request) (*options.Kubernet
 		return nil, &httperror.HandlerError{http.StatusUnauthorized, "Unauthorized", err}
 	}
 
+	sslSettings, err := handler.dataStore.SSLSettings().Settings()
+	if err != nil {
+		return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve settings from the database", err}
+	}
+
 	hostURL := "localhost"
+	if !sslSettings.SelfSigned {
+		hostURL = r.Host
+	}
 
 	kubeConfigInternal := handler.kubeClusterAccessService.GetData(hostURL, endpoint.ID)
 	return &options.KubernetesClusterAccess{

--- a/api/http/handler/helm/handler.go
+++ b/api/http/handler/helm/handler.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/portainer/libhelm"
@@ -101,15 +100,7 @@ func (handler *Handler) getHelmClusterAccess(r *http.Request) (*options.Kubernet
 		return nil, &httperror.HandlerError{http.StatusUnauthorized, "Unauthorized", err}
 	}
 
-	sslSettings, err := handler.dataStore.SSLSettings().Settings()
-	if err != nil {
-		return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to retrieve settings from the database", err}
-	}
-
 	hostURL := "localhost"
-	if !sslSettings.SelfSigned {
-		hostURL = strings.Split(r.Host, ":")[0]
-	}
 
 	kubeConfigInternal := handler.kubeClusterAccessService.GetData(hostURL, endpoint.ID)
 	return &options.KubernetesClusterAccess{

--- a/api/http/handler/kubernetes/kubernetes_config.go
+++ b/api/http/handler/kubernetes/kubernetes_config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	httperror "github.com/portainer/libhttp/error"
 	"github.com/portainer/libhttp/request"
@@ -145,8 +144,7 @@ func (handler *Handler) buildConfig(r *http.Request, tokenData *portainer.TokenD
 }
 
 func (handler *Handler) buildCluster(r *http.Request, endpoint portainer.Endpoint) clientV1.NamedCluster {
-	hostURL := strings.Split(r.Host, ":")[0]
-	kubeConfigInternal := handler.kubeClusterAccessService.GetData(hostURL, endpoint.ID)
+	kubeConfigInternal := handler.kubeClusterAccessService.GetData(r.Host, endpoint.ID)
 	return clientV1.NamedCluster{
 		Name: buildClusterName(endpoint.Name),
 		Cluster: clientV1.Cluster{

--- a/api/kubernetes/kubeclusteraccess_service.go
+++ b/api/kubernetes/kubeclusteraccess_service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	portainer "github.com/portainer/portainer/api"
+	"github.com/sirupsen/logrus"
 )
 
 // KubeClusterAccessService represents a service that is responsible for centralizing kube cluster access data
@@ -94,11 +95,20 @@ func (service *kubeClusterAccessService) IsSecure() bool {
 // - pass down params to binaries
 func (service *kubeClusterAccessService) GetData(hostURL string, endpointID portainer.EndpointID) kubernetesClusterAccessData {
 	baseURL := service.baseURL
+
+	// When the api call is internal, the baseURL should not be used.
+	if hostURL == "localhost" {
+		hostURL = hostURL + service.httpsBindAddr
+		baseURL = "/"
+	}
+
 	if baseURL != "/" {
 		baseURL = fmt.Sprintf("/%s/", strings.Trim(baseURL, "/"))
 	}
 
-	clusterURL := hostURL + service.httpsBindAddr + baseURL
+	logrus.Infof("[kubeconfig] [hostURL: %s, httpsBindAddr: %s, baseURL: %s]", hostURL, service.httpsBindAddr, baseURL)
+
+	clusterURL := hostURL + baseURL
 
 	clusterServerURL := fmt.Sprintf("https://%sapi/endpoints/%d/kubernetes", clusterURL, endpointID)
 

--- a/api/kubernetes/kubeclusteraccess_service_test.go
+++ b/api/kubernetes/kubeclusteraccess_service_test.go
@@ -115,7 +115,7 @@ func TestKubeClusterAccessService_GetKubeConfigInternal(t *testing.T) {
 		clusterAccessDetails := kcs.GetData("mysite.com", 1)
 
 		wantClusterAccessDetails := kubernetesClusterAccessData{
-			ClusterServerURL:         "https://mysite.com:9443/api/endpoints/1/kubernetes",
+			ClusterServerURL:         "https://mysite.com/api/endpoints/1/kubernetes",
 			CertificateAuthorityFile: "",
 			CertificateAuthorityData: "",
 		}

--- a/app/kubernetes/helm/rest.js
+++ b/app/kubernetes/helm/rest.js
@@ -5,7 +5,7 @@ angular.module('portainer.kubernetes').factory('HelmFactory', HelmFactory);
 /* @ngInject */
 function HelmFactory($resource, API_ENDPOINT_ENDPOINTS) {
   const helmUrl = API_ENDPOINT_ENDPOINTS + '/:endpointId/kubernetes/helm';
-  const templatesUrl = '/api/templates/helm';
+  const templatesUrl = 'api/templates/helm';
 
   return $resource(
     helmUrl,


### PR DESCRIPTION


closes [EE-3455] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
- helm templates api call fix for proxy url
- kubeconfig url fix

[EE-3455]: https://portainer.atlassian.net/browse/EE-3455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ