### PR TITLE
chore(version): bump to 2.19.1 [EE-6069]

### DIFF
--- a/api/datastore/test_data/output_24_to_latest.json
+++ b/api/datastore/test_data/output_24_to_latest.json
@@ -944,6 +944,6 @@
     }
   ],
   "version": {
-    "VERSION": "{\"SchemaVersion\":\"2.19.0\",\"MigratorCount\":3,\"Edition\":1,\"InstanceID\":\"463d5c47-0ea5-4aca-85b1-405ceefee254\"}"
+    "VERSION": "{\"SchemaVersion\":\"2.19.1\",\"MigratorCount\":0,\"Edition\":1,\"InstanceID\":\"463d5c47-0ea5-4aca-85b1-405ceefee254\"}"
   }
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -84,7 +84,7 @@ type Handler struct {
 }
 
 // @title PortainerCE API
-// @version 2.19.0
+// @version 2.19.1
 // @description.markdown api-description.md
 // @termsOfService
 

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1559,7 +1559,7 @@ type (
 
 const (
 	// APIVersion is the version number of the Portainer API
-	APIVersion = "2.19.0"
+	APIVersion = "2.19.1"
 	// Edition is what this edition of Portainer is called
 	Edition = PortainerCE
 	// ComposeSyntaxMaxVersion is a maximum supported version of the docker compose syntax

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Portainer.io",
   "name": "portainer",
   "homepage": "http://portainer.io",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:portainer/portainer.git"


### PR DESCRIPTION
 [EE-6069]


[EE-6069]: https://portainer.atlassian.net/browse/EE-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ