### PR TITLE
chore(prettier): ignore tailwind changes [EE-4809]

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@ cf5056d9c03b62d91a25c3b9127caac838695f98
 
 # prettier v2
 42e7db0ae7897d3cb72b0ea1ecf57ee2dd694169
+
+# tailwind prettier
+58d66d3142950bb90a7d85511c034ac9fabba9ba


### PR DESCRIPTION
Closes EE-4809

Ignore prettier changes from git blame