### PR TITLE
fix(authentication): allow whitespaces when loading AD OU name EE-5206

### DIFF
--- a/app/portainer/settings/authentication/ldap/ldap-settings-dn-builder/ldap-settings-dn-builder.controller.js
+++ b/app/portainer/settings/authentication/ldap/ldap-settings-dn-builder/ldap-settings-dn-builder.controller.js
@@ -41,7 +41,7 @@ export default class LdapSettingsBaseDnBuilderController {
   }
 
   getOUValues(dn, domainSuffix = '') {
-    const regex = /(\w+)=(\w*),?/;
+    const regex = /(\w+)=([a-zA-Z0-9_ ]*),?/;
     let ouValues = [];
     let left = dn;
     let match = left.match(regex);


### PR DESCRIPTION
[EE-5206]


[EE-5206]: https://portainer.atlassian.net/browse/EE-5206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ