### PR TITLE
Remove unused token query parameter

### DIFF
--- a/api/http/handler/websocket/exec.go
+++ b/api/http/handler/websocket/exec.go
@@ -32,7 +32,6 @@ type execStartOperationPayload struct {
 // @produce json
 // @param endpointId query int true "environment(endpoint) ID of the environment(endpoint) where the resource is located"
 // @param nodeName query string false "node name"
-// @param token query string true "JWT token used for authentication against this environment(endpoint)"
 // @success 200
 // @failure 400
 // @failure 409


### PR DESCRIPTION
The token parameter was used in earlier versions of Portainer (before 2.12?) and has been replaced by headers auth; the documentation is misleading.
