### PR TITLE
fix(access-control): fix a typo in placeholder [EE-4983]

### DIFF
--- a/app/react/portainer/access-control/PorAccessControlForm/UsersSelector.tsx
+++ b/app/react/portainer/access-control/PorAccessControlForm/UsersSelector.tsx
@@ -27,7 +27,7 @@ export function PorAccessControlFormUserSelector({
       onChange={onChange}
       data-cy="portainer-selectUserAccess"
       inputId={inputId}
-      placeholder="Select one or more teams"
+      placeholder="Select one or more users"
     />
   );
 }


### PR DESCRIPTION
Fixed a typo showing teams rather than users on the user form.

Closes [EE-4983](https://portainer.atlassian.net/browse/EE-4983)

[EE-4983]: https://portainer.atlassian.net/browse/EE-4983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ