### PR TITLE
fix(endpoint): don't error out early when deleting an endpoint [EE-5623]

### DIFF
--- a/api/http/handler/endpoints/endpoint_delete.go
+++ b/api/http/handler/endpoints/endpoint_delete.go
@@ -10,6 +10,7 @@ import (
 	portainer "github.com/portainer/portainer/api"
 	httperrors "github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/internal/endpointutils"
+	"github.com/rs/zerolog/log"
 )
 
 // @id EndpointDelete
@@ -22,6 +23,7 @@ import (
 // @param id path int true "Environment(Endpoint) identifier"
 // @success 204 "Success"
 // @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
 // @failure 404 "Environment(Endpoint) not found"
 // @failure 500 "Server error"
 // @router /endpoints/{id} [delete]
@@ -39,32 +41,27 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 	if handler.DataStore.IsErrObjectNotFound(err) {
 		return httperror.NotFound("Unable to find an environment with the specified identifier inside the database", err)
 	} else if err != nil {
-		return httperror.InternalServerError("Unable to find an environment with the specified identifier inside the database", err)
+		return httperror.InternalServerError("Unable to read the environment record from the database", err)
 	}
 
 	if endpoint.TLSConfig.TLS {
 		folder := strconv.Itoa(endpointID)
 		err = handler.FileService.DeleteTLSFiles(folder)
 		if err != nil {
-			return httperror.InternalServerError("Unable to remove TLS files from disk", err)
+			log.Error().Err(err).Msgf("Unable to remove TLS files from disk when deleting endpoint %d", endpointID)
 		}
 	}
 
 	err = handler.DataStore.Snapshot().Delete(portainer.EndpointID(endpointID))
 	if err != nil {
-		return httperror.InternalServerError("Unable to remove the snapshot from the database", err)
-	}
-
-	err = handler.DataStore.Endpoint().DeleteEndpoint(portainer.EndpointID(endpointID))
-	if err != nil {
-		return httperror.InternalServerError("Unable to remove environment from the database", err)
+		log.Warn().Err(err).Msgf("Unable to remove the snapshot from the database")
 	}
 
 	handler.ProxyManager.DeleteEndpointProxy(endpoint.ID)
 
 	err = handler.DataStore.EndpointRelation().DeleteEndpointRelation(endpoint.ID)
 	if err != nil {
-		return httperror.InternalServerError("Unable to remove environment relation from the database", err)
+		log.Warn().Err(err).Msgf("Unable to remove environment relation from the database")
 	}
 
 	for _, tagID := range endpoint.TagIDs {
@@ -73,15 +70,15 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 		})
 
 		if handler.DataStore.IsErrObjectNotFound(err) {
-			return httperror.NotFound("Unable to find tag inside the database", err)
+			log.Warn().Err(err).Msgf("Unable to find tag inside the database")
 		} else if err != nil {
-			return httperror.InternalServerError("Unable to persist tag relation inside the database", err)
+			log.Warn().Err(err).Msgf("Unable to delete tag relation from the database")
 		}
 	}
 
 	edgeGroups, err := handler.DataStore.EdgeGroup().ReadAll()
 	if err != nil {
-		return httperror.InternalServerError("Unable to retrieve edge groups from the database", err)
+		log.Warn().Err(err).Msgf("Unable to retrieve edge groups from the database")
 	}
 
 	for _, edgeGroup := range edgeGroups {
@@ -89,13 +86,13 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 			g.Endpoints = removeElement(g.Endpoints, endpoint.ID)
 		})
 		if err != nil {
-			return httperror.InternalServerError("Unable to update edge group", err)
+			log.Warn().Err(err).Msgf("Unable to update edge group")
 		}
 	}
 
 	edgeStacks, err := handler.DataStore.EdgeStack().EdgeStacks()
 	if err != nil {
-		return httperror.InternalServerError("Unable to retrieve edge stacks from the database", err)
+		log.Warn().Err(err).Msgf("Unable to retrieve edge stacks from the database")
 	}
 
 	for idx := range edgeStacks {
@@ -104,14 +101,14 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 			delete(edgeStack.Status, endpoint.ID)
 			err = handler.DataStore.EdgeStack().UpdateEdgeStack(edgeStack.ID, edgeStack)
 			if err != nil {
-				return httperror.InternalServerError("Unable to update edge stack", err)
+				log.Warn().Err(err).Msgf("Unable to update edge stack")
 			}
 		}
 	}
 
 	registries, err := handler.DataStore.Registry().ReadAll()
 	if err != nil {
-		return httperror.InternalServerError("Unable to retrieve registries from the database", err)
+		log.Warn().Err(err).Msgf("Unable to retrieve registries from the database")
 	}
 
 	for idx := range registries {
@@ -120,31 +117,34 @@ func (handler *Handler) endpointDelete(w http.ResponseWriter, r *http.Request) *
 			delete(registry.RegistryAccesses, endpoint.ID)
 			err = handler.DataStore.Registry().Update(registry.ID, registry)
 			if err != nil {
-				return httperror.InternalServerError("Unable to update registry accesses", err)
+				log.Warn().Err(err).Msgf("Unable to update registry accesses")
 			}
 		}
 	}
 
-	if !endpointutils.IsEdgeEndpoint(endpoint) {
-		return response.Empty(w)
+	if endpointutils.IsEdgeEndpoint(endpoint) {
+		edgeJobs, err := handler.DataStore.EdgeJob().ReadAll()
+		if err != nil {
+			log.Warn().Err(err).Msgf("Unable to retrieve edge jobs from the database")
+		}
+
+		for idx := range edgeJobs {
+			edgeJob := &edgeJobs[idx]
+			if _, ok := edgeJob.Endpoints[endpoint.ID]; ok {
+				err = handler.DataStore.EdgeJob().UpdateEdgeJobFunc(edgeJob.ID, func(j *portainer.EdgeJob) {
+					delete(j.Endpoints, endpoint.ID)
+				})
+
+				if err != nil {
+					log.Warn().Err(err).Msgf("Unable to update edge job")
+				}
+			}
+		}
 	}
 
-	edgeJobs, err := handler.DataStore.EdgeJob().ReadAll()
+	err = handler.DataStore.Endpoint().DeleteEndpoint(portainer.EndpointID(endpointID))
 	if err != nil {
-		return httperror.InternalServerError("Unable to retrieve edge jobs from the database", err)
-	}
-
-	for idx := range edgeJobs {
-		edgeJob := &edgeJobs[idx]
-		if _, ok := edgeJob.Endpoints[endpoint.ID]; ok {
-			err = handler.DataStore.EdgeJob().UpdateEdgeJobFunc(edgeJob.ID, func(j *portainer.EdgeJob) {
-				delete(j.Endpoints, endpoint.ID)
-			})
-
-			if err != nil {
-				return httperror.InternalServerError("Unable to update edge job", err)
-			}
-		}
+		return httperror.InternalServerError("Unable to remove environment from the database", err)
 	}
 
 	return response.Empty(w)


### PR DESCRIPTION
Don't stop deleting resources when deleting an endpoint.  And ensure the last thing removed is the endpoint.
This ensures something left in the DB will always refer to an endpoint that exists.  The final thing to remove is the actual endpoint.   

Closes [EE-5623]


[EE-5623]: https://portainer.atlassian.net/browse/EE-5623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ