### PR TITLE
fix(migration): better logging during critical failure [EE-4992]

### DIFF
--- a/api/datastore/migrate_data.go
+++ b/api/datastore/migrate_data.go
@@ -48,13 +48,16 @@ func (store *Store) MigrateData() error {
 
 	err = store.FailSafeMigrate(migrator, version)
 	if err != nil {
+		err = errors.Wrap(err, "failed to migrate database")
+
+		log.Warn().Msg("migration failed, restoring database to previous version")
 		err = store.restoreWithOptions(&BackupOptions{BackupPath: backupPath})
 		if err != nil {
 			return errors.Wrap(err, "failed to restore database")
 		}
 
 		log.Info().Msg("database restored to previous version")
-		return errors.Wrap(err, "failed to migrate database")
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Closes [EE-4992](https://portainer.atlassian.net/browse/EE-4992)

[EE-4992]: https://portainer.atlassian.net/browse/EE-4992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ