### PR TITLE
fix(containers): fix image Autocomplete

### DIFF
--- a/app/docker/components/imageRegistry/por-image-registry.controller.js
+++ b/app/docker/components/imageRegistry/por-image-registry.controller.js
@@ -68,6 +68,7 @@ class porImageRegistryController {
   }
 
   async onImageChange() {
+    this.prepareAutocomplete();
     if (!this.isDockerHubRegistry()) {
       this.setValidity(true);
     }
@@ -114,6 +115,7 @@ class porImageRegistryController {
 
         const images = await this.ImageService.images();
         this.images = this.ImageService.getUniqueTagListFromImages(images);
+        this.prepareAutocomplete();
       } catch (err) {
         this.Notifications.error('Failure', err, 'Unable to retrieve images');
       }

--- a/app/docker/components/imageRegistry/por-image-registry.controller.js
+++ b/app/docker/components/imageRegistry/por-image-registry.controller.js
@@ -43,7 +43,7 @@ class porImageRegistryController {
   prepareAutocomplete() {
     let images = [];
     const registry = this.model.Registry;
-    if (this.isKnownRegistry(registry)) {
+    if (this.model.UseRegistry && this.isKnownRegistry(registry)) {
       const url = this.getRegistryURL(registry);
       const registryImages = _.filter(this.images, (image) => _.includes(image, url));
       images = _.map(registryImages, (image) => _.replace(image, new RegExp(url + '/?'), ''));

--- a/app/docker/components/imageRegistry/por-image-registry.html
+++ b/app/docker/components/imageRegistry/por-image-registry.html
@@ -21,7 +21,6 @@
           type="text"
           class="form-control"
           aria-describedby="registry-name"
-          uib-typeahead="image for image in $ctrl.availableImages | filter:$viewValue | limitTo:5"
           ng-model="$ctrl.model.Image"
           name="image_name"
           placeholder="e.g. my-image:my-tag"
@@ -51,7 +50,7 @@
       </span>
       <label for="image_name" ng-class="$ctrl.labelClass" class="control-label col-sm-3 col-lg-2 required text-left">Image </label>
       <div ng-class="$ctrl.inputClass" class="col-sm-8">
-        <input type="text" class="form-control" ng-model="$ctrl.model.Image" name="image_name" placeholder="e.g. registry:port/my-image:my-tag" required />
+        <input type="text" class="form-control" typeahead-min-length=0 uib-typeahead="image for image in $ctrl.availableImages | filter:$viewValue | limitTo:10" ng-model="$ctrl.model.Image" name="image_name" placeholder="e.g. registry:port/my-image:my-tag" ng-change="$ctrl.onImageChange()" typeahead-wait-ms=100 required />
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes #169 

似乎好几个版本都不能自动填充image了，修复了一下
It seems that several versions can not autocomplete the image, fix it

### Changes:
在simple时不进行自动填充，在advance时进行自动填充
No autocomplete at simple mode, and autocomplete at advance mode

<img width="915" alt="image" src="https://user-images.githubusercontent.com/28103567/230312916-4cc08fa8-5dc6-4bc7-9f1c-61f697b19b9d.png">
