### PR TITLE
fix(ldap/tls): allow to upload TLS CA certificate [EE-3654]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ storybook-static
 .tmp
 **/.vscode/settings.json
 **/.vscode/tasks.json
+.vscode
 *.DS_Store
 
 .eslintcache

--- a/app/portainer/settings/authentication/ldap/ldap-settings/index.js
+++ b/app/portainer/settings/authentication/ldap/ldap-settings/index.js
@@ -5,6 +5,7 @@ export const ldapSettings = {
   controller,
   bindings: {
     settings: '=',
+    tlscaCert: '=',
     state: '<',
     connectivityCheck: '<',
     onSaveSettings: '<',

--- a/app/portainer/settings/authentication/ldap/ldap-settings/ldap-settings.controller.js
+++ b/app/portainer/settings/authentication/ldap/ldap-settings/ldap-settings.controller.js
@@ -31,7 +31,7 @@ export default class LdapSettingsController {
   }
 
   $onInit() {
-    this.tlscaCert = this.settings.TLSCACert;
+    this.tlscaCert = this.settings.TLSConfig.TLSCACert;
   }
 
   onChangeServerType(serverType) {

--- a/app/portainer/views/settings/authentication/settingsAuthenticationController.js
+++ b/app/portainer/views/settings/authentication/settingsAuthenticationController.js
@@ -187,7 +187,7 @@ function SettingsAuthenticationController($q, $scope, $state, Notifications, Set
     return (
       _.compact(ldapSettings.URLs).length &&
       (ldapSettings.AnonymousMode || (ldapSettings.ReaderDN && ldapSettings.Password)) &&
-      (!isTLSMode || $scope.formValues.TLSCACert || ldapSettings.TLSConfig.TLSSkipVerify) &&
+      (!isTLSMode || (isTLSMode && $scope.formValues.TLSCACert) || ldapSettings.TLSConfig.TLSSkipVerify) &&
       (!$scope.settings.LDAPSettings.AdminAutoPopulate || ($scope.settings.LDAPSettings.AdminAutoPopulate && $scope.formValues.selectedAdminGroups.length > 0))
     );
   }


### PR DESCRIPTION
closes [EE-3654]

- allow to upload the ca certificate 
- display the correct tls setting information

[EE-3654]: https://portainer.atlassian.net/browse/EE-3654?