### PR TITLE
feat(environment): update wording when editing agent environment [EE-3081]

### DIFF
--- a/api/http/handler/endpoints/endpoint_create.go
+++ b/api/http/handler/endpoints/endpoint_create.go
@@ -259,13 +259,7 @@ func (handler *Handler) createEndpoint(payload *endpointCreatePayload) (*portain
 	endpointType := portainer.DockerEnvironment
 	if payload.EndpointCreationType == agentEnvironment {
 
-		// Case insensitive strip http or https scheme if URL entered
-		index := strings.Index(payload.URL, "://")
-		if index >= 0 {
-			payload.URL = payload.URL[index+3:]
-		}
-
-		payload.URL = "tcp://" + payload.URL
+		payload.URL = "tcp://" + normalizeAgentAddress(payload.URL)
 
 		agentPlatform, err := handler.pingAndCheckPlatform(payload)
 		if err != nil {

--- a/api/http/handler/endpoints/endpoint_update.go
+++ b/api/http/handler/endpoints/endpoint_update.go
@@ -105,7 +105,12 @@ func (handler *Handler) endpointUpdate(w http.ResponseWriter, r *http.Request) *
 	}
 
 	if payload.URL != nil {
-		endpoint.URL = *payload.URL
+		if endpoint.Type == portainer.AgentOnDockerEnvironment ||
+			endpoint.Type == portainer.AgentOnKubernetesEnvironment {
+			endpoint.URL = normalizeAgentAddress(*payload.URL)
+		} else {
+			endpoint.URL = *payload.URL
+		}
 	}
 
 	if payload.PublicURL != nil {

--- a/api/http/handler/endpoints/utils.go
+++ b/api/http/handler/endpoints/utils.go
@@ -1,6 +1,18 @@
 package endpoints
 
+import "strings"
+
 func BoolAddr(b bool) *bool {
 	boolVar := b
 	return &boolVar
+}
+
+func normalizeAgentAddress(url string) string {
+	// Case insensitive strip http or https scheme if URL entered
+	index := strings.Index(url, "://")
+	if index >= 0 {
+		return url[index+3:]
+	}
+
+	return url
 }

--- a/app/portainer/views/endpoints/edit/endpoint.html
+++ b/app/portainer/views/endpoints/edit/endpoint.html
@@ -107,7 +107,8 @@
           <!-- endpoint-url-input -->
           <div class="form-group" ng-if="!state.edgeEndpoint">
             <label for="endpoint_url" class="col-sm-3 col-lg-2 control-label text-left">
-              Environment URL
+              <span ng-if="!state.agentEndpoint">Environment URL</span>
+              <span ng-if="state.agentEndpoint">Environment address</span>
               <portainer-tooltip
                 message="'URL or IP address of a Docker host. The Docker API must be exposed over a TCP port. Please refer to the Docker documentation to configure it.'"
               >


### PR DESCRIPTION
When editing an agent environment, update the wording to also say "address" instead of "URL"

Closes: [EE-3081](https://portainer.atlassian.net/browse/EE-3081)