### PR TITLE
fix(endpoints): check environment type before start metrics detection EE-4944

### DIFF
--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -53,7 +53,7 @@ func (handler *Handler) endpointInspect(w http.ResponseWriter, r *http.Request) 
 	}
 
 	isServerMetricsDetected := endpoint.Kubernetes.Flags.IsServerMetricsDetected
-	if !isServerMetricsDetected && handler.K8sClientFactory != nil {
+	if endpointutils.IsKubernetesEndpoint(endpoint) && !isServerMetricsDetected && handler.K8sClientFactory != nil {
 		endpointutils.InitialMetricsDetection(
 			endpoint,
 			handler.DataStore.Endpoint(),


### PR DESCRIPTION
fixes [EE-4944](https://portainer.atlassian.net/browse/EE-4944)

[EE-4944]: https://portainer.atlassian.net/browse/EE-4944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ