### PR TITLE
fix(docker/networks): load containers from target node [EE-5446]

### DIFF
--- a/app/portainer/services/axios.ts
+++ b/app/portainer/services/axios.ts
@@ -27,6 +27,8 @@ axios.interceptors.request.use(async (config) => {
   return newConfig;
 });
 
+export const agentTargetHeader = 'X-PortainerAgent-Target';
+
 export function agentInterceptor(config: AxiosRequestConfig) {
   if (!config.url || !config.url.includes('/docker/')) {
     return config;
@@ -35,7 +37,7 @@ export function agentInterceptor(config: AxiosRequestConfig) {
   const newConfig = { headers: config.headers || {}, ...config };
   const target = portainerAgentTargetHeader();
   if (target) {
-    newConfig.headers['X-PortainerAgent-Target'] = target;
+    newConfig.headers[agentTargetHeader] = target;
   }
 
   if (portainerAgentManagerOperation()) {

--- a/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
@@ -45,12 +45,9 @@ export function ContainersDatatable({
   const columns = useColumns(isHostColumnVisible, isGPUsColumnVisible);
   const tableState = useTableState(settingsStore, storageKey);
 
-  const containersQuery = useContainers(
-    environment.Id,
-    true,
-    undefined,
-    tableState.autoRefreshRate * 1000
-  );
+  const containersQuery = useContainers(environment.Id, undefined, {
+    autoRefreshRate: tableState.autoRefreshRate * 1000,
+  });
 
   return (
     <RowProvider context={{ environment }}>

--- a/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
@@ -45,7 +45,7 @@ export function ContainersDatatable({
   const columns = useColumns(isHostColumnVisible, isGPUsColumnVisible);
   const tableState = useTableState(settingsStore, storageKey);
 
-  const containersQuery = useContainers(environment.Id, undefined, {
+  const containersQuery = useContainers(environment.Id, {
     autoRefreshRate: tableState.autoRefreshRate * 1000,
   });
 

--- a/app/react/docker/containers/queries/containers.ts
+++ b/app/react/docker/containers/queries/containers.ts
@@ -5,6 +5,7 @@ import axios, {
   agentTargetHeader,
   parseAxiosError,
 } from '@/portainer/services/axios';
+import { withGlobalError } from '@/react-tools/react-query';
 
 import { urlBuilder } from '../containers.service';
 import { DockerContainerResponse } from '../types/response';
@@ -30,10 +31,7 @@ export function useContainers(
     queryKeys.filters(environmentId, { all, filters, nodeName }),
     () => getContainers(environmentId, { all, filters, nodeName }),
     {
-      meta: {
-        title: 'Failure',
-        message: 'Unable to retrieve containers',
-      },
+      ...withGlobalError('Unable to retrieve containers'),
       refetchInterval() {
         return autoRefreshRate ?? false;
       },

--- a/app/react/docker/containers/queries/containers.ts
+++ b/app/react/docker/containers/queries/containers.ts
@@ -14,22 +14,25 @@ import { parseViewModel } from '../utils';
 import { Filters } from './types';
 import { queryKeys } from './query-keys';
 
+interface UseContainers {
+  all?: boolean;
+  filters?: Filters;
+  nodeName?: string;
+}
+
 export function useContainers(
   environmentId: EnvironmentId,
   {
-    all = true,
-    filters,
-    nodeName,
-  }: { all?: boolean; filters?: Filters; nodeName?: string } = {},
-  {
     autoRefreshRate,
-  }: {
+
+    ...params
+  }: UseContainers & {
     autoRefreshRate?: number;
   } = {}
 ) {
   return useQuery(
-    queryKeys.filters(environmentId, { all, filters, nodeName }),
-    () => getContainers(environmentId, { all, filters, nodeName }),
+    queryKeys.filters(environmentId, params),
+    () => getContainers(environmentId, params),
     {
       ...withGlobalError('Unable to retrieve containers'),
       refetchInterval() {
@@ -41,11 +44,7 @@ export function useContainers(
 
 async function getContainers(
   environmentId: EnvironmentId,
-  {
-    all = true,
-    filters,
-    nodeName,
-  }: { all?: boolean; filters?: Filters; nodeName?: string } = {}
+  { all = true, filters, nodeName }: UseContainers = {}
 ) {
   try {
     const { data } = await axios.get<DockerContainerResponse[]>(

--- a/app/react/docker/containers/queries/query-keys.ts
+++ b/app/react/docker/containers/queries/query-keys.ts
@@ -8,8 +8,10 @@ export const queryKeys = {
   list: (environmentId: EnvironmentId) =>
     [dockerQueryKeys.root(environmentId), 'containers'] as const,
 
-  filters: (environmentId: EnvironmentId, all?: boolean, filters?: Filters) =>
-    [...queryKeys.list(environmentId), { all, filters }] as const,
+  filters: (
+    environmentId: EnvironmentId,
+    params: { all?: boolean; filters?: Filters; nodeName?: string } = {}
+  ) => [...queryKeys.list(environmentId), params] as const,
 
   container: (environmentId: EnvironmentId, id: string) =>
     [...queryKeys.list(environmentId), id] as const,

--- a/app/react/docker/networks/network.service.ts
+++ b/app/react/docker/networks/network.service.ts
@@ -1,5 +1,8 @@
 import { ContainerId } from '@/react/docker/containers/types';
-import axios, { parseAxiosError } from '@/portainer/services/axios';
+import axios, {
+  agentTargetHeader,
+  parseAxiosError,
+} from '@/portainer/services/axios';
 import { EnvironmentId } from '@/react/portainer/environments/types';
 
 import { NetworkId, DockerNetwork } from './types';
@@ -8,11 +11,19 @@ type NetworkAction = 'connect' | 'disconnect' | 'create';
 
 export async function getNetwork(
   environmentId: EnvironmentId,
-  networkId: NetworkId
+  networkId: NetworkId,
+  { nodeName }: { nodeName?: string } = {}
 ) {
   try {
     const { data: network } = await axios.get<DockerNetwork>(
-      buildUrl(environmentId, networkId)
+      buildUrl(environmentId, networkId),
+      nodeName
+        ? {
+            headers: {
+              [agentTargetHeader]: nodeName,
+            },
+          }
+        : undefined
     );
     return network;
   } catch (e) {

--- a/app/react/docker/networks/queries.ts
+++ b/app/react/docker/networks/queries.ts
@@ -14,10 +14,21 @@ import {
 } from './network.service';
 import { NetworkId } from './types';
 
-export function useNetwork(environmentId: EnvironmentId, networkId: NetworkId) {
+export function useNetwork(
+  environmentId: EnvironmentId,
+  networkId: NetworkId,
+  { nodeName }: { nodeName?: string } = {}
+) {
   return useQuery(
-    ['environments', environmentId, 'docker', 'networks', networkId],
-    () => getNetwork(environmentId, networkId),
+    [
+      'environments',
+      environmentId,
+      'docker',
+      'networks',
+      networkId,
+      { nodeName },
+    ],
+    () => getNetwork(environmentId, networkId, { nodeName }),
     {
       onError: (err) => {
         notifyError('Failure', err as Error, 'Unable to get network');

--- a/app/react/docker/stacks/ItemView/StackContainersDatatable.tsx
+++ b/app/react/docker/stacks/ItemView/StackContainersDatatable.tsx
@@ -42,15 +42,12 @@ export function StackContainersDatatable({ environment, stackName }: Props) {
   const isGPUsColumnVisible = useShowGPUsColumn(environment.Id);
   const columns = useColumns(false, isGPUsColumnVisible);
 
-  const containersQuery = useContainers(
-    environment.Id,
-    {
-      filters: {
-        label: [`com.docker.compose.project=${stackName}`],
-      },
+  const containersQuery = useContainers(environment.Id, {
+    filters: {
+      label: [`com.docker.compose.project=${stackName}`],
     },
-    { autoRefreshRate: tableState.autoRefreshRate * 1000 }
-  );
+    autoRefreshRate: tableState.autoRefreshRate * 1000,
+  });
 
   return (
     <RowProvider context={{ environment }}>

--- a/app/react/docker/stacks/ItemView/StackContainersDatatable.tsx
+++ b/app/react/docker/stacks/ItemView/StackContainersDatatable.tsx
@@ -44,11 +44,12 @@ export function StackContainersDatatable({ environment, stackName }: Props) {
 
   const containersQuery = useContainers(
     environment.Id,
-    true,
     {
-      label: [`com.docker.compose.project=${stackName}`],
+      filters: {
+        label: [`com.docker.compose.project=${stackName}`],
+      },
     },
-    tableState.autoRefreshRate * 1000
+    { autoRefreshRate: tableState.autoRefreshRate * 1000 }
   );
 
   return (


### PR DESCRIPTION
close [EE-5446]

changes:
- remove double tables in network view
- send agent target header with nodename when it's there
- refactor `useContainers` to receive params and query options


[EE-5446]: https://portainer.atlassian.net/browse/EE-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ