### PR TITLE
fix(stagger): add stack version into DelploymentInfo [EE-5838]

### DIFF
--- a/api/portainer.go
+++ b/api/portainer.go
@@ -301,6 +301,8 @@ type (
 
 	// StackDeploymentInfo records the information of a deployed stack
 	StackDeploymentInfo struct {
+		// Version is the version of the stack and also is the deployed version in edge agent
+		Version int `json:"Version"`
 		// FileVersion is the version of the stack file, used to detect changes
 		FileVersion int `json:"FileVersion"`
 		// ConfigHash is the commit hash of the git repository used for deploying the stack


### PR DESCRIPTION
closes [EE-5838]

> **Warning**
> After merging this PR, then EE release/2.19 PR go module should be upgraded to use the latest version

[EE-5838]: https://portainer.atlassian.net/browse/EE-5838?