### PR TITLE
fix(kube): updated kube terminology for configmaps/secrets [EE-4816]

### DIFF
--- a/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
+++ b/app/kubernetes/components/datatables/configurations-datatable/configurationsDatatable.html
@@ -172,7 +172,7 @@
               <td colspan="4" class="text-muted text-center">Loading...</td>
             </tr>
             <tr ng-if="$ctrl.state.filteredDataSet.length === 0">
-              <td colspan="4" class="text-muted text-center">No configuration available.</td>
+              <td colspan="4" class="text-muted text-center">No ConfigMaps or Secrets available.</td>
             </tr>
           </tbody>
         </table>

--- a/app/kubernetes/views/applications/create/createApplication.html
+++ b/app/kubernetes/views/applications/create/createApplication.html
@@ -414,7 +414,8 @@
                     <div class="row clearfix" ng-if="config.SelectedConfiguration && !config.Overriden">
                       <div class="col-sm-9 small text-muted !mt-2 !p-0">
                         The following keys will be loaded from the <code>{{ config.SelectedConfiguration.Name }}</code>
-                        configuration as environment variables:
+                        <span ng-if="config.SelectedConfiguration.Kind === 1">ConfigMap</span><span ng-if="config.SelectedConfiguration.Kind === 2">Secret</span> as environment
+                        variables:
                         <span ng-repeat="(key, _) in config.SelectedConfiguration.Data">
                           <code>{{ key }}</code
                           >{{ $last ? '' : ', ' }}

--- a/app/kubernetes/views/applications/edit/application.html
+++ b/app/kubernetes/views/applications/edit/application.html
@@ -214,7 +214,7 @@
 
           <div class="small text-muted" ng-if="!ctrl.application.Env.length > 0 && !ctrl.hasVolumeConfiguration()" style="margin-bottom: 15px">
             <pr-icon icon="'info'" mode="'primary'" class="mr-1"></pr-icon>
-            This application is not using any environment variable or configuration.
+            This application is not using any environment variable, ConfigMap or Secret.
           </div>
 
           <table class="table" ng-if="ctrl.application.Env.length > 0">

--- a/app/kubernetes/views/applications/edit/application.html
+++ b/app/kubernetes/views/applications/edit/application.html
@@ -209,7 +209,7 @@
           <!-- CONFIGURATIONS -->
           <div class="text-muted" style="margin-bottom: 15px; margin-top: 25px">
             <pr-icon icon="'file'" class="mr-1"></pr-icon>
-            Configuration
+            ConfigMap or Secret
           </div>
 
           <div class="small text-muted" ng-if="!ctrl.application.Env.length > 0 && !ctrl.hasVolumeConfiguration()" style="margin-bottom: 15px">

--- a/app/kubernetes/views/applications/edit/application.html
+++ b/app/kubernetes/views/applications/edit/application.html
@@ -222,7 +222,7 @@
               <td style="width: 25%">Container</td>
               <td style="width: 25%">Environment variable</td>
               <td style="width: 25%">Value</td>
-              <td style="width: 25%">Configuration</td>
+              <td style="width: 25%">ConfigMap or Secret</td>
             </tr>
             <tbody ng-repeat="container in ctrl.application.Containers" style="border-top: 0">
               <tr ng-repeat="envvar in container.Env | orderBy: 'name'">

--- a/app/kubernetes/views/configurations/configurationsController.js
+++ b/app/kubernetes/views/configurations/configurationsController.js
@@ -43,11 +43,11 @@ class KubernetesConfigurationsController {
     for (const configuration of selectedItems) {
       try {
         await this.KubernetesConfigurationService.delete(configuration);
-        this.Notifications.success('Configurations successfully removed', configuration.Name);
+        this.Notifications.success('ConfigMaps/Secrets successfully removed', configuration.Name);
         const index = this.configurations.indexOf(configuration);
         this.configurations.splice(index, 1);
       } catch (err) {
-        this.Notifications.error('Failure', err, 'Unable to remove ConfigMaps & Secrets');
+        this.Notifications.error('Failure', err, 'Unable to remove ConfigMaps/Secrets');
       } finally {
         --actionCount;
         if (actionCount === 0) {

--- a/app/kubernetes/views/configurations/configurationsController.js
+++ b/app/kubernetes/views/configurations/configurationsController.js
@@ -28,7 +28,7 @@ class KubernetesConfigurationsController {
       this.configurations = await this.KubernetesConfigurationService.get();
       KubernetesConfigurationHelper.setConfigurationsUsed(this.configurations, this.applications);
     } catch (err) {
-      this.Notifications.error('Failure', err, 'Unable to retrieve configurations');
+      this.Notifications.error('Failure', err, 'Unable to retrieve ConfigMaps & Secrets');
     } finally {
       this.state.configurationsLoading = false;
     }
@@ -47,7 +47,7 @@ class KubernetesConfigurationsController {
         const index = this.configurations.indexOf(configuration);
         this.configurations.splice(index, 1);
       } catch (err) {
-        this.Notifications.error('Failure', err, 'Unable to remove configuration');
+        this.Notifications.error('Failure', err, 'Unable to remove ConfigMaps & Secrets');
       } finally {
         --actionCount;
         if (actionCount === 0) {
@@ -58,7 +58,7 @@ class KubernetesConfigurationsController {
   }
 
   removeAction(selectedItems) {
-    confirmDelete('Do you want to remove the selected configuration(s)?').then((confirmed) => {
+    confirmDelete('Do you want to remove the selected ConfigMap(s) & Secret(s)?').then((confirmed) => {
       if (confirmed) {
         return this.$async(this.removeActionAsync, selectedItems);
       }

--- a/app/kubernetes/views/configurations/create/createConfiguration.html
+++ b/app/kubernetes/views/configurations/create/createConfiguration.html
@@ -1,7 +1,7 @@
 <page-header
   ng-if="ctrl.state.viewReady"
-  title="'Create configuration'"
-  breadcrumbs="[{ label:'ConfigMaps and Secrets', link:'kubernetes.configurations' }, 'Create a configuration']"
+  title="'Create ConfigMap or Secret'"
+  breadcrumbs="[{ label:'ConfigMaps and Secrets', link:'kubernetes.configurations' }, 'Create a ConfigMap or Secret']"
   reload="true"
 ></page-header>
 
@@ -53,7 +53,7 @@
                   ng-model="ctrl.formValues.Name"
                   ng-pattern="/^[a-z0-9]([a-z0-9-.]{0,61}[a-z0-9])?$/"
                   ng-change="ctrl.onChangeName()"
-                  placeholder="my-configuration"
+                  placeholder="my-configmap-or-secret"
                   auto-focus
                   required
                   data-cy="k8sConfigCreate-nameInput"
@@ -81,10 +81,10 @@
             </div>
 
             <div ng-if="ctrl.formValues.ResourcePool">
-              <div class="col-sm-12 form-section-title"> Configuration kind </div>
+              <div class="col-sm-12 form-section-title"> Kind </div>
 
               <div class="form-group">
-                <div class="col-sm-12 small text-muted"> Select the kind of data that you want to save in the configuration. </div>
+                <div class="col-sm-12 small text-muted"> Select the kind of data that you want to save. </div>
               </div>
 
               <box-selector options="ctrl.typeOptions" value="ctrl.formValues.Kind" on-change="(ctrl.onChangeKind)" radio-name="'Kind'" slim="true"> </box-selector>

--- a/app/kubernetes/views/configurations/create/createConfigurationController.js
+++ b/app/kubernetes/views/configurations/create/createConfigurationController.js
@@ -140,6 +140,11 @@ class KubernetesCreateConfigurationController {
   }
 
   async createConfigurationAsync() {
+    let kind = 'ConfigMap';
+    if (this.formValues.Kind === this.KubernetesConfigurationKinds.SECRET) {
+      kind = 'Secret';
+    }
+
     try {
       this.state.actionInProgress = true;
       this.formValues.ConfigurationOwner = this.Authentication.getUserDetails().username;
@@ -148,11 +153,12 @@ class KubernetesCreateConfigurationController {
       }
 
       await this.KubernetesConfigurationService.create(this.formValues);
-      this.Notifications.success('Success', 'Configuration succesfully created');
+
+      this.Notifications.success('Success', `${kind} successfully created`);
       this.state.isEditorDirty = false;
       this.$state.go('kubernetes.configurations');
     } catch (err) {
-      this.Notifications.error('Failure', err, 'Unable to create configuration');
+      this.Notifications.error('Failure', err, `Unable to create ${kind}`);
     } finally {
       this.state.actionInProgress = false;
     }
@@ -166,7 +172,7 @@ class KubernetesCreateConfigurationController {
     try {
       this.configurations = await this.KubernetesConfigurationService.get();
     } catch (err) {
-      this.Notifications.error('Failure', err, 'Unable to retrieve configurations');
+      this.Notifications.error('Failure', err, 'Unable to retrieve ConfigMaps and Secrets');
     }
   }
 

--- a/app/kubernetes/views/configurations/edit/configuration.html
+++ b/app/kubernetes/views/configurations/edit/configuration.html
@@ -1,6 +1,6 @@
 <page-header
   ng-if="ctrl.state.viewReady"
-  title="'Configuration details'"
+  title="'ConfigMap or Secret details'"
   breadcrumbs="[
     { label:'Namespaces', link:'kubernetes.resourcePools' },
     {
@@ -46,7 +46,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td class="!pl-0">Configuration kind</td>
+                      <td class="!pl-0">Kind</td>
                       <td>
                         {{ ctrl.configuration.Kind | kubernetesConfigurationKindText }}
                       </td>

--- a/app/kubernetes/views/configurations/edit/configurationController.js
+++ b/app/kubernetes/views/configurations/edit/configurationController.js
@@ -87,6 +87,11 @@ class KubernetesConfigurationController {
   // It looks like we're still doing a create/delete process but we've decided to get rid of this
   // approach.
   async updateConfigurationAsync() {
+    let kind = 'ConfigMap';
+    if (this.formValues.Kind === KubernetesConfigurationKinds.SECRET) {
+      kind = 'Secret';
+    }
+
     try {
       this.state.actionInProgress = true;
       if (
@@ -96,7 +101,7 @@ class KubernetesConfigurationController {
       ) {
         await this.KubernetesConfigurationService.create(this.formValues);
         await this.KubernetesConfigurationService.delete(this.configuration);
-        this.Notifications.success('Success', 'Configuration succesfully updated');
+        this.Notifications.success('Success', `${kind} successfully updated`);
         this.$state.go(
           'kubernetes.configurations.configuration',
           {
@@ -107,11 +112,11 @@ class KubernetesConfigurationController {
         );
       } else {
         await this.KubernetesConfigurationService.update(this.formValues, this.configuration);
-        this.Notifications.success('Success', 'Configuration succesfully updated');
+        this.Notifications.success('Success', `${kind} successfully updated`);
         this.$state.reload(this.$state.current);
       }
     } catch (err) {
-      this.Notifications.error('Failure', err, 'Unable to update configuration');
+      this.Notifications.error('Failure', err, `Unable to update ${kind}`);
     } finally {
       this.state.actionInProgress = false;
     }

--- a/app/kubernetes/views/configurations/edit/configurationController.js
+++ b/app/kubernetes/views/configurations/edit/configurationController.js
@@ -125,8 +125,9 @@ class KubernetesConfigurationController {
   updateConfiguration() {
     if (this.configuration.Used) {
       const plural = this.configuration.Applications.length > 1 ? 's' : '';
+      const thisorthese = this.configuration.Applications.length > 1 ? 'these' : 'this';
       confirmUpdate(
-        `The changes will be propagated to ${this.configuration.Applications.length} running application${plural}. Are you sure you want to update this configuration?`,
+        `The changes will be propagated to ${this.configuration.Applications.length} running application${plural}. Are you sure you want to update ${thisorthese} ConfigMap${plural} or Secret${plural}?`,
         (confirmed) => {
           if (confirmed) {
             return this.$async(this.updateConfigurationAsync);

--- a/app/react/kubernetes/configs/CreateView/options.tsx
+++ b/app/react/kubernetes/configs/CreateView/options.tsx
@@ -10,7 +10,7 @@ export const typeOptions: ReadonlyArray<BoxSelectorOption<number>> = [
     icon: FileCode,
     iconType: 'badge',
     label: 'ConfigMap',
-    description: 'This configuration holds non-sensitive information',
+    description: 'This kind holds non-sensitive information',
   },
   {
     id: 'type_secret',
@@ -18,6 +18,6 @@ export const typeOptions: ReadonlyArray<BoxSelectorOption<number>> = [
     icon: Lock,
     iconType: 'badge',
     label: 'Secret',
-    description: 'This configuration holds sensitive information',
+    description: 'This kind holds sensitive information',
   },
 ] as const;


### PR DESCRIPTION
Closes [EE-4816](https://portainer.atlassian.net/browse/EE-4816)

[EE-4816]: https://portainer.atlassian.net/browse/EE-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ