### PR TITLE
fix(oauth): danger confirm for hiding prompt [EE-4576]

### DIFF
--- a/app/portainer/oauth/components/oauth-settings/oauth-settings.controller.js
+++ b/app/portainer/oauth/components/oauth-settings/oauth-settings.controller.js
@@ -87,7 +87,7 @@ export default class OAuthSettingsController {
         const confirmed = await confirm({
           title: 'Hide internal authentication prompt',
           message: 'By hiding internal authentication prompt, you will only be able to login via SSO. Are you sure?',
-          confirmButton: buildConfirmButton('Confirm', 'btn-warning'),
+          confirmButton: buildConfirmButton('Confirm', 'danger'),
           modalType: ModalType.Warn,
         });
 


### PR DESCRIPTION
fix [EE-4576]


[EE-4576]: https://portainer.atlassian.net/browse/EE-4576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ