### PR TITLE
fix(stack): validate original containers names [EE-4520]

### DIFF
--- a/app/portainer/helpers/stackHelper.js
+++ b/app/portainer/helpers/stackHelper.js
@@ -23,28 +23,49 @@ angular.module('portainer.app').factory('StackHelper', [
       );
     }
 
-    helper.validateYAML = function (yaml, containerNames) {
-      let yamlObject;
-
-      try {
-        yamlObject = YAML.parse(yaml);
-      } catch (err) {
-        return 'There is an error in the yaml syntax: ' + err;
-      }
-
-      const names = _.uniq(GenericHelper.findDeepAll(yamlObject, 'container_name'));
-      const duplicateContainers = _.intersection(containerNames, names);
-
-      if (duplicateContainers.length === 0) return;
-
-      return (
-        (duplicateContainers.length === 1 ? 'This container name is' : 'These container names are') +
-        ' already used by another container running in this environment: ' +
-        _.join(duplicateContainers, ', ') +
-        '.'
-      );
-    };
+    helper.validateYAML = validateYAML;
 
     return helper;
   },
 ]);
+
+function validateYAML(yaml, containerNames, originalContainersNames = []) {
+  let yamlObject;
+
+  try {
+    yamlObject = YAML.parse(yaml);
+  } catch (err) {
+    return 'There is an error in the yaml syntax: ' + err;
+  }
+
+  const names = _.uniq(GenericHelper.findDeepAll(yamlObject, 'container_name'));
+
+  if (names.length === originalContainersNames.length && _.difference(names, originalContainersNames).length === 0) {
+    return '';
+  }
+
+  const duplicateContainers = _.intersection(containerNames, names);
+
+  if (duplicateContainers.length === 0) {
+    return '';
+  }
+
+  return (
+    (duplicateContainers.length === 1 ? 'This container name is' : 'These container names are') +
+    ' already used by another container running in this environment: ' +
+    _.join(duplicateContainers, ', ') +
+    '.'
+  );
+}
+
+export function extractContainerNames(yaml = '') {
+  let yamlObject;
+
+  try {
+    yamlObject = YAML.parse(yaml);
+  } catch (err) {
+    return [];
+  }
+
+  return _.uniq(GenericHelper.findDeepAll(yamlObject, 'container_name'));
+}

--- a/app/portainer/helpers/stackHelper.js
+++ b/app/portainer/helpers/stackHelper.js
@@ -40,11 +40,7 @@ function validateYAML(yaml, containerNames, originalContainersNames = []) {
 
   const names = _.uniq(GenericHelper.findDeepAll(yamlObject, 'container_name'));
 
-  if (names.length === originalContainersNames.length && _.difference(names, originalContainersNames).length === 0) {
-    return '';
-  }
-
-  const duplicateContainers = _.intersection(containerNames, names);
+  const duplicateContainers = _.intersection(_.difference(containerNames, originalContainersNames), names);
 
   if (duplicateContainers.length === 0) {
     return '';

--- a/app/portainer/views/stacks/edit/stack.html
+++ b/app/portainer/views/stacks/edit/stack.html
@@ -141,6 +141,9 @@
                 <span class="col-sm-12 text-muted small">
                   You can get more information about Compose file format in the <a href="https://docs.docker.com/compose/compose-file/" target="_blank">official documentation</a>.
                 </span>
+                <div class="col-sm-12" ng-if="state.yamlError">
+                  <span class="text-danger small">{{ state.yamlError }}</span>
+                </div>
               </div>
               <div class="form-group">
                 <div class="col-sm-12">

--- a/app/portainer/views/stacks/edit/stackController.js
+++ b/app/portainer/views/stacks/edit/stackController.js
@@ -3,6 +3,7 @@ import { AccessControlFormData } from 'Portainer/components/accessControlForm/po
 import { FeatureId } from 'Portainer/feature-flags/enums';
 import { getEnvironments } from '@/portainer/environments/environment.service';
 import { StackStatus, StackType } from '@/react/docker/stacks/types';
+import { extractContainerNames } from '@/portainer/helpers/stackHelper';
 
 angular.module('portainer.app').controller('StackController', [
   '$async',
@@ -281,7 +282,7 @@ angular.module('portainer.app').controller('StackController', [
       if ($scope.stackFileContent.replace(/(\r\n|\n|\r)/gm, '') !== cm.getValue().replace(/(\r\n|\n|\r)/gm, '')) {
         $scope.state.isEditorDirty = true;
         $scope.stackFileContent = cm.getValue();
-        $scope.state.yamlError = StackHelper.validateYAML($scope.stackFileContent, $scope.containerNames);
+        $scope.state.yamlError = StackHelper.validateYAML($scope.stackFileContent, $scope.containerNames, $scope.state.originalContainerNames);
       }
     };
 
@@ -371,8 +372,9 @@ angular.module('portainer.app').controller('StackController', [
             if (isSwarm && $scope.stack.Status === StackStatus.Active) {
               assignSwarmStackResources(data.resources, agentProxy);
             }
+            $scope.state.originalContainerNames = extractContainerNames($scope.stackFileContent);
 
-            $scope.state.yamlError = StackHelper.validateYAML($scope.stackFileContent, $scope.containerNames);
+            $scope.state.yamlError = StackHelper.validateYAML($scope.stackFileContent, $scope.containerNames, $scope.state.originalContainerNames);
           })
           .catch(function error(err) {
             Notifications.error('Failure', err, 'Unable to retrieve stack details');


### PR DESCRIPTION
closes [EE-4520]

- add option to pass original containers names to validation function
- show validation error on edit



[EE-4520]: https://portainer.atlassian.net/browse/EE-4520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ