### PR TITLE
chore(deps): upgrade docker compose [EE-4642]

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
     distdir: 'dist/public',
     binaries: {
       dockerVersion: 'v20.10.9',
-      dockerComposePluginVersion: 'v2.10.2',
+      dockerComposePluginVersion: 'v2.13.0',
       helmVersion: 'v3.9.3',
       komposeVersion: 'v1.22.0',
       kubectlVersion: 'v1.24.1',


### PR DESCRIPTION
closes [EE-4642]
upgrades docker compose to v2.13.0


[EE-4642]: https://portainer.atlassian.net/browse/EE-4642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ