### PR TITLE
fix(cluster): faster submitting load times [EE-5524]

### DIFF
--- a/app/react/kubernetes/cluster/ConfigureView/ConfigureForm/handleSubmitConfigureCluster.ts
+++ b/app/react/kubernetes/cluster/ConfigureView/ConfigureForm/handleSubmitConfigureCluster.ts
@@ -64,6 +64,8 @@ export async function handleSubmitConfigureCluster(
     {
       id: environment.Id,
       updateEnvironmentPayload: updatedEnvironment,
+      initialIngressControllers:
+        initialValues?.ingressClasses as IngressControllerClassMapRowData[],
       ingressControllers:
         values.ingressClasses as IngressControllerClassMapRowData[],
       storageClassPatches,

--- a/app/react/portainer/environments/common/TimeWindowPicker/TimeWindowPickerInputGroup.tsx
+++ b/app/react/portainer/environments/common/TimeWindowPicker/TimeWindowPickerInputGroup.tsx
@@ -57,6 +57,12 @@ export function TimeWindowPickerInputGroup({
     });
   }
 
+  // find the option index for react-select to scroll to the current option
+  const timeZoneOptionIndex = useMemo(
+    () => timeZoneOptions.findIndex((option) => option.value === timeZone),
+    [timeZone, timeZoneOptions]
+  );
+
   return (
     <div className="flex flex-wrap items-center gap-x-5">
       <div className="flex items-center gap-x-5">
@@ -90,7 +96,7 @@ export function TimeWindowPickerInputGroup({
       </div>
       <Select<Option<string>>
         options={timeZoneOptions}
-        value={{ value: timeZone, label: timeZone }}
+        value={timeZoneOptions[timeZoneOptionIndex]}
         className="w-72 min-w-fit"
         onChange={(newTimeZone) => {
           if (!newTimeZone) return;


### PR DESCRIPTION
Closes [EE-5524]

This small fix from EE improves submission load times by:
- Only sending the ingress controller update request if the form values have changed
- Not waiting for the invalidated ingress controllers to reload before telling the user the env has updated successfully

[EE-5524]: https://portainer.atlassian.net/browse/EE-5524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ