### PR TITLE
fix(docker): remove prepended slash by default on container names [EE-3592]

### DIFF
--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -110,6 +110,15 @@ angular
       return 'success';
     };
   })
+  .filter('trimcontainername', function () {
+    'use strict';
+    return function (name) {
+      if (name) {
+        return name.indexOf('/') === 0 ? name.slice(1) : name;
+      }
+      return '';
+    };
+  })
   .filter('getstatetext', function () {
     'use strict';
     return function (state) {

--- a/app/docker/filters/filters.js
+++ b/app/docker/filters/filters.js
@@ -110,15 +110,6 @@ angular
       return 'success';
     };
   })
-  .filter('trimcontainername', function () {
-    'use strict';
-    return function (name) {
-      if (name) {
-        return name.indexOf('/') === 0 ? name.replace('/', '') : name;
-      }
-      return '';
-    };
-  })
   .filter('getstatetext', function () {
     'use strict';
     return function (state) {
@@ -161,8 +152,7 @@ angular
   .filter('containername', function () {
     'use strict';
     return function (container) {
-      var name = container.Names[0];
-      return name.substring(1, name.length);
+      return container.Names[0];
     };
   })
   .filter('swarmversion', function () {
@@ -174,7 +164,7 @@ angular
   .filter('swarmhostname', function () {
     'use strict';
     return function (container) {
-      return _.split(container.Names[0], '/')[1];
+      return container.Names[0];
     };
   })
   .filter('repotags', function () {

--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -338,7 +338,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       var container = $scope.formValues.NetworkContainer;
       var containerName = container;
       if (container && typeof container === 'object') {
-        containerName = $filter('trimcontainername')(container.Names[0]);
+        containerName = container.Names[0];
       }
       var networkMode = mode;
       if (containerName) {
@@ -979,7 +979,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
         if (!oldContainer) {
           return;
         }
-        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0].substring(1));
+        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0]);
       }
 
       function confirmCreateContainer(container) {
@@ -1025,7 +1025,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       }
 
       function renameContainer() {
-        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0].substring(1) + '-old');
+        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0] + '-old');
       }
 
       function pullImageIfNeeded() {

--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/name.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/name.tsx
@@ -10,10 +10,7 @@ import { TableSettings } from '../types';
 
 export const name: Column<DockerContainer> = {
   Header: 'Name',
-  accessor: (row) => {
-    const name = row.Names[0];
-    return name.substring(1, name.length);
-  },
+  accessor: (row) => row.Names[0],
   id: 'name',
   Cell: NameCell,
   disableFilters: true,

--- a/app/react/docker/containers/utils.ts
+++ b/app/react/docker/containers/utils.ts
@@ -37,9 +37,15 @@ export function parseViewModel(
     )
   );
 
+  const names = response.Names.map((n) => {
+    const nameWithoutSlash = n[0] === '/' ? response.Names[0].slice(1) : n;
+    return nameWithoutSlash;
+  });
+
   return {
     ...response,
     ResourceControl: resourceControl,
+    Names: names,
     NodeName: nodeName,
     IP: ip,
     StackName: stackName,


### PR DESCRIPTION
The data coming back from the docker api prepends the name with "/" which we were removing in many places.
Rather than do that and potentially miss some, we remove it if present from the API response data.

Closes [EE-3592](https://portainer.atlassian.net/browse/EE-3592)

[EE-3592]: https://portainer.atlassian.net/browse/EE-3592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ