### PR TITLE
fix(images): avoid returning null on registryId default value EE-5394

### DIFF
--- a/app/portainer/services/registryModalService.js
+++ b/app/portainer/services/registryModalService.js
@@ -11,7 +11,7 @@ function RegistryModalService(RegistryService) {
     const defaultValue = _.get(registryModel, 'Registry.Id', 0);
 
     const registryId = await selectRegistry(registries, defaultValue);
-    if (!registryId) {
+    if (registryId === undefined) {
       return null;
     }
 


### PR DESCRIPTION
fixes [EE-5394](https://portainer.atlassian.net/browse/EE-5394)

[EE-5394]: https://portainer.atlassian.net/browse/EE-5394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ