### PR TITLE
fix(stack/compose): remove orphan containers if stack deployment is failed [EE-4144]

### DIFF
--- a/api/stacks/deployer.go
+++ b/api/stacks/deployer.go
@@ -52,7 +52,11 @@ func (d *stackDeployer) DeployComposeStack(stack *portainer.Stack, endpoint *por
 	d.swarmStackManager.Login(registries, endpoint)
 	defer d.swarmStackManager.Logout(endpoint)
 
-	return d.composeStackManager.Up(context.TODO(), stack, endpoint, forceRereate)
+	err := d.composeStackManager.Up(context.TODO(), stack, endpoint, forceRereate)
+	if err != nil {
+		d.composeStackManager.Down(context.TODO(), stack, endpoint)
+	}
+	return err
 }
 
 func (d *stackDeployer) DeployKubernetesStack(stack *portainer.Stack, endpoint *portainer.Endpoint, user *portainer.User) error {


### PR DESCRIPTION
closes [EE-4144]

### Changes:

When deploying a compose stack with the mapping port that is already in use, the container defined in the compose file will still be created but no port specified and it will be marked as external stack. 
This PR fixes the issue by removing orphan containers created from the same compose file, so that no unexpected stack will show in the stack list.

[EE-4144]: https://portainer.atlassian.net/browse/EE-4144?
