### PR TITLE
fix(ingress): empty initial selection + fixes [EE-5852]

### DIFF
--- a/app/react/kubernetes/ingresses/CreateIngressView/IngressForm.tsx
+++ b/app/react/kubernetes/ingresses/CreateIngressView/IngressForm.tsx
@@ -47,6 +47,7 @@ interface Props {
   tlsOptions: Option<string>[];
   namespacesOptions: Option<string>[];
   isNamespaceOptionsLoading: boolean;
+  isIngressNamesLoading: boolean;
 
   removeIngressRoute: (hostIndex: number, pathIndex: number) => void;
   removeIngressHost: (hostIndex: number) => void;
@@ -102,6 +103,7 @@ export function IngressForm({
   errors,
   namespacesOptions,
   isNamespaceOptionsLoading,
+  isIngressNamesLoading,
   handleNamespaceChange,
   namespace,
 }: Props) {
@@ -114,10 +116,21 @@ export function IngressForm({
   // when the namespace options update the value to an available one
   useEffect(() => {
     const namespaces = namespacesOptions.map((option) => option.value);
-    if (!namespaces.includes(namespace) && namespaces.length > 0) {
+    if (
+      !namespaces.includes(namespace) &&
+      namespaces.length > 0 &&
+      (!isIngressNamesLoading || isEdit)
+    ) {
       handleNamespaceChange(namespaces[0]);
     }
-  }, [namespacesOptions, namespace, handleNamespaceChange]);
+  }, [
+    namespacesOptions,
+    namespace,
+    handleNamespaceChange,
+    isNamespaceOptionsLoading,
+    isEdit,
+    isIngressNamesLoading,
+  ]);
 
   return (
     <Widget>
@@ -526,7 +539,7 @@ export function IngressForm({
                       )}
                     </div>
 
-                    <div className="form-group col-sm-2 col-xl-2 !m-0 !pl-0">
+                    <div className="form-group col-sm-2 col-xl-2 !m-0 min-w-[170px] !pl-0">
                       {servicePorts && (
                         <>
                           <InputGroup size="small">
@@ -669,7 +682,7 @@ export function IngressForm({
 
                     <div className="form-group col-sm-1 !m-0 !pl-0">
                       <Button
-                        className="btn-only-icon vertical-center !ml-0"
+                        className="!ml-0 h-[30px]"
                         color="dangerlight"
                         type="button"
                         data-cy={`k8sAppCreate-rmPortButton_${hostIndex}-${pathIndex}`}


### PR DESCRIPTION
* Make initial label the placeholder instead of the first available option
* Update the annotations component when there is a namespace change
* Ensure that the prefilled ingress name is valid
* Update the path delete button to have the same height as the other inputs (30px)
* Remove the momentary error for the ingress class when editing an existing ingress rule

Closes [EE-5852]

[EE-5852]: https://portainer.atlassian.net/browse/EE-5852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ