### PR TITLE
fix(cache): trigger page reload on logout EE-3188

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,9 @@
     <title>Portainer</title>
     <meta name="description" content="" />
     <meta name="author" content="<%= author %>" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="pragma" content="no-cache" />
     <base id="base" />
     <script>
       if (window.origin == 'file://') {

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -22,6 +22,7 @@ async function initAuthentication(authManager, Authentication, $rootScope, $stat
   $rootScope.$on('unauthenticated', function (event, data) {
     if (!_.includes(data.config.url, '/v2/') && !_.includes(data.config.url, '/api/v4/') && isTransitionRequiresAuthentication($state.transition)) {
       $state.go('portainer.logout', { error: 'Your session has expired' });
+      window.location.reload();
     }
   });
 


### PR DESCRIPTION
https://portainer.atlassian.net/browse/EE-3188

When portainer is restarted the user's session is invalidated and as
soon as they start clicking around they will be logged out. This PR does
two additional things when this happens.

1) We trigger a browser page reload which will force the client the grab
   the latest version of our js, css, etc. Previously if a user updated
   portainer, but never clicked the browser's refresh button they would
   never see new css changes.

2) We also set "cache-control no-cache" on the index.html header. Since
   portainer is an SPA and the the index.html is very small it makes
   sense to avoid letting the browser cache it so that the user is
   always given the latest version when the above reload is triggered.

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
