### PR TITLE
chore(version): bump version to 2.16.0 [EE-3755]

### DIFF
--- a/api/datastore/test_data/output_24_to_latest.json
+++ b/api/datastore/test_data/output_24_to_latest.json
@@ -919,7 +919,7 @@
   ],
   "version": {
     "DB_UPDATING": "false",
-    "DB_VERSION": "60",
+    "DB_VERSION": "70",
     "INSTANCE_ID": "null"
   }
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -82,7 +82,7 @@ type Handler struct {
 }
 
 // @title PortainerCE API
-// @version 2.15.0
+// @version 2.16.0
 // @description.markdown api-description.md
 // @termsOfService
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1400,9 +1400,9 @@ type (
 
 const (
 	// APIVersion is the version number of the Portainer API
-	APIVersion = "2.15.0"
+	APIVersion = "2.16.0"
 	// DBVersion is the version number of the Portainer database
-	DBVersion = 60
+	DBVersion = 70
 	// ComposeSyntaxMaxVersion is a maximum supported version of the docker compose syntax
 	ComposeSyntaxMaxVersion = "3.9"
 	// AssetsServerURL represents the URL of the Portainer asset server

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Portainer.io",
   "name": "portainer",
   "homepage": "http://portainer.io",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:portainer/portainer.git"


### PR DESCRIPTION
Closes: [EE-3755](https://portainer.atlassian.net/browse/EE-3755)