### PR TITLE
Revert "fix(stacks): confirm enable tls verification [EE-5410]"

### DIFF
--- a/app/portainer/components/forms/kubernetes-redeploy-app-git-form/kubernetes-redeploy-app-git-form.controller.js
+++ b/app/portainer/components/forms/kubernetes-redeploy-app-git-form/kubernetes-redeploy-app-git-form.controller.js
@@ -4,7 +4,6 @@ import { buildConfirmButton } from '@@/modals/utils';
 import { ModalType } from '@@/modals';
 import { parseAutoUpdateResponse } from '@/react/portainer/gitops/AutoUpdateFieldset/utils';
 import { baseStackWebhookUrl, createWebhookId } from '@/portainer/helpers/webhookHelper';
-import { confirmEnableTLSVerify } from '@/react/portainer/gitops/utils';
 
 class KubernetesRedeployAppGitFormController {
   /* @ngInject */
@@ -72,13 +71,6 @@ class KubernetesRedeployAppGitFormController {
 
   onChangeTLSSkipVerify(value) {
     return this.$async(async () => {
-      if (this.stack.GitConfig.TLSSkipVerify && !value) {
-        const confirmed = await confirmEnableTLSVerify();
-
-        if (!confirmed) {
-          return;
-        }
-      }
       this.onChange({ TLSSkipVerify: value });
     });
   }

--- a/app/portainer/components/forms/stack-redeploy-git-form/stack-redeploy-git-form.controller.js
+++ b/app/portainer/components/forms/stack-redeploy-git-form/stack-redeploy-git-form.controller.js
@@ -4,7 +4,6 @@ import { confirmStackUpdate } from '@/react/docker/stacks/common/confirm-stack-u
 
 import { parseAutoUpdateResponse } from '@/react/portainer/gitops/AutoUpdateFieldset/utils';
 import { baseStackWebhookUrl, createWebhookId } from '@/portainer/helpers/webhookHelper';
-import { confirmEnableTLSVerify } from '@/react/portainer/gitops/utils';
 
 class StackRedeployGitFormController {
   /* @ngInject */
@@ -96,17 +95,8 @@ class StackRedeployGitFormController {
     this.onChange({ Env: value });
   }
 
-  async onChangeTLSSkipVerify(value) {
-    return this.$async(async () => {
-      if (this.model.TLSSkipVerify && !value) {
-        const confirmed = await confirmEnableTLSVerify();
-
-        if (!confirmed) {
-          return;
-        }
-      }
-      this.onChange({ TLSSkipVerify: value });
-    });
+  onChangeTLSSkipVerify(value) {
+    this.onChange({ TLSSkipVerify: value });
   }
 
   onChangeOption(values) {

--- a/app/react/portainer/gitops/utils.ts
+++ b/app/react/portainer/gitops/utils.ts
@@ -1,5 +1,3 @@
-import { confirm } from '@@/modals/confirm';
-
 import { GitFormModel } from './types';
 
 export function getAuthentication(
@@ -19,12 +17,4 @@ export function getAuthentication(
     username: model.RepositoryUsername,
     password: model.RepositoryPassword,
   };
-}
-
-export function confirmEnableTLSVerify() {
-  return confirm({
-    title: 'Enable TLS Verification?',
-    message:
-      'Enabling the verification of TLS certificates without ensuring the correct configuration of your Certificate Authority (CA) for self-signed certificates can result in deployment failures.',
-  });
 }


### PR DESCRIPTION
Reverts portainer/portainer#8895

this is to revert an issue merged to 2.18.3, while it should be on 2.18.4

[EE-5410]

[EE-5410]: https://portainer.atlassian.net/browse/EE-5410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ