### PR TITLE
feat(resourcequotas): reduce resource quota requests [EE-4757]

### DIFF
--- a/app/kubernetes/services/namespaceService.js
+++ b/app/kubernetes/services/namespaceService.js
@@ -5,7 +5,6 @@ import PortainerError from 'Portainer/error';
 import { KubernetesCommonParams } from 'Kubernetes/models/common/params';
 import KubernetesNamespaceConverter from 'Kubernetes/converters/namespace';
 import { updateNamespaces } from 'Kubernetes/store/namespace';
-import $allSettled from 'Portainer/services/allSettled';
 
 class KubernetesNamespaceService {
   /* @ngInject */
@@ -65,10 +64,8 @@ class KubernetesNamespaceService {
 
   async getAllAsync() {
     try {
-      const data = await this.KubernetesNamespaces().get().$promise;
-      const promises = _.map(data.items, (item) => this.KubernetesNamespaces().status({ id: item.metadata.name }).$promise);
-      const namespaces = await $allSettled(promises);
-      const allNamespaces = _.map(namespaces.fulfilled, (item) => {
+      const namespaces = await this.KubernetesNamespaces().get().$promise;
+      const allNamespaces = _.map(namespaces.items, (item) => {
         return KubernetesNamespaceConverter.apiToNamespace(item);
       });
       updateNamespaces(allNamespaces);

--- a/app/kubernetes/views/applications/create/createApplicationController.js
+++ b/app/kubernetes/views/applications/create/createApplicationController.js
@@ -845,8 +845,8 @@ class KubernetesCreateApplicationController {
   /* #endregion */
 
   /* #region  DATA AUTO REFRESH */
-  updateSliders() {
-    const quota = this.formValues.ResourcePool.Quota;
+  updateSliders(namespaceWithQuota) {
+    const quota = namespaceWithQuota.Quota;
     let minCpu = 0,
       minMemory = 0,
       maxCpu = this.state.namespaceLimits.cpu,
@@ -879,33 +879,36 @@ class KubernetesCreateApplicationController {
     }
   }
 
-  updateNamespaceLimits() {
-    let maxCpu = this.state.nodes.cpu;
-    let maxMemory = this.state.nodes.memory;
-    const quota = this.formValues.ResourcePool.Quota;
+  updateNamespaceLimits(namespaceWithQuota) {
+    return this.$async(async () => {
+      let maxCpu = this.state.nodes.cpu;
+      let maxMemory = this.state.nodes.memory;
 
-    this.state.resourcePoolHasQuota = false;
+      const quota = namespaceWithQuota.Quota;
 
-    if (quota) {
-      if (quota.CpuLimit) {
-        this.state.resourcePoolHasQuota = true;
-        maxCpu = quota.CpuLimit - quota.CpuLimitUsed;
-        if (this.state.isEdit && this.savedFormValues.CpuLimit) {
-          maxCpu += this.savedFormValues.CpuLimit * this.effectiveInstances();
+      this.state.resourcePoolHasQuota = false;
+
+      if (quota) {
+        if (quota.CpuLimit) {
+          this.state.resourcePoolHasQuota = true;
+          maxCpu = quota.CpuLimit - quota.CpuLimitUsed;
+          if (this.state.isEdit && this.savedFormValues.CpuLimit) {
+            maxCpu += this.savedFormValues.CpuLimit * this.effectiveInstances();
+          }
+        }
+
+        if (quota.MemoryLimit) {
+          this.state.resourcePoolHasQuota = true;
+          maxMemory = quota.MemoryLimit - quota.MemoryLimitUsed;
+          if (this.state.isEdit && this.savedFormValues.MemoryLimit) {
+            maxMemory += KubernetesResourceReservationHelper.bytesValue(this.savedFormValues.MemoryLimit) * this.effectiveInstances();
+          }
         }
       }
 
-      if (quota.MemoryLimit) {
-        this.state.resourcePoolHasQuota = true;
-        maxMemory = quota.MemoryLimit - quota.MemoryLimitUsed;
-        if (this.state.isEdit && this.savedFormValues.MemoryLimit) {
-          maxMemory += KubernetesResourceReservationHelper.bytesValue(this.savedFormValues.MemoryLimit) * this.effectiveInstances();
-        }
-      }
-    }
-
-    this.state.namespaceLimits.cpu = maxCpu;
-    this.state.namespaceLimits.memory = maxMemory;
+      this.state.namespaceLimits.cpu = maxCpu;
+      this.state.namespaceLimits.memory = maxMemory;
+    });
   }
 
   refreshStacks(namespace) {
@@ -999,9 +1002,10 @@ class KubernetesCreateApplicationController {
 
   onResourcePoolSelectionChange() {
     return this.$async(async () => {
+      const namespaceWithQuota = await this.KubernetesResourcePoolService.get(this.formValues.ResourcePool.Namespace.Name);
       const namespace = this.formValues.ResourcePool.Namespace.Name;
-      this.updateNamespaceLimits();
-      this.updateSliders();
+      this.updateNamespaceLimits(namespaceWithQuota);
+      this.updateSliders(namespaceWithQuota);
       await this.refreshNamespaceData(namespace);
       this.resetFormValues();
     });
@@ -1195,7 +1199,9 @@ class KubernetesCreateApplicationController {
         this.allNamespaces = resourcePools.map(({ Namespace }) => Namespace.Name);
         this.resourcePools = _.sortBy(nonSystemNamespaces, ({ Namespace }) => (Namespace.Name === 'default' ? 0 : 1));
 
+        const namespaceWithQuota = await this.KubernetesResourcePoolService.get(this.resourcePools[0].Namespace.Name);
         this.formValues.ResourcePool = this.resourcePools[0];
+        this.formValues.ResourcePool.Quota = namespaceWithQuota.Quota;
         if (!this.formValues.ResourcePool) {
           return;
         }
@@ -1262,8 +1268,8 @@ class KubernetesCreateApplicationController {
 
         this.oldFormValues = angular.copy(this.formValues);
 
-        this.updateNamespaceLimits();
-        this.updateSliders();
+        this.updateNamespaceLimits(namespaceWithQuota);
+        this.updateSliders(namespaceWithQuota);
       } catch (err) {
         this.Notifications.error('Failure', err, 'Unable to load view data');
       } finally {

--- a/app/kubernetes/views/resource-pools/resourcePoolsController.js
+++ b/app/kubernetes/views/resource-pools/resourcePoolsController.js
@@ -62,7 +62,7 @@ class KubernetesResourcePoolsController {
 
   async getResourcePoolsAsync() {
     try {
-      this.resourcePools = await this.KubernetesResourcePoolService.get();
+      this.resourcePools = await this.KubernetesResourcePoolService.get('', { getQuota: true });
     } catch (err) {
       this.Notifications.error('Failure', err, 'Unable to retreive namespaces');
     }


### PR DESCRIPTION
Closes EE-4757

Changes made:
- Change the default behaviour of the namespace getAll request to NOT get all resource quotas
- Make only the namespaces table view get all resource quotas (it is the only view that needs it)

Benefits:
- If there are many namespaces in a cluster, 10 views now load noticeably faster 

Future work:
- Move request to the backend with pagination
- Discuss if sorting by resource quota enabled is still required with a PO 