### PR TITLE
fix(stack): hide containers for swarm stack [EE-3969]

### DIFF
--- a/app/portainer/views/stacks/edit/stackController.js
+++ b/app/portainer/views/stacks/edit/stackController.js
@@ -497,7 +497,8 @@ angular.module('portainer.app').controller('StackController', [
 
       $scope.composeSyntaxMaxVersion = endpoint.ComposeSyntaxMaxVersion;
 
-      $scope.stackType = $transition$.params().type;
+      $scope.stackType = parseInt($transition$.params().type, 10);
+
       $scope.editorReadOnly = !Authentication.hasAuthorizations(['PortainerStackUpdate']);
     }
 


### PR DESCRIPTION
fixes [EE-3969]

changes:
- query parameter `stackType` is parsed as int


[EE-3969]: https://portainer.atlassian.net/browse/EE-3969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ