### PR TITLE
fix(handler): extend kube guard around kube only actions for endpoint inspect [EE-4991] 

### DIFF
--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -52,22 +52,24 @@ func (handler *Handler) endpointInspect(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	isServerMetricsDetected := endpoint.Kubernetes.Flags.IsServerMetricsDetected
-	if endpointutils.IsKubernetesEndpoint(endpoint) && !isServerMetricsDetected && handler.K8sClientFactory != nil {
-		endpointutils.InitialMetricsDetection(
-			endpoint,
-			handler.DataStore.Endpoint(),
-			handler.K8sClientFactory,
-		)
-	}
+	if endpointutils.IsKubernetesEndpoint(endpoint) {
+		isServerMetricsDetected := endpoint.Kubernetes.Flags.IsServerMetricsDetected
+		if !isServerMetricsDetected && handler.K8sClientFactory != nil {
+			endpointutils.InitialMetricsDetection(
+				endpoint,
+				handler.DataStore.Endpoint(),
+				handler.K8sClientFactory,
+			)
+		}
 
-	isServerStorageDetected := endpoint.Kubernetes.Flags.IsServerStorageDetected
-	if !isServerStorageDetected && handler.K8sClientFactory != nil {
-		endpointutils.InitialStorageDetection(
-			endpoint,
-			handler.DataStore.Endpoint(),
-			handler.K8sClientFactory,
-		)
+		isServerStorageDetected := endpoint.Kubernetes.Flags.IsServerStorageDetected
+		if !isServerStorageDetected && handler.K8sClientFactory != nil {
+			endpointutils.InitialStorageDetection(
+				endpoint,
+				handler.DataStore.Endpoint(),
+				handler.K8sClientFactory,
+			)
+		}
 	}
 
 	return response.JSON(w, endpoint)


### PR DESCRIPTION
Closes [EE-4991](https://portainer.atlassian.net/browse/EE-4991)

[EE-4991]: https://portainer.atlassian.net/browse/EE-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ