### PR TITLE
fix(app/home): render only the appropriate connect button per env type

### DIFF
--- a/app/react/portainer/HomeView/EnvironmentList/EnvironmentItem/EnvironmentBrowseButtons.tsx
+++ b/app/react/portainer/HomeView/EnvironmentList/EnvironmentItem/EnvironmentBrowseButtons.tsx
@@ -116,7 +116,7 @@ function BrowseStatusTag({ status }: { status: BrowseStatus }) {
 
 function Disconnected() {
   return (
-    <div className="flex items-center gap-2 justify-center opacity-50">
+    <div className="flex items-center gap-2 justify-center">
       <Icon icon={WifiOff} />
       Disconnected
     </div>


### PR DESCRIPTION
Close [EE-4890]

[EE-4890]: https://portainer.atlassian.net/browse/EE-4890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ