### PR TITLE
fix(endpoint handler): fix endpoint address(url) parsing EE-3081]

### DIFF
--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -258,6 +258,14 @@ func (handler *Handler) createEndpoint(payload *endpointCreatePayload) (*portain
 
 	endpointType := portainer.DockerEnvironment
 	if payload.EndpointCreationType == agentEnvironment {
+		if strings.HasPrefix(payload.URL, "https://") {
+			payload.URL = strings.TrimPrefix(payload.URL, "https://")
+		} else if strings.HasPrefix(payload.URL, "http://") {
+			payload.URL = strings.TrimPrefix(payload.URL, "http://")
+		}
+
+		payload.URL = "tcp://" + payload.URL
+
 		agentPlatform, err := handler.pingAndCheckPlatform(payload)
 		if err != nil {
 			return nil, &httperror.HandlerError{http.StatusInternalServerError, "Unable to get environment type", err}

--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -258,10 +258,11 @@ func (handler *Handler) createEndpoint(payload *endpointCreatePayload) (*portain
 
 	endpointType := portainer.DockerEnvironment
 	if payload.EndpointCreationType == agentEnvironment {
-		if strings.HasPrefix(payload.URL, "https://") {
-			payload.URL = strings.TrimPrefix(payload.URL, "https://")
-		} else if strings.HasPrefix(payload.URL, "http://") {
-			payload.URL = strings.TrimPrefix(payload.URL, "http://")
+
+		// Case insensitive strip http or https scheme if URL entered
+		index := strings.Index(payload.URL, "://")
+		if index >= 0 {
+			payload.URL = payload.URL[index+3:]
 		}
 
 		payload.URL = "tcp://" + payload.URL

--- a/app/portainer/environments/environment.service/create.ts
+++ b/app/portainer/environments/environment.service/create.ts
@@ -130,7 +130,7 @@ export async function createRemoteEnvironment({
 }: CreateRemoteEnvironment) {
   return createEnvironment(name, creationType, {
     ...options,
-    url: `tcp://${url}`,
+    url: `${url}`,
   });
 }
 

--- a/app/react/portainer/environments/wizard/EnvironmentsCreationView/shared/AgentForm/EnvironmentUrlField.tsx
+++ b/app/react/portainer/environments/wizard/EnvironmentsCreationView/shared/AgentForm/EnvironmentUrlField.tsx
@@ -8,10 +8,11 @@ export function EnvironmentUrlField() {
 
   return (
     <FormControl
-      label="Environment URL"
+      label="Environment address"
       errors={meta.error}
       required
       inputId="environment-url-field"
+      tooltip="A host:port combination. The host can be either an IP address or a host name."
     >
       <Field
         id="environment-url-field"


### PR DESCRIPTION
Closes [EE-3081](https://portainer.atlassian.net/browse/EE-3081) and [EE-3819](https://portainer.atlassian.net/browse/EE-3819)