### PR TITLE
fix(edge): parse agent platform on every polling request to avoid endpoint misconfiguration

### DIFF
--- a/api/http/handler/endpointedge/endpoint_edgestatus_inspect.go
+++ b/api/http/handler/endpointedge/endpoint_edgestatus_inspect.go
@@ -77,13 +77,13 @@ func (handler *Handler) endpointEdgeStatusInspect(w http.ResponseWriter, r *http
 	if endpoint.EdgeID == "" {
 		edgeIdentifier := r.Header.Get(portainer.PortainerAgentEdgeIDHeader)
 		endpoint.EdgeID = edgeIdentifier
-
-		agentPlatform, agentPlatformErr := parseAgentPlatform(r)
-		if agentPlatformErr != nil {
-			return httperror.BadRequest("agent platform header is not valid", err)
-		}
-		endpoint.Type = agentPlatform
 	}
+
+	agentPlatform, agentPlatformErr := parseAgentPlatform(r)
+	if agentPlatformErr != nil {
+		return httperror.BadRequest("agent platform header is not valid", err)
+	}
+	endpoint.Type = agentPlatform
 
 	endpoint.LastCheckInDate = time.Now().Unix()
 

--- a/api/http/handler/endpointedge/endpoint_edgestatus_inspect_test.go
+++ b/api/http/handler/endpointedge/endpoint_edgestatus_inspect_test.go
@@ -57,7 +57,7 @@ var endpointTestCases = []endpointTestCase{
 		portainer.EndpointRelation{
 			EndpointID: 2,
 		},
-		http.StatusBadRequest,
+		http.StatusForbidden,
 	},
 	{
 		portainer.Endpoint{
@@ -194,7 +194,9 @@ func TestWithEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatal("request error:", err)
 		}
-		req.Header.Set(portainer.PortainerAgentEdgeIDHeader, "edge-id")
+
+		req.Header.Set(portainer.PortainerAgentEdgeIDHeader, test.endpoint.EdgeID)
+		req.Header.Set(portainer.HTTPResponseAgentPlatform, "1")
 
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)

--- a/api/http/handler/endpointedge/endpoint_edgestatus_inspect_test.go
+++ b/api/http/handler/endpointedge/endpoint_edgestatus_inspect_test.go
@@ -241,6 +241,7 @@ func TestLastCheckInDateIncreases(t *testing.T) {
 		t.Fatal("request error:", err)
 	}
 	req.Header.Set(portainer.PortainerAgentEdgeIDHeader, "edge-id")
+	req.Header.Set(portainer.HTTPResponseAgentPlatform, "1")
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -357,6 +358,7 @@ func TestEdgeStackStatus(t *testing.T) {
 		t.Fatal("request error:", err)
 	}
 	req.Header.Set(portainer.PortainerAgentEdgeIDHeader, "edge-id")
+	req.Header.Set(portainer.HTTPResponseAgentPlatform, "1")
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -426,6 +428,7 @@ func TestEdgeJobsResponse(t *testing.T) {
 		t.Fatal("request error:", err)
 	}
 	req.Header.Set(portainer.PortainerAgentEdgeIDHeader, "edge-id")
+	req.Header.Set(portainer.HTTPResponseAgentPlatform, "1")
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)


### PR DESCRIPTION
closes [EE-3095](https://portainer.atlassian.net/browse/EE-3095)
