### PR TITLE
fix(api/registry): encode X-Registry-Auth header using base64url instead of base64 [EE-4726]

### DIFF
--- a/api/http/proxy/factory/docker/transport.go
+++ b/api/http/proxy/factory/docker/transport.go
@@ -471,7 +471,7 @@ func (transport *Transport) decorateRegistryAuthenticationHeader(request *http.R
 			return err
 		}
 
-		header := base64.StdEncoding.EncodeToString(headerData)
+		header := base64.URLEncoding.EncodeToString(headerData)
 
 		request.Header.Set("X-Registry-Auth", header)
 	}


### PR DESCRIPTION
Close [EE-4726]

[EE-4726]: https://portainer.atlassian.net/browse/EE-4726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ