### PR TITLE
feat(ui): add confirmation to delete actions [EE-4612]

### DIFF
--- a/app/docker/views/images/imagesController.js
+++ b/app/docker/views/images/imagesController.js
@@ -57,7 +57,8 @@ angular.module('portainer.docker').controller('ImagesController', [
     function confirmImageForceRemoval() {
       return confirmDestructive({
         title: 'Are you sure?',
-        message: 'Forcing the removal of the image will remove the image even if it has multiple tags or if it is used by stopped containers.',
+        message:
+          "Forcing removal of an image will remove it even if it's used by stopped containers, and delete all associated tags. Are you sure you want to remove the selected image(s)?",
         confirmButton: buildConfirmButton('Remove the image', 'danger'),
       });
     }
@@ -65,7 +66,7 @@ angular.module('portainer.docker').controller('ImagesController', [
     function confirmRegularRemove() {
       return confirmDestructive({
         title: 'Are you sure?',
-        message: 'Removing the image will remove all tags associated to that image. Are you sure you want to remove the image?',
+        message: 'Removing an image will also delete all associated tags. Are you sure you want to remove the selected image(s)?',
         confirmButton: buildConfirmButton('Remove the image', 'danger'),
       });
     }

--- a/app/edge/views/edge-groups/edgeGroupsView/edgeGroupsViewController.js
+++ b/app/edge/views/edge-groups/edgeGroupsView/edgeGroupsViewController.js
@@ -1,4 +1,5 @@
 import _ from 'lodash-es';
+import { confirmDelete } from '@@/modals/confirm';
 
 export class EdgeGroupsController {
   /* @ngInject */
@@ -26,6 +27,10 @@ export class EdgeGroupsController {
   }
 
   async removeActionAsync(selectedItems) {
+    if (!(await confirmDelete('Do you want to remove the selected Edge Group(s)?'))) {
+      return;
+    }
+
     for (let item of selectedItems) {
       try {
         await this.EdgeGroupService.remove(item.Id);

--- a/app/edge/views/edge-jobs/edgeJobsView/edgeJobsViewController.js
+++ b/app/edge/views/edge-jobs/edgeJobsView/edgeJobsViewController.js
@@ -15,7 +15,7 @@ export class EdgeJobsViewController {
   }
 
   removeAction(selectedItems) {
-    confirmDelete('Do you want to remove the selected edge job(s)?').then((confirmed) => {
+    confirmDelete('Do you want to remove the selected Edge job(s)?').then((confirmed) => {
       if (!confirmed) {
         return;
       }


### PR DESCRIPTION
closes [EE-4612]

adds confirmation to:
- image delete tag
- image view delete image
- edge groups delete

rewords the confirmations for:
- images delete and force delete
- edge jobs


[EE-4612]: https://portainer.atlassian.net/browse/EE-4612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ