### PR TITLE
chore(edgestacks): fix edge stack tests EE-4951

### DIFF
--- a/api/http/handler/edgestacks/edgestack_test.go
+++ b/api/http/handler/edgestacks/edgestack_test.go
@@ -622,7 +622,7 @@ func TestUpdateAndInspect(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(data.EdgeGroups, payload.EdgeGroups) {
-		t.Fatalf("expected EdgeGroups to be equal")
+		t.Fatal("expected EdgeGroups to be equal")
 	}
 }
 


### PR DESCRIPTION
closes [EE-4951](https://portainer.atlassian.net/browse/EE-4951)

[EE-4951]: https://portainer.atlassian.net/browse/EE-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ