### PR TITLE
chore(version): bump version to 2.16.1 [EE-4550]

### DIFF
--- a/api/datastore/test_data/output_24_to_latest.json
+++ b/api/datastore/test_data/output_24_to_latest.json
@@ -931,7 +931,7 @@
   ],
   "version": {
     "DB_UPDATING": "false",
-    "DB_VERSION": "70",
+    "DB_VERSION": "71",
     "INSTANCE_ID": "null"
   }
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -84,7 +84,7 @@ type Handler struct {
 }
 
 // @title PortainerCE API
-// @version 2.16.0
+// @version 2.16.1
 // @description.markdown api-description.md
 // @termsOfService
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1451,9 +1451,9 @@ type (
 
 const (
 	// APIVersion is the version number of the Portainer API
-	APIVersion = "2.16.0"
+	APIVersion = "2.16.1"
 	// DBVersion is the version number of the Portainer database
-	DBVersion = 70
+	DBVersion = 71
 	// ComposeSyntaxMaxVersion is a maximum supported version of the docker compose syntax
 	ComposeSyntaxMaxVersion = "3.9"
 	// AssetsServerURL represents the URL of the Portainer asset server

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Portainer.io",
   "name": "portainer",
   "homepage": "http://portainer.io",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:portainer/portainer.git"


### PR DESCRIPTION
Closes [EE-4550](https://portainer.atlassian.net/browse/EE-4550)