### PR TITLE
fix(docker): container health alignment [EE-5008]

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -175,7 +175,7 @@ input[type='checkbox'] {
 
 .widget .widget-body table tbody td {
   white-space: normal;
-  word-break: break-word;
+  word-break: normal;
 }
 
 .widget .widget-body table.container-details-table > tbody > tr > td:first-child {


### PR DESCRIPTION
change `word-break: break-word;` -> `word-break: normal;` to prevent long logs from breaking table UI

closes #0 <!-- Github issue number (remove if unknown) -->
closes [EE-5008](https://portainer.atlassian.net/browse/EE-5008)

### Changes:
There is a small UI bug when "Last Output" from the Container health is very long, this updates CSS to fix that.

![Screenshot 2023-02-01 at 11 33 26 AM](https://user-images.githubusercontent.com/19308155/216120572-638fc687-1213-4176-806f-164d5aed1658.png)



[EE-5008]: https://portainer.atlassian.net/browse/EE-5008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ