### PR TITLE
feat(edge/stacks): use namespace in manifest [EE-4507]

### DIFF
--- a/api/http/handler/edgestacks/edgestack_create.go
+++ b/api/http/handler/edgestacks/edgestack_create.go
@@ -92,6 +92,8 @@ type swarmStackFromFileContentPayload struct {
 	DeploymentType portainer.EdgeStackDeploymentType `example:"0" enums:"0,1,2"`
 	// List of Registries to use for this stack
 	Registries []portainer.RegistryID
+	// Uses the manifest's namespaces instead of the default one
+	UseManifestNamespaces bool
 }
 
 func (payload *swarmStackFromFileContentPayload) Validate(r *http.Request) error {
@@ -114,7 +116,7 @@ func (handler *Handler) createSwarmStackFromFileContent(r *http.Request, dryrun 
 		return nil, err
 	}
 
-	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries)
+	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries, payload.UseManifestNamespaces)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Edge stack object")
 	}
@@ -197,6 +199,8 @@ type swarmStackFromGitRepositoryPayload struct {
 	DeploymentType portainer.EdgeStackDeploymentType `example:"0" enums:"0,1,2"`
 	// List of Registries to use for this stack
 	Registries []portainer.RegistryID
+	// Uses the manifest's namespaces instead of the default one
+	UseManifestNamespaces bool
 }
 
 func (payload *swarmStackFromGitRepositoryPayload) Validate(r *http.Request) error {
@@ -230,7 +234,7 @@ func (handler *Handler) createSwarmStackFromGitRepository(r *http.Request, dryru
 		return nil, err
 	}
 
-	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries)
+	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries, payload.UseManifestNamespaces)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create edge stack object")
 	}
@@ -268,6 +272,8 @@ type swarmStackFromFileUploadPayload struct {
 	// nomad deploytype is enabled only for nomad environments(endpoints)
 	DeploymentType portainer.EdgeStackDeploymentType `example:"0" enums:"0,1,2"`
 	Registries     []portainer.RegistryID
+	// Uses the manifest's namespaces instead of the default one
+	UseManifestNamespaces bool
 }
 
 func (payload *swarmStackFromFileUploadPayload) Validate(r *http.Request) error {
@@ -303,6 +309,9 @@ func (payload *swarmStackFromFileUploadPayload) Validate(r *http.Request) error 
 	}
 	payload.Registries = registries
 
+	useManifestNamespaces, _ := request.RetrieveBooleanMultiPartFormValue(r, "UseManifestNamespaces", true)
+	payload.UseManifestNamespaces = useManifestNamespaces
+
 	return nil
 }
 
@@ -313,7 +322,7 @@ func (handler *Handler) createSwarmStackFromFileUpload(r *http.Request, dryrun b
 		return nil, err
 	}
 
-	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries)
+	stack, err := handler.edgeStacksService.BuildEdgeStack(payload.Name, payload.DeploymentType, payload.EdgeGroups, payload.Registries, payload.UseManifestNamespaces)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create edge stack object")
 	}

--- a/api/http/handler/edgestacks/edgestack_update.go
+++ b/api/http/handler/edgestacks/edgestack_update.go
@@ -19,6 +19,8 @@ type updateEdgeStackPayload struct {
 	Version          *int
 	EdgeGroups       []portainer.EdgeGroupID
 	DeploymentType   portainer.EdgeStackDeploymentType
+	// Uses the manifest's namespaces instead of the default one
+	UseManifestNamespaces bool
 }
 
 func (payload *updateEdgeStackPayload) Validate(r *http.Request) error {
@@ -167,6 +169,8 @@ func (handler *Handler) edgeStackUpdate(w http.ResponseWriter, r *http.Request) 
 		if stack.ManifestPath == "" {
 			stack.ManifestPath = filesystem.ManifestFileDefaultName
 		}
+
+		stack.UseManifestNamespaces = payload.UseManifestNamespaces
 
 		hasDockerEndpoint, err := hasDockerEndpoint(handler.DataStore.Endpoint(), relatedEndpointIds)
 		if err != nil {

--- a/api/internal/edge/edgestacks/service.go
+++ b/api/internal/edge/edgestacks/service.go
@@ -30,7 +30,9 @@ func NewService(dataStore dataservices.DataStore) *Service {
 func (service *Service) BuildEdgeStack(name string,
 	deploymentType portainer.EdgeStackDeploymentType,
 	edgeGroups []portainer.EdgeGroupID,
-	registries []portainer.RegistryID) (*portainer.EdgeStack, error) {
+	registries []portainer.RegistryID,
+	useManifestNamespaces bool,
+) (*portainer.EdgeStack, error) {
 	edgeStacksService := service.dataStore.EdgeStack()
 
 	err := validateUniqueName(edgeStacksService.EdgeStacks, name)
@@ -40,13 +42,14 @@ func (service *Service) BuildEdgeStack(name string,
 
 	stackID := edgeStacksService.GetNextIdentifier()
 	return &portainer.EdgeStack{
-		ID:             portainer.EdgeStackID(stackID),
-		Name:           name,
-		DeploymentType: deploymentType,
-		CreationDate:   time.Now().Unix(),
-		EdgeGroups:     edgeGroups,
-		Status:         make(map[portainer.EndpointID]portainer.EdgeStackStatus),
-		Version:        1,
+		ID:                    portainer.EdgeStackID(stackID),
+		Name:                  name,
+		DeploymentType:        deploymentType,
+		CreationDate:          time.Now().Unix(),
+		EdgeGroups:            edgeGroups,
+		Status:                make(map[portainer.EndpointID]portainer.EdgeStackStatus),
+		Version:               1,
+		UseManifestNamespaces: useManifestNamespaces,
 	}, nil
 }
 

--- a/api/kubernetes/contants.go
+++ b/api/kubernetes/contants.go
@@ -1,0 +1,6 @@
+package kubernetes
+
+const (
+	// DefaultNamespace is the default namespace used when no namespace is specified
+	DefaultNamespace = "default"
+)

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -281,6 +281,8 @@ type (
 		Version        int                            `json:"Version"`
 		ManifestPath   string
 		DeploymentType EdgeStackDeploymentType
+		// Uses the manifest's namespaces instead of the default one
+		UseManifestNamespaces bool
 
 		// Deprecated
 		Prune bool `json:"Prune"`

--- a/app/edge/components/edit-edge-stack-form/editEdgeStackForm.html
+++ b/app/edge/components/edit-edge-stack-form/editEdgeStackForm.html
@@ -48,21 +48,33 @@
     </editor-description>
   </web-editor-form>
 
-  <web-editor-form
-    ng-if="$ctrl.model.DeploymentType === 1"
-    value="$ctrl.model.StackFileContent"
-    yml="true"
-    identifier="kube-manifest-editor"
-    placeholder="# Define or paste the content of your manifest here"
-    on-change="($ctrl.onChangeKubeManifest)"
-  >
-    <editor-description>
-      <p>
-        You can get more information about Kubernetes file format in the
-        <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/" target="_blank">official documentation</a>.
-      </p>
-    </editor-description>
-  </web-editor-form>
+  <div ng-if="$ctrl.model.DeploymentType === 1">
+    <div class="form-group">
+      <div class="col-sm-12">
+        <por-switch-field
+          label="'Use namespace(s) specified from manifest'"
+          tooltip="'If you have defined namespaces in your deployment file turning this on will enforce the use of those only in the deployment'"
+          checked="$ctrl.formValues.UseManifestNamespaces"
+          on-change="($ctrl.onChangeUseManifestNamespaces)"
+        ></por-switch-field>
+      </div>
+    </div>
+
+    <web-editor-form
+      value="$ctrl.model.StackFileContent"
+      yml="true"
+      identifier="kube-manifest-editor"
+      placeholder="# Define or paste the content of your manifest here"
+      on-change="($ctrl.onChangeKubeManifest)"
+    >
+      <editor-description>
+        <p>
+          You can get more information about Kubernetes file format in the
+          <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/" target="_blank">official documentation</a>.
+        </p>
+      </editor-description>
+    </web-editor-form>
+  </div>
 
   <!-- actions -->
   <div class="col-sm-12 form-section-title"> Actions </div>

--- a/app/edge/components/edit-edge-stack-form/editEdgeStackFormController.js
+++ b/app/edge/components/edit-edge-stack-form/editEdgeStackFormController.js
@@ -22,6 +22,13 @@ export class EditEdgeStackFormController {
     this.onChangeDeploymentType = this.onChangeDeploymentType.bind(this);
     this.removeLineBreaks = this.removeLineBreaks.bind(this);
     this.onChangeFileContent = this.onChangeFileContent.bind(this);
+    this.onChangeUseManifestNamespaces = this.onChangeUseManifestNamespaces.bind(this);
+  }
+
+  onChangeUseManifestNamespaces(value) {
+    this.$scope.$evalAsync(() => {
+      this.model.UseManifestNamespaces = value;
+    });
   }
 
   hasKubeEndpoint() {

--- a/app/edge/views/edge-stacks/createEdgeStackView/create-edge-stack-view.controller.js
+++ b/app/edge/views/edge-stacks/createEdgeStackView/create-edge-stack-view.controller.js
@@ -16,6 +16,7 @@ export default class CreateEdgeStackViewController {
       ComposeFilePathInRepository: '',
       Groups: [],
       DeploymentType: 0,
+      UseManifestNamespaces: false,
     };
 
     this.state = {
@@ -166,30 +167,32 @@ export default class CreateEdgeStackViewController {
   }
 
   createStackFromFileContent(name) {
-    const { StackFileContent, Groups, DeploymentType } = this.formValues;
+    const { StackFileContent, Groups, DeploymentType, UseManifestNamespaces } = this.formValues;
 
     return this.EdgeStackService.createStackFromFileContent({
       name,
       StackFileContent,
       EdgeGroups: Groups,
       DeploymentType,
+      UseManifestNamespaces,
     });
   }
 
   createStackFromFileUpload(name) {
-    const { StackFile, Groups, DeploymentType } = this.formValues;
+    const { StackFile, Groups, DeploymentType, UseManifestNamespaces } = this.formValues;
     return this.EdgeStackService.createStackFromFileUpload(
       {
         Name: name,
         EdgeGroups: Groups,
         DeploymentType,
+        UseManifestNamespaces,
       },
       StackFile
     );
   }
 
   createStackFromGitRepository(name) {
-    const { Groups, DeploymentType } = this.formValues;
+    const { Groups, DeploymentType, UseManifestNamespaces } = this.formValues;
     const repositoryOptions = {
       RepositoryURL: this.formValues.RepositoryURL,
       RepositoryReferenceName: this.formValues.RepositoryReferenceName,
@@ -203,6 +206,7 @@ export default class CreateEdgeStackViewController {
         name,
         EdgeGroups: Groups,
         DeploymentType,
+        UseManifestNamespaces,
       },
       repositoryOptions
     );

--- a/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.controller.js
+++ b/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.controller.js
@@ -11,10 +11,15 @@ class KubeManifestFormController {
     this.onChangeFormValues = this.onChangeFormValues.bind(this);
     this.onChangeFile = this.onChangeFile.bind(this);
     this.onChangeMethod = this.onChangeMethod.bind(this);
+    this.onChangeUseManifestNamespaces = this.onChangeUseManifestNamespaces.bind(this);
   }
 
   onChangeFormValues(values) {
     this.formValues = values;
+  }
+
+  onChangeUseManifestNamespaces(value) {
+    this.onChangeFormValues({ UseManifestNamespaces: value });
   }
 
   onChangeFileContent(value) {

--- a/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.controller.js
+++ b/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.controller.js
@@ -14,8 +14,13 @@ class KubeManifestFormController {
     this.onChangeUseManifestNamespaces = this.onChangeUseManifestNamespaces.bind(this);
   }
 
-  onChangeFormValues(values) {
-    this.formValues = values;
+  onChangeFormValues(newValues) {
+    return this.$async(async () => {
+      this.formValues = {
+        ...this.formValues,
+        ...newValues,
+      };
+    });
   }
 
   onChangeUseManifestNamespaces(value) {

--- a/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.html
+++ b/app/edge/views/edge-stacks/createEdgeStackView/kube-manifest-form/kube-manifest-form.html
@@ -1,3 +1,14 @@
+<div class="form-group">
+  <div class="col-sm-12">
+    <por-switch-field
+      label="'Use namespace(s) specified from manifest'"
+      tooltip="'If you have defined namespaces in your deployment file turning this on will enforce the use of those only in the deployment'"
+      checked="$ctrl.formValues.UseManifestNamespaces"
+      on-change="($ctrl.onChangeUseManifestNamespaces)"
+    ></por-switch-field>
+  </div>
+</div>
+
 <div class="col-sm-12 form-section-title"> Build method </div>
 <box-selector radio-name="'method'" value="$ctrl.state.Method" options="$ctrl.methodOptions" on-change="($ctrl.onChangeMethod)"></box-selector>
 

--- a/app/edge/views/edge-stacks/editEdgeStackView/editEdgeStackViewController.js
+++ b/app/edge/views/edge-stacks/editEdgeStackView/editEdgeStackViewController.js
@@ -39,6 +39,7 @@ export class EditEdgeStackViewController {
       this.formValues = {
         StackFileContent: file,
         EdgeGroups: this.stack.EdgeGroups,
+        UseManifestNamespaces: this.stack.UseManifestNamespaces,
         DeploymentType: this.stack.DeploymentType,
       };
       this.oldFileContent = this.formValues.StackFileContent;
@@ -79,7 +80,7 @@ export class EditEdgeStackViewController {
   async deployStackAsync() {
     this.state.actionInProgress = true;
     try {
-      if (this.originalFileContent != this.formValues.StackFileContent) {
+      if (this.originalFileContent != this.formValues.StackFileContent || this.formValues.UseManifestNamespaces !== this.stack.UseManifestNamespaces) {
         this.formValues.Version = this.stack.Version + 1;
       }
       await this.EdgeStackService.updateStack(this.stack.Id, this.formValues);

--- a/app/react/components/form-components/SwitchField/SwitchField.module.css
+++ b/app/react/components/form-components/SwitchField/SwitchField.module.css
@@ -3,13 +3,3 @@
   align-items: center;
   margin: 0;
 }
-
-.label {
-  padding: 0;
-}
-
-.switchValues {
-  font-style: normal;
-  font-weight: 500;
-  margin-left: 5px;
-}

--- a/app/react/components/form-components/SwitchField/SwitchField.tsx
+++ b/app/react/components/form-components/SwitchField/SwitchField.tsx
@@ -42,11 +42,7 @@ export function SwitchField({
   return (
     <label className={clsx(styles.root, fieldClass)}>
       <span
-        className={clsx(
-          'text-left space-right control-label',
-          styles.label,
-          labelClass
-        )}
+        className={clsx('text-left space-right control-label !p-0', labelClass)}
       >
         {label}
         {tooltip && (


### PR DESCRIPTION
changes:
- allow a user to use namespaces in their manifest
- add toggle in edge stack edit and create forms
- send namespace empty or default based on the toggle value