### PR TITLE
feat(waiting-room): show and filter by check in [EE-5186]

### DIFF
--- a/api/dataservices/endpoint/endpoint.go
+++ b/api/dataservices/endpoint/endpoint.go
@@ -34,7 +34,7 @@ func NewService(connection portainer.Connection) (*Service, error) {
 		idxEdgeID:  make(map[string]portainer.EndpointID),
 	}
 
-	es, err := s.Endpoints()
+	es, err := s.endpoints()
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,7 @@ func (service *Service) DeleteEndpoint(ID portainer.EndpointID) error {
 	})
 }
 
-// Endpoints return an array containing all the environments(endpoints).
-func (service *Service) Endpoints() ([]portainer.Endpoint, error) {
+func (service *Service) endpoints() ([]portainer.Endpoint, error) {
 	var endpoints []portainer.Endpoint
 	var err error
 
@@ -99,8 +98,14 @@ func (service *Service) Endpoints() ([]portainer.Endpoint, error) {
 		return err
 	})
 
+	return endpoints, err
+}
+
+// Endpoints return an array containing all the environments(endpoints).
+func (service *Service) Endpoints() ([]portainer.Endpoint, error) {
+	endpoints, err := service.endpoints()
 	if err != nil {
-		return endpoints, err
+		return nil, err
 	}
 
 	for i, e := range endpoints {

--- a/api/http/handler/endpointedge/endpoint_edgestatus_inspect.go
+++ b/api/http/handler/endpointedge/endpoint_edgestatus_inspect.go
@@ -117,6 +117,11 @@ func (handler *Handler) endpointEdgeStatusInspect(w http.ResponseWriter, r *http
 		return httperror.InternalServerError("Unable to Unable to persist environment changes inside the database", err)
 	}
 
+	err = handler.requestBouncer.TrustedEdgeEnvironmentAccess(endpoint)
+	if err != nil {
+		return httperror.Forbidden("Permission denied to access environment", err)
+	}
+
 	checkinInterval := endpoint.EdgeCheckinInterval
 	if endpoint.EdgeCheckinInterval == 0 {
 		settings, err := handler.DataStore.Settings().Settings()

--- a/api/http/handler/endpoints/endpoint_list.go
+++ b/api/http/handler/endpoints/endpoint_list.go
@@ -44,6 +44,7 @@ const (
 // @param agentVersions query []string false "will return only environments with on of these agent versions"
 // @param edgeAsync query bool false "if exists true show only edge async agents, false show only standard edge agents. if missing, will show both types (relevant only for edge agents)"
 // @param edgeDeviceUntrusted query bool false "if true, show only untrusted edge agents, if false show only trusted edge agents (relevant only for edge agents)"
+// @param edgeCheckInPassedSeconds query number false "if bigger then zero, show only edge agents that checked-in in the last provided seconds (relevant only for edge agents)"
 // @param name query string false "will return only environments(endpoints) with this name"
 // @success 200 {array} portainer.Endpoint "Endpoints"
 // @failure 500 "Server error"

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -1,12 +1,11 @@
 package security
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	httperror "github.com/portainer/libhttp/error"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/apikey"
@@ -147,13 +146,19 @@ func (bouncer *RequestBouncer) AuthorizedEdgeEndpointOperation(r *http.Request, 
 		return errors.New("invalid Edge identifier")
 	}
 
+	return nil
+}
+
+// TrustedEdgeEnvironmentAccess defines a security check for Edge environments, checks if
+// the request is coming from a trusted Edge environment
+func (bouncer *RequestBouncer) TrustedEdgeEnvironmentAccess(endpoint *portainer.Endpoint) error {
 	if endpoint.LastCheckInDate > 0 || endpoint.UserTrusted {
 		return nil
 	}
 
 	settings, err := bouncer.dataStore.Settings().Settings()
 	if err != nil {
-		return fmt.Errorf("could not retrieve the settings: %w", err)
+		return errors.WithMessage(err, "could not retrieve the settings")
 	}
 
 	if !settings.TrustOnFirstConnect {

--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -152,7 +152,7 @@ func (bouncer *RequestBouncer) AuthorizedEdgeEndpointOperation(r *http.Request, 
 // TrustedEdgeEnvironmentAccess defines a security check for Edge environments, checks if
 // the request is coming from a trusted Edge environment
 func (bouncer *RequestBouncer) TrustedEdgeEnvironmentAccess(endpoint *portainer.Endpoint) error {
-	if endpoint.LastCheckInDate > 0 || endpoint.UserTrusted {
+	if endpoint.UserTrusted {
 		return nil
 	}
 

--- a/app/react/edge/edge-devices/WaitingRoomView/Datatable/Filter.tsx
+++ b/app/react/edge/edge-devices/WaitingRoomView/Datatable/Filter.tsx
@@ -3,7 +3,17 @@ import { useGroups } from '@/react/portainer/environments/environment-groups/que
 import { useEdgeGroups } from '@/react/edge/edge-groups/queries/useEdgeGroups';
 import { useTags } from '@/portainer/tags/queries';
 
+import { PortainerSelect } from '@@/form-components/PortainerSelect';
+
 import { useFilterStore } from './filter-store';
+
+const checkInOptions = [
+  { value: 0, label: 'Show all time' },
+  { value: 60 * 60, label: 'Show past hour' },
+  { value: 60 * 60 * 24, label: 'Show past day' },
+  { value: 60 * 60 * 24 * 7, label: 'Show past week' },
+  { value: 60 * 60 * 24 * 14, label: 'Show past 14 days' },
+];
 
 export function Filter() {
   const edgeGroupsQuery = useEdgeGroups();
@@ -44,6 +54,14 @@ export function Filter() {
           label: g.Name,
           value: g.ID,
         }))}
+      />
+
+      <div className="ml-auto" />
+      <PortainerSelect
+        onChange={(f) => filterStore.setCheckIn(f || 0)}
+        value={filterStore.checkIn}
+        options={checkInOptions}
+        bindToBody
       />
     </div>
   );

--- a/app/react/edge/edge-devices/WaitingRoomView/Datatable/columns.ts
+++ b/app/react/edge/edge-devices/WaitingRoomView/Datatable/columns.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { CellProps, Column } from 'react-table';
 
 import { WaitingRoomEnvironment } from '../types';
@@ -52,4 +53,32 @@ export const columns: readonly Column<WaitingRoomEnvironment>[] = [
     canHide: false,
     sortType: 'string',
   },
+  {
+    Header: 'Last Check-in',
+    accessor: 'LastCheckInDate',
+    Cell: LastCheckinDateCell,
+    id: 'last-check-in',
+    disableFilters: true,
+    Filter: () => null,
+    canHide: false,
+    sortType: 'string',
+  },
 ] as const;
+
+function LastCheckinDateCell({
+  value,
+}: CellProps<WaitingRoomEnvironment, number>) {
+  if (!value) {
+    return '-';
+  }
+
+  const checkIn = moment(value * 1000).utc();
+
+  const now = moment().utc();
+
+  const diff = checkIn.diff(now);
+
+  const duration = moment.duration(diff);
+
+  return `${duration.humanize()} ago`;
+}

--- a/app/react/edge/edge-devices/WaitingRoomView/Datatable/columns.ts
+++ b/app/react/edge/edge-devices/WaitingRoomView/Datatable/columns.ts
@@ -72,13 +72,5 @@ function LastCheckinDateCell({
     return '-';
   }
 
-  const checkIn = moment(value * 1000).utc();
-
-  const now = moment().utc();
-
-  const diff = checkIn.diff(now);
-
-  const duration = moment.duration(diff);
-
-  return `${duration.humanize()} ago`;
+  return moment(value * 1000).fromNow();
 }

--- a/app/react/edge/edge-devices/WaitingRoomView/Datatable/filter-store.ts
+++ b/app/react/edge/edge-devices/WaitingRoomView/Datatable/filter-store.ts
@@ -10,6 +10,8 @@ interface TableFiltersStore {
   setEdgeGroups(value: number[]): void;
   tags: number[];
   setTags(value: number[]): void;
+  checkIn: number;
+  setCheckIn(value: number): void;
 }
 
 export const useFilterStore = createStore<TableFiltersStore>()(
@@ -26,6 +28,10 @@ export const useFilterStore = createStore<TableFiltersStore>()(
       tags: [],
       setTags(tags: number[]) {
         set({ tags });
+      },
+      checkIn: 0,
+      setCheckIn(checkIn: number) {
+        set({ checkIn });
       },
     }),
     {

--- a/app/react/edge/edge-devices/WaitingRoomView/Datatable/useEnvironments.ts
+++ b/app/react/edge/edge-devices/WaitingRoomView/Datatable/useEnvironments.ts
@@ -30,6 +30,7 @@ export function useEnvironments() {
     tagIds: filterStore.tags.length ? filterStore.tags : undefined,
     groupIds: filterStore.groups.length ? filterStore.groups : undefined,
     endpointIds: filterByEnvironmentsIds,
+    edgeCheckInPassedSeconds: filterStore.checkIn,
   });
 
   const groupsQuery = useGroups({

--- a/app/react/portainer/environments/environment.service/index.ts
+++ b/app/react/portainer/environments/environment.service/index.ts
@@ -29,6 +29,7 @@ export interface EnvironmentsQueryParams {
   name?: string;
   agentVersions?: string[];
   updateInformation?: boolean;
+  edgeCheckInPassedSeconds?: number;
 }
 
 export interface GetEnvironmentsOptions {


### PR DESCRIPTION
fix [EE-5186]

## changes:
- add check-in column, show "X days/seconds ago"
- add filter by check-in passed time, changed endpoints api for that
- fix a bug where when caching checkin time on startup of server, it would cache first a 0 value

[EE-5186]: https://portainer.atlassian.net/browse/EE-5186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ