### PR TITLE
chore(version): bump version to 2.14.2 [EE-3754]

### DIFF
--- a/api/datastore/test_data/output_24_to_latest.json
+++ b/api/datastore/test_data/output_24_to_latest.json
@@ -910,7 +910,7 @@
   ],
   "version": {
     "DB_UPDATING": "false",
-    "DB_VERSION": "51",
+    "DB_VERSION": "52",
     "INSTANCE_ID": "null"
   }
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -80,7 +80,7 @@ type Handler struct {
 }
 
 // @title PortainerCE API
-// @version 2.14.1
+// @version 2.14.2
 // @description.markdown api-description.md
 // @termsOfService
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1385,9 +1385,9 @@ type (
 
 const (
 	// APIVersion is the version number of the Portainer API
-	APIVersion = "2.14.1"
+	APIVersion = "2.14.2"
 	// DBVersion is the version number of the Portainer database
-	DBVersion = 51
+	DBVersion = 52
 	// ComposeSyntaxMaxVersion is a maximum supported version of the docker compose syntax
 	ComposeSyntaxMaxVersion = "3.9"
 	// AssetsServerURL represents the URL of the Portainer asset server

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Portainer.io",
   "name": "portainer",
   "homepage": "http://portainer.io",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:portainer/portainer.git"


### PR DESCRIPTION
Closes: [EE-3754](https://portainer.atlassian.net/browse/EE-3754)