### PR TITLE
feat(ci/security): remove deprecated github action command alert [EE-3059]

### DIFF
--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -14,10 +14,10 @@ jobs:
     outputs:
       js: ${{ steps.set-matrix.outputs.js_result }}
     steps:
-      - name: Checkout Repository
+      - name: checkout repository
         uses: actions/checkout@master
 
-      - name: Scan Vulnerability by Snyk 
+      - name: scan vulnerabilities by Snyk
         uses: snyk/actions/node@master
         continue-on-error: true # To make sure that artifact upload gets called
         env:
@@ -25,26 +25,26 @@ jobs:
         with:
           json: true
 
-      - name: Upload Scan Result As develop Artifact
+      - name: upload scan result as develop artifact 
         uses: actions/upload-artifact@v3
         with:
           name: js-security-scan-develop-result
           path: snyk.json
 
-      - name: Develop Scan Report Export to HTML
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=table -export -export-filename="/data/js-result")
+      - name: develop scan report export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=snyk --path="/data/snyk.json" --output-type=table --export --export-filename="/data/js-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-js-result-${{github.run_id}}
           path: js-result.html
 
-      - name: Analyse Vulnerabilities
+      - name: analyse vulnerabilities 
         id: set-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=snyk --path="/data/snyk.json" --output-type=matrix)
           echo "js_result=${result}" >> $GITHUB_OUTPUT
 
   server-dependencies:
@@ -55,18 +55,18 @@ jobs:
     outputs:
       go: ${{ steps.set-matrix.outputs.go_result }}
     steps:
-      - name: Checkout Repository
+      - name: checkout repository
         uses: actions/checkout@master
 
-      - name: Install Golang
+      - name: install Go 
         uses: actions/setup-go@v3
         with:
           go-version: '1.19.4'
 
-      - name: Download Go Modules
+      - name: download Go modules
         run: cd ./api && go get -t -v -d ./...
 
-      - name: Scan Vulnerability by Snyk
+      - name: scan vulnerabilities by Snyk
         continue-on-error: true # To make sure that artifact upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -74,26 +74,26 @@ jobs:
           yarn global add snyk
           snyk test --file=./api/go.mod --json-file-output=snyk.json 2>/dev/null || :
 
-      - name: Upload Scan Result As develop Artifact
+      - name: upload scan result as develop artifact 
         uses: actions/upload-artifact@v3
         with:
           name: go-security-scan-develop-result
           path: snyk.json
 
-      - name: Develop Scan Report Export to HTML
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=table -export -export-filename="/data/go-result")
+      - name: develop scan report export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=snyk --path="/data/snyk.json" --output-type=table --export --export-filename="/data/go-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-go-result-${{github.run_id}}
           path: go-result.html
 
-      - name: Analyse Vulnerabilities
+      - name: analyse vulnerabilities
         id: set-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=snyk --path="/data/snyk.json" --output-type=matrix)
           echo "go_result=${result}" >> $GITHUB_OUTPUT
 
   image-vulnerability:
@@ -104,32 +104,32 @@ jobs:
     outputs:
       image: ${{ steps.set-matrix.outputs.image_result }}
     steps:
-      - name: Scan Vulnerability by Trivy
+      - name: scan vulnerabilities by Trivy 
         uses: docker://docker.io/aquasec/trivy:latest
         continue-on-error: true 
         with:
           args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress  portainerci/portainer:develop
 
-      - name: Upload Image Security Scan Result As Artifact
+      - name: upload image security scan result as artifact
         uses: actions/upload-artifact@v3
         with:
           name: image-security-scan-develop-result
           path: image-trivy.json
 
-      - name: Develop Scan Report Export to HTML 
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=trivy -path="/data/image-trivy.json" -output-type=table -export -export-filename="/data/image-result")
+      - name: develop scan report export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=trivy --path="/data/image-trivy.json" --output-type=table --export --export-filename="/data/image-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-image-result-${{github.run_id}}
           path: image-result.html
 
-      - name: Analyse Vulnerabilities
+      - name: analyse vulnerabilities
         id: set-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=trivy -path="/data/image-trivy.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest summary --report-type=trivy --path="/data/image-trivy.json" --output-type=matrix)
           echo "image_result=${result}" >> $GITHUB_OUTPUT
 
   result-analysis:
@@ -144,7 +144,7 @@ jobs:
         go: ${{fromJson(needs.server-dependencies.outputs.go)}}
         image: ${{fromJson(needs.image-vulnerability.outputs.image)}}
     steps:
-      - name: Display the results of js, go and image
+      - name: display the results of js, Go, and image scan
         run: |
           echo ${{ matrix.js.status }}
           echo ${{ matrix.go.status }}
@@ -153,7 +153,7 @@ jobs:
           echo ${{ matrix.go.summary }}
           echo ${{ matrix.image.summary }}
 
-      - name: Send Slack message
+      - name: send message to Slack 
         if: >- 
           matrix.js.status == 'failure' ||
           matrix.go.status == 'failure' || 

--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -2,7 +2,7 @@ name: Nightly Code Security Scan
 
 on: 
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 20 * * *'
   workflow_dispatch:
     
 jobs:

--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -61,7 +61,7 @@ jobs:
       - name: install Go 
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - name: download Go modules
         run: cd ./api && go get -t -v -d ./...
@@ -108,7 +108,7 @@ jobs:
         uses: docker://docker.io/aquasec/trivy:latest
         continue-on-error: true 
         with:
-          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress  portainerci/portainer:develop
+          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress portainerci/portainer:develop
 
       - name: upload image security scan result as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -7,16 +7,17 @@ on:
     
 jobs:
   client-dependencies:
-    name: Client dependency check
+    name: Client Dependency Check
     runs-on: ubuntu-latest
     if: >- # only run for develop branch
       github.ref == 'refs/heads/develop' 
     outputs:
       js: ${{ steps.set-matrix.outputs.js_result }}
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@master
 
-      - name: Run Snyk to check for vulnerabilities
+      - name: Scan Vulnerability by Snyk 
         uses: snyk/actions/node@master
         continue-on-error: true # To make sure that artifact upload gets called
         env:
@@ -24,46 +25,48 @@ jobs:
         with:
           json: true
 
-      - name: Upload js security scan result as artifact 
+      - name: Upload Scan Result As develop Artifact
         uses: actions/upload-artifact@v3
         with:
           name: js-security-scan-develop-result
           path: snyk.json
 
-      - name: Export scan result to html file 
+      - name: Develop Scan Report Export to HTML
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=table -export -export-filename="/data/js-result")
 
-      - name: Upload js result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-js-result-${{github.run_id}}
           path: js-result.html
 
-      - name: Analyse the js result
+      - name: Analyse Vulnerabilities
         id: set-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=matrix)
-          echo "::set-output name=js_result::${result}"
+          echo "js_result=${result}" >> $GITHUB_OUTPUT
 
   server-dependencies:
-    name: Server dependency check
+    name: Server Dependency Check
     runs-on: ubuntu-latest
     if: >- # only run for develop branch
       github.ref == 'refs/heads/develop' 
     outputs:
       go: ${{ steps.set-matrix.outputs.go_result }}
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@master
 
-      - uses: actions/setup-go@v3
+      - name: Install Golang
+        uses: actions/setup-go@v3
         with:
           go-version: '1.19.4'
 
-      - name: Download go modules
+      - name: Download Go Modules
         run: cd ./api && go get -t -v -d ./...
 
-      - name: Run Snyk to check for vulnerabilities
+      - name: Scan Vulnerability by Snyk
         continue-on-error: true # To make sure that artifact upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -71,97 +74,66 @@ jobs:
           yarn global add snyk
           snyk test --file=./api/go.mod --json-file-output=snyk.json 2>/dev/null || :
 
-      - name: Upload go security scan result as artifact
+      - name: Upload Scan Result As develop Artifact
         uses: actions/upload-artifact@v3
         with:
           name: go-security-scan-develop-result
           path: snyk.json
 
-      - name: Export scan result to html file 
+      - name: Develop Scan Report Export to HTML
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=table -export -export-filename="/data/go-result")
 
-      - name: Upload go result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-go-result-${{github.run_id}}
           path: go-result.html
 
-      - name: Analyse the go result
+      - name: Analyse Vulnerabilities
         id: set-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=snyk -path="/data/snyk.json" -output-type=matrix)
-          echo "::set-output name=go_result::${result}"
+          echo "go_result=${result}" >> $GITHUB_OUTPUT
 
   image-vulnerability:
-    name: Build docker image and Image vulnerability check
+    name: Image Vulnerability Check
     runs-on: ubuntu-latest
     if: >-
       github.ref == 'refs/heads/develop'
     outputs:
       image: ${{ steps.set-matrix.outputs.image_result }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-
-      - name: Use golang 1.19.4
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.19.4'
-
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18.x
-
-      - name: Install packages and build
-        run: yarn install && yarn build
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: build/linux/Dockerfile
-          tags: trivy-portainer:${{ github.sha }}
-          outputs: type=docker,dest=/tmp/trivy-portainer-image.tar
-
-      - name: Load docker image
-        run: |
-          docker load --input /tmp/trivy-portainer-image.tar
-
-      - name: Run Trivy vulnerability scanner
+      - name: Scan Vulnerability by Trivy
         uses: docker://docker.io/aquasec/trivy:latest
         continue-on-error: true 
         with:
-          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress trivy-portainer:${{ github.sha }}  
+          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress  portainerci/portainer:develop
 
-      - name: Upload image security scan result as artifact
+      - name: Upload Image Security Scan Result As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: image-security-scan-develop-result
           path: image-trivy.json
 
-      - name: Export scan result to html file 
+      - name: Develop Scan Report Export to HTML 
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=trivy -path="/data/image-trivy.json" -output-type=table -export -export-filename="/data/image-result")
 
-      - name: Upload go result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-image-result-${{github.run_id}}
           path: image-result.html
 
-      - name: Analyse the trivy result
+      - name: Analyse Vulnerabilities
         id: set-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 summary -report-type=trivy -path="/data/image-trivy.json" -output-type=matrix)
-          echo "::set-output name=image_result::${result}"
+          echo "image_result=${result}" >> $GITHUB_OUTPUT
 
   result-analysis:
-    name: Analyse scan result
+    name: Analyse Scan Results
     needs: [client-dependencies, server-dependencies, image-vulnerability]
     runs-on: ubuntu-latest
     if: >-
@@ -186,7 +158,7 @@ jobs:
           matrix.js.status == 'failure' ||
           matrix.go.status == 'failure' || 
           matrix.image.status == 'failure'
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
             {

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -142,13 +142,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
 
-      - name: Use golang 1.19.4
+      - name: Use golang 1.19.5
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
 
@@ -156,10 +156,10 @@ jobs:
         run: yarn install && yarn build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: build/linux/Dockerfile

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -15,7 +15,7 @@ on:
     
 jobs:
   client-dependencies:
-    name: Client dependency check
+    name: Client Dependency Check
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request &&
@@ -23,9 +23,10 @@ jobs:
     outputs:
       jsdiff: ${{ steps.set-diff-matrix.outputs.js_diff_result }}
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@master
 
-      - name: Run Snyk to check for vulnerabilities
+      - name: Scan Vulnerability by Snyk 
         uses: snyk/actions/node@master
         continue-on-error: true # To make sure that artifact upload gets called
         env:
@@ -33,13 +34,13 @@ jobs:
         with:
           json: true
 
-      - name: Upload js security scan result as artifact
+      - name: Upload Scan Result As Pull-Request Artifact
         uses: actions/upload-artifact@v3
         with:
           name: js-security-scan-feat-result
           path: snyk.json
 
-      - name: Download artifacts from develop branch
+      - name: Download Artifacts From develop Branch Built By Nightly Scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -51,24 +52,24 @@ jobs:
             echo "null" > ./js-snyk-develop.json
           fi
 
-      - name: Export scan result to html file 
+      - name: PR vs Develop Scan Report Comparison Export to HTML
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/js-snyk-feature.json" -compare-to="/data/js-snyk-develop.json" -output-type=table -export -export-filename="/data/js-result")
 
-      - name: Upload js result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-js-result-compare-to-develop-${{github.run_id}}
           path: js-result.html
 
-      - name: Analyse the js diff result
+      - name: Analyse Different Vulnerabilites Compared to develop Branch
         id: set-diff-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/js-snyk-feature.json" -compare-to="./data/js-snyk-develop.json" -output-type=matrix)
-          echo "::set-output name=js_diff_result::${result}"
+          echo "js_diff_result=${result}" >> $GITHUB_OUTPUT
 
   server-dependencies:
-    name: Server dependency check
+    name: Server Dependency Check
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request &&
@@ -76,16 +77,18 @@ jobs:
     outputs:
       godiff: ${{ steps.set-diff-matrix.outputs.go_diff_result }}
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@master
 
-      - uses: actions/setup-go@v3
+      - name: Install Golang
+        uses: actions/setup-go@v3
         with:
           go-version: '1.19.4'
 
-      - name: Download go modules
+      - name: Download Go Modules
         run: cd ./api && go get -t -v -d ./...
 
-      - name: Run Snyk to check for vulnerabilities
+      - name: Scan Vulnerability by Snyk
         continue-on-error: true # To make sure that artifact upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -93,13 +96,13 @@ jobs:
           yarn global add snyk
           snyk test --file=./api/go.mod --json-file-output=snyk.json 2>/dev/null || :
 
-      - name: Upload go security scan result as artifact
+      - name: Upload Scan Result As Pull-Request Artifact
         uses: actions/upload-artifact@v3
         with:
           name: go-security-scan-feature-result
           path: snyk.json
 
-      - name: Download artifacts from develop branch
+      - name: Download Artifacts From develop Branch Built By Nightly Scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -111,24 +114,24 @@ jobs:
             echo "null" > ./go-snyk-develop.json
           fi
 
-      - name: Export scan result to html file 
+      - name: PR vs Develop Scan Report Comparison Export to HTML
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/go-snyk-feature.json" -compare-to="/data/go-snyk-develop.json" -output-type=table -export -export-filename="/data/go-result")
 
-      - name: Upload go result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-go-result-compare-to-develop-${{github.run_id}}
           path: go-result.html
 
-      - name: Analyse the go diff result
+      - name: Analyse Different Vulnerabilites Aginst develop Branch
         id: set-diff-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/go-snyk-feature.json" -compare-to="/data/go-snyk-develop.json" -output-type=matrix)
-          echo "::set-output name=go_diff_result::${result}"
+          echo "go_diff_result=${result}" >> $GITHUB_OUTPUT
 
   image-vulnerability:
-    name: Build docker image and Image vulnerability check
+    name: Image Vulnerability Check
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request &&
@@ -167,19 +170,19 @@ jobs:
         run: |
           docker load --input /tmp/trivy-portainer-image.tar
 
-      - name: Run Trivy vulnerability scanner
+      - name: Scan Vulnerability by Trivy
         uses: docker://docker.io/aquasec/trivy:latest
         continue-on-error: true 
         with:
           args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress trivy-portainer:${{ github.sha }}  
 
-      - name: Upload image security scan result as artifact
+      - name: Upload Image Security Scan Result As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: image-security-scan-feature-result
           path: image-trivy.json
 
-      - name: Download artifacts from develop branch
+      - name: Download Artifacts From develop Branch Built By Nightly Scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -191,24 +194,24 @@ jobs:
             echo "null" > ./image-trivy-develop.json
           fi
 
-      - name: Export scan result to html file 
+      - name: PR vs Develop Scan Report Comparison Export to HTML
         run: | 
           $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=trivy -path="/data/image-trivy-feature.json" -compare-to="/data/image-trivy-develop.json" -output-type=table -export -export-filename="/data/image-result")
 
-      - name: Upload image result html file
+      - name: Upload HTML File As Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-image-result-compare-to-develop-${{github.run_id}}
           path: image-result.html
 
-      - name: Analyse the image diff result
+      - name: Analyse Different Vulnerabilites Aginst develop Branch
         id: set-diff-matrix
         run: | 
           result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=trivy -path="/data/image-trivy-feature.json" -compare-to="./data/image-trivy-develop.json" -output-type=matrix)
-          echo "::set-output name=image_diff_result::${result}"
+          echo "image_diff_result=${result}" >> $GITHUB_OUTPUT
 
   result-analysis:
-    name: Analyse scan result compared to develop
+    name: Analyse Scan Result Against develop Branch
     needs: [client-dependencies, server-dependencies, image-vulnerability]
     runs-on: ubuntu-latest
     if: >-
@@ -220,8 +223,7 @@ jobs:
         godiff: ${{fromJson(needs.server-dependencies.outputs.godiff)}}
         imagediff: ${{fromJson(needs.image-vulnerability.outputs.imagediff)}}
     steps:
-
-      - name: Check job status of diff result
+      - name: Check Job Status of Diff Result
         if: >-
           matrix.jsdiff.status == 'failure' ||
           matrix.godiff.status == 'failure' ||

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -12,6 +12,7 @@ on:
       - 'build/linux/Dockerfile'
       - 'build/linux/alpine.Dockerfile'
       - 'build/windows/Dockerfile'
+      - '.github/workflows/pr-security.yml'
     
 jobs:
   client-dependencies:

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -89,7 +89,7 @@ jobs:
       - name: download Go modules
         run: cd ./api && go get -t -v -d ./...
 
-       - name: scan vulnerabilities by Snyk
+      - name: scan vulnerabilities by Snyk
         continue-on-error: true # To make sure that artifact upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       jsdiff: ${{ steps.set-diff-matrix.outputs.js_diff_result }}
     steps:
-      - name: Checkout Repository
+      - name: checkout repository 
         uses: actions/checkout@master
 
-      - name: Scan Vulnerability by Snyk 
+      - name: scan vulnerabilities by Snyk
         uses: snyk/actions/node@master
         continue-on-error: true # To make sure that artifact upload gets called
         env:
@@ -34,13 +34,13 @@ jobs:
         with:
           json: true
 
-      - name: Upload Scan Result As Pull-Request Artifact
+      - name: upload scan result as pull-request artifact
         uses: actions/upload-artifact@v3
         with:
           name: js-security-scan-feat-result
           path: snyk.json
 
-      - name: Download Artifacts From develop Branch Built By Nightly Scan
+      - name: download artifacts from develop branch built by nightly scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -52,20 +52,20 @@ jobs:
             echo "null" > ./js-snyk-develop.json
           fi
 
-      - name: PR vs Develop Scan Report Comparison Export to HTML
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/js-snyk-feature.json" -compare-to="/data/js-snyk-develop.json" -output-type=table -export -export-filename="/data/js-result")
+      - name: pr vs develop scan report comparison export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=snyk --path="/data/js-snyk-feature.json" --compare-to="/data/js-snyk-develop.json" --output-type=table --export --export-filename="/data/js-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-js-result-compare-to-develop-${{github.run_id}}
           path: js-result.html
 
-      - name: Analyse Different Vulnerabilites Compared to develop Branch
+      - name: analyse different vulnerabilities compared to develop branch
         id: set-diff-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/js-snyk-feature.json" -compare-to="./data/js-snyk-develop.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=snyk --path="/data/js-snyk-feature.json" --compare-to="/data/js-snyk-develop.json" --output-type=matrix)
           echo "js_diff_result=${result}" >> $GITHUB_OUTPUT
 
   server-dependencies:
@@ -77,18 +77,18 @@ jobs:
     outputs:
       godiff: ${{ steps.set-diff-matrix.outputs.go_diff_result }}
     steps:
-      - name: Checkout Repository
+      - name: checkout repository
         uses: actions/checkout@master
 
-      - name: Install Golang
+      - name: install Go
         uses: actions/setup-go@v3
         with:
           go-version: '1.19.4'
 
-      - name: Download Go Modules
+      - name: download Go modules
         run: cd ./api && go get -t -v -d ./...
 
-      - name: Scan Vulnerability by Snyk
+       - name: scan vulnerabilities by Snyk
         continue-on-error: true # To make sure that artifact upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -96,13 +96,13 @@ jobs:
           yarn global add snyk
           snyk test --file=./api/go.mod --json-file-output=snyk.json 2>/dev/null || :
 
-      - name: Upload Scan Result As Pull-Request Artifact
+      - name: upload scan result as pull-request artifact
         uses: actions/upload-artifact@v3
         with:
           name: go-security-scan-feature-result
           path: snyk.json
 
-      - name: Download Artifacts From develop Branch Built By Nightly Scan
+      - name: download artifacts from develop branch built by nightly scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -114,20 +114,20 @@ jobs:
             echo "null" > ./go-snyk-develop.json
           fi
 
-      - name: PR vs Develop Scan Report Comparison Export to HTML
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/go-snyk-feature.json" -compare-to="/data/go-snyk-develop.json" -output-type=table -export -export-filename="/data/go-result")
+      - name: pr vs develop scan report comparison export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=snyk --path="/data/go-snyk-feature.json" --compare-to="/data/go-snyk-develop.json" --output-type=table --export --export-filename="/data/go-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-go-result-compare-to-develop-${{github.run_id}}
           path: go-result.html
 
-      - name: Analyse Different Vulnerabilites Aginst develop Branch
+      - name: analyse different vulnerabilities against develop branch
         id: set-diff-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=snyk -path="/data/go-snyk-feature.json" -compare-to="/data/go-snyk-develop.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=snyk --path="/data/go-snyk-feature.json" --compare-to="/data/go-snyk-develop.json" --output-type=matrix)
           echo "go_diff_result=${result}" >> $GITHUB_OUTPUT
 
   image-vulnerability:
@@ -139,26 +139,26 @@ jobs:
     outputs:
       imagediff: ${{ steps.set-diff-matrix.outputs.image_diff_result }}
     steps:
-      - name: Checkout code
+      - name: checkout code
         uses: actions/checkout@master
 
-      - name: Use golang 1.19.5
+      - name: install Go 1.19.5
         uses: actions/setup-go@v3
         with:
           go-version: '1.19.5'
 
-      - name: Use Node.js 18.x
+      - name: install Node.js 18.x
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
 
-      - name: Install packages and build
+      - name: install packages and build binary
         run: yarn install && yarn build
 
-      - name: Set up Docker Buildx
+      - name: set up docker buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push
+      - name: build and compress image
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -166,23 +166,23 @@ jobs:
           tags: trivy-portainer:${{ github.sha }}
           outputs: type=docker,dest=/tmp/trivy-portainer-image.tar
 
-      - name: Load docker image
+      - name: load docker image
         run: |
           docker load --input /tmp/trivy-portainer-image.tar
 
-      - name: Scan Vulnerability by Trivy
+      - name: scan vulnerabilities by Trivy
         uses: docker://docker.io/aquasec/trivy:latest
         continue-on-error: true 
         with:
-          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress trivy-portainer:${{ github.sha }}  
+          args: image --ignore-unfixed=true --vuln-type="os,library" --exit-code=1 --format="json" --output="image-trivy.json" --no-progress trivy-portainer:${{ github.sha }}
 
-      - name: Upload Image Security Scan Result As Artifact
+      - name: upload image security scan result as artifact
         uses: actions/upload-artifact@v3
         with:
           name: image-security-scan-feature-result
           path: image-trivy.json
 
-      - name: Download Artifacts From develop Branch Built By Nightly Scan
+      - name: download artifacts from develop branch built by nightly scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -194,20 +194,20 @@ jobs:
             echo "null" > ./image-trivy-develop.json
           fi
 
-      - name: PR vs Develop Scan Report Comparison Export to HTML
-        run: | 
-          $(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=trivy -path="/data/image-trivy-feature.json" -compare-to="/data/image-trivy-develop.json" -output-type=table -export -export-filename="/data/image-result")
+      - name: pr vs develop scan report comparison export to html
+        run: |
+          $(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=trivy --path="/data/image-trivy-feature.json" --compare-to="/data/image-trivy-develop.json" --output-type=table --export --export-filename="/data/image-result")
 
-      - name: Upload HTML File As Artifact
+      - name: upload html file as artifact
         uses: actions/upload-artifact@v3
         with:
           name: html-image-result-compare-to-develop-${{github.run_id}}
           path: image-result.html
 
-      - name: Analyse Different Vulnerabilites Aginst develop Branch
+      - name: analyse different vulnerabilities against develop branch
         id: set-diff-matrix
-        run: | 
-          result=$(docker run --rm -v ${{ github.workspace }}:/data oscarzhou/scan-report:0.1.8 diff -report-type=trivy -path="/data/image-trivy-feature.json" -compare-to="./data/image-trivy-develop.json" -output-type=matrix)
+        run: |
+          result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=trivy --path="/data/image-trivy-feature.json" --compare-to="/data/image-trivy-develop.json" --output-type=matrix)
           echo "image_diff_result=${result}" >> $GITHUB_OUTPUT
 
   result-analysis:
@@ -223,7 +223,7 @@ jobs:
         godiff: ${{fromJson(needs.server-dependencies.outputs.godiff)}}
         imagediff: ${{fromJson(needs.image-vulnerability.outputs.imagediff)}}
     steps:
-      - name: Check Job Status of Diff Result
+      - name: check job status of diff result
         if: >-
           matrix.jsdiff.status == 'failure' ||
           matrix.godiff.status == 'failure' ||

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -63,7 +63,7 @@ jobs:
           name: html-js-result-compare-to-develop-${{github.run_id}}
           path: js-result.html
 
-      - name: analyse different vulnerabilities compared to develop branch
+      - name: analyse different vulnerabilities against develop branch
         id: set-diff-matrix
         run: |
           result=$(docker run --rm -v ${{ github.workspace }}:/data portainerci/code-security-report:latest diff --report-type=snyk --path="/data/js-snyk-feature.json" --compare-to="/data/js-snyk-develop.json" --output-type=matrix)
@@ -84,7 +84,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.4'
+          go-version: '1.19.5'
 
       - name: download Go modules
         run: cd ./api && go get -t -v -d ./...


### PR DESCRIPTION
closes [EE-3059]

This PR will make the below enhancements:
- [x] apply the latest GITHUB_OUTPUT grammars before the due day of deprecated grammar
- [ ] docker image vulnerability scan will target the image built by Azure Pipeline
	- [x] nightly scan 
	- [ ] pr scan 
- [x] update package version 
- [x] better GITHUB workflow job step description

[EE-3059]: https://portainer.atlassian.net/browse/EE-3059?