### PR TITLE
refactor(edgestack): rename version to fileVersion [EE-5689]

### DIFF
--- a/api/portainer.go
+++ b/api/portainer.go
@@ -301,7 +301,9 @@ type (
 
 	// StackDeploymentInfo records the information of a deployed stack
 	StackDeploymentInfo struct {
-		Version    int    `json:"Version"`
+		// FileVersion is the version of the stack file, used to detect changes
+		FileVersion int `json:"FileVersion"`
+		// ConfigHash is the commit hash of the git repository used for deploying the stack
 		ConfigHash string `json:"ConfigHash"`
 	}
 


### PR DESCRIPTION
closes [EE-5689]
> **Warning**
> After merging this PR, then EE PR go module should be upgraded to use the latest version

[EE-5689]: https://portainer.atlassian.net/browse/EE-5689?
