### PR TITLE
fix(data-cy): rename the duplicated data-cy attribute in kube data table pages [EE-3749]

### DIFF
--- a/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
@@ -51,7 +51,7 @@
                       ng-model="$ctrl.settings.repeater.refreshRate"
                       ng-change="$ctrl.onSettingsRepeaterChange()"
                       class="small-select"
-                      data-cy="k8sApp-refreshRateDropdown"
+                      data-cy="k8sApp-refreshRateDropdown-port"
                     >
                       <option value="10">10s</option>
                       <option value="30">30s</option>

--- a/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
@@ -40,7 +40,7 @@
                       type="checkbox"
                       ng-model="$ctrl.settings.repeater.autoRefresh"
                       ng-change="$ctrl.onSettingsRepeaterChange()"
-                      data-cy="k8sApp-autoRefreshCheckbox"
+                      data-cy="k8sApp-autoRefreshCheckbox-port"
                     />
                     <label for="setting_auto_refresh">Auto refresh</label>
                   </div>

--- a/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
@@ -66,7 +66,7 @@
                 </div>
               </div>
               <div>
-                <a type="button" class="btn btn-sm btn-default btn-sm" ng-click="$ctrl.settings.open = false;" data-cy="k8sApp-tableSettingsCloseButton">Close</a>
+                <a type="button" class="btn btn-sm btn-default btn-sm" ng-click="$ctrl.settings.open = false;" data-cy="k8sApp-tableSettingsCloseButton-port">Close</a>
               </div>
             </div>
           </div>

--- a/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-ports-datatable/applicationsPortsDatatable.html
@@ -20,7 +20,7 @@
         />
       </div>
       <!-- actions -->
-      <div data-cy="k8sApp-tableSettings" class="settings">
+      <div data-cy="k8sApp-portTableSettings" class="settings">
         <span class="setting" ng-class="{ 'setting-active': $ctrl.settings.open }" uib-dropdown dropdown-append-to-body auto-close="disabled" is-open="$ctrl.settings.open">
           <span uib-dropdown-toggle aria-label="Settings">
             <pr-icon icon="'more-vertical'" feather="true" class-name="'icon !mr-0 !h-4'"></pr-icon>

--- a/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
+++ b/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
@@ -62,7 +62,7 @@
                         ng-model="$ctrl.settings.repeater.refreshRate"
                         ng-change="$ctrl.onSettingsRepeaterChange()"
                         class="small-select"
-                        data-cy="k8sApp-refreshRateDropdown"
+                        data-cy="k8sApp-refreshRateDropdown-stack"
                       >
                         <option value="10">10s</option>
                         <option value="30">30s</option>

--- a/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
+++ b/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
@@ -77,7 +77,7 @@
                   </div>
                 </div>
                 <div>
-                  <a type="button" class="btn btn-sm btn-default btn-sm" ng-click="$ctrl.settings.open = false;" data-cy="k8sApp-tableSettingsCloseButton">Close</a>
+                  <a type="button" class="btn btn-sm btn-default btn-sm" ng-click="$ctrl.settings.open = false;" data-cy="k8sApp-tableSettingsCloseButton-stack">Close</a>
                 </div>
               </div>
             </div>

--- a/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
+++ b/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
@@ -31,7 +31,7 @@
           <pr-icon icon="'trash-2'" feather="true"></pr-icon>
           Remove
         </button>
-        <div class="settings" data-cy="k8sApp-tableSettings">
+        <div class="settings" data-cy="k8sApp-StackTableSettings">
           <span class="setting" ng-class="{ 'setting-active': $ctrl.settings.open }" uib-dropdown dropdown-append-to-body auto-close="disabled" is-open="$ctrl.settings.open">
             <span uib-dropdown-toggle>
               <pr-icon icon="'more-vertical'" feather="true" class-name="'!mr-0 !h-4'"></pr-icon>

--- a/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
+++ b/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
@@ -26,7 +26,7 @@
           class="btn btn-sm btn-dangerlight h-fit vertical-center !ml-0"
           ng-disabled="$ctrl.state.selectedItemCount === 0"
           ng-click="$ctrl.removeAction($ctrl.state.selectedItems)"
-          data-cy="k8sApp-removeAppButton"
+          data-cy="k8sApp-removeStackButton"
         >
           <pr-icon icon="'trash-2'" feather="true"></pr-icon>
           Remove

--- a/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
+++ b/app/kubernetes/components/datatables/applications-stacks-datatable/applicationsStacksDatatable.html
@@ -51,7 +51,7 @@
                         type="checkbox"
                         ng-model="$ctrl.settings.repeater.autoRefresh"
                         ng-change="$ctrl.onSettingsRepeaterChange()"
-                        data-cy="k8sApp-autoRefreshCheckbox"
+                        data-cy="k8sApp-autoRefreshCheckbox-stack"
                       />
                       <label for="setting_auto_refresh">Auto refresh</label>
                     </div>


### PR DESCRIPTION
close [EE-3749]
### Changes: rename the duplicated data-cy attribute in kube stack data table page
[EE-3749]: https://portainer.atlassian.net/browse/EE-3749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ