### PR TITLE
fix(registry): fix anonymous dockerhub name to make it same with BE [EE4208]

### DIFF
--- a/app/portainer/models/dockerhub.js
+++ b/app/portainer/models/dockerhub.js
@@ -3,6 +3,6 @@ import { RegistryTypes } from './registryTypes';
 export function DockerHubViewModel() {
   this.Id = 0;
   this.Type = RegistryTypes.ANONYMOUS;
-  this.Name = 'DockerHub (anonymous)';
+  this.Name = 'Docker Hub (anonymous)';
   this.URL = 'docker.io';
 }


### PR DESCRIPTION
closes [EE-4208](https://portainer.atlassian.net/browse/EE-4208)
