### PR TITLE
fix(authentication): allow nested whitespaces on AD OU names EE-5206

### DIFF
--- a/app/portainer/settings/authentication/ldap/ldap-settings-dn-builder/ldap-settings-dn-builder.controller.js
+++ b/app/portainer/settings/authentication/ldap/ldap-settings-dn-builder/ldap-settings-dn-builder.controller.js
@@ -49,7 +49,7 @@ export default class LdapSettingsBaseDnBuilderController {
       const [, type, value] = match;
       ouValues.push({ type, value });
       left = left.replace(regex, '');
-      match = left.match(/(\w+)=(\w+),?/);
+      match = left.match(regex);
     }
     return ouValues;
   }


### PR DESCRIPTION
Fixes [EE-5206]


[EE-5206]: https://portainer.atlassian.net/browse/EE-5206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ