### PR TITLE
fix(setting/auth): save different authentication setting if custom ldap server is not set [EE-3155]

### DIFF
--- a/app/portainer/settings/authentication/ldap/ldap-settings-custom/ldap-settings-custom.html
+++ b/app/portainer/settings/authentication/ldap/ldap-settings-custom/ldap-settings-custom.html
@@ -34,15 +34,7 @@
   </label>
   <div class="col-sm-9 col-lg-10">
     <div class="mb-3 flex" ng-repeat="url in $ctrl.settings.URLs track by $index">
-      <input
-        type="text"
-        class="form-control"
-        id="ldap_url"
-        ng-model="$ctrl.settings.URLs[$index]"
-        placeholder="e.g. 10.0.0.10:389 or myldap.domain.tld:389"
-        ng-model-options="{ allowInvalid: true }"
-        required
-      />
+      <input type="text" class="form-control" id="ldap_url" ng-model="$ctrl.settings.URLs[$index]" placeholder="e.g. 10.0.0.10:389 or myldap.domain.tld:389" required />
       <button ng-if="$index > 0" class="btn btn-sm btn-danger" type="button" ng-click="$ctrl.removeLDAPUrl($index)">
         <pr-icon icon="'trash-2'" feather="true" size="'md'"></pr-icon>
       </button>

--- a/app/portainer/views/settings/authentication/settingsAuthenticationController.js
+++ b/app/portainer/views/settings/authentication/settingsAuthenticationController.js
@@ -166,7 +166,7 @@ function SettingsAuthenticationController($q, $scope, $state, Notifications, Set
     }
 
     settings.URLs = settings.URLs.map((url) => {
-      if (url === '') {
+      if (url === undefined || url === '') {
         return;
       }
 


### PR DESCRIPTION


closes [EE-3155]

This fix covers internal authentication, active directory, and oauth setting saving when the ldap server url is empty

[EE-3155]: https://portainer.atlassian.net/browse/EE-3155?