### PR TITLE
(UI): bugfix space on sm login page

### DIFF
--- a/app/portainer/views/auth/auth.html
+++ b/app/portainer/views/auth/auth.html
@@ -1,7 +1,7 @@
 <div class="page-wrapper">
   <!-- login box -->
   <div class="container simple-box">
-    <div class="col-sm-4 col-sm-offset-4">
+    <div class="col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-4">
       <!-- login box logo -->
       <div class="row">
         <img ng-if="!ctrl.logo" src="~@/assets/images/logo_alt.svg" class="simple-box-logo" alt="Portainer" />


### PR DESCRIPTION
Greetings. 

Testing portainer with Chrome and resizing the window, showed this UI bug.


![Before](https://user-images.githubusercontent.com/38993394/192582789-885fd1ca-fc02-495a-b94c-b322fa68d0e6.png)

### Changes:

Changed the classes that are assign in the login container to give enough space.

With this change, the login box will resize propperly and I added the md class to keep the original look.

![After](https://user-images.githubusercontent.com/38993394/192583096-66e4c040-9470-4bb4-be71-e885a76b687e.png)

