### PR TITLE
chore(readme): update readme to display latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please note that the public demo cluster is **reset every 15min**.
 
 Portainer CE is updated regularly. We aim to do an update release every couple of months.
 
-**The latest version of Portainer is 2.13.x**.
+<a href="https://github.com/portainer/portainer/releases/latest"><img alt="latest version" src="https://img.shields.io/github/v/release/portainer/portainer?color=%2344cc11&label=Latest%20release&style=for-the-badge"></img></a>
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please note that the public demo cluster is **reset every 15min**.
 
 Portainer CE is updated regularly. We aim to do an update release every couple of months.
 
-<a href="https://github.com/portainer/portainer/releases/latest"><img alt="latest version" src="https://img.shields.io/github/v/release/portainer/portainer?color=%2344cc11&label=Latest%20release&style=for-the-badge"></img></a>
+[![latest version](https://img.shields.io/github/v/release/portainer/portainer?color=%2344cc11&label=Latest%20release&style=for-the-badge)](https://github.com/portainer/portainer/releases/latest)
 
 ## Getting started
 


### PR DESCRIPTION
To keep the latest version up to date, I created a badge

See the affect here:  https://github.com/portainer/portainer/tree/chore/update-readme