### PR TITLE
fix: Fallback to sans-serif font when chosen font is not loaded

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -21,7 +21,7 @@ html {
 
 body {
   background: var(--bg-body-color);
-  font-family: 'Inter';
+  font-family: 'Inter', sans-serif;
   color: var(--text-body-color) !important;
 }
 


### PR DESCRIPTION
### Changes:
This change specifies a sans-serif fallback font instead of the browser's default (which is a serif font in at least Safari). This fallback font is used when the Inter font is not loaded (see attached screenshot). Since Inter is a sans-serif font, this fallback is a closer fit.

##### Before
![screenshot of the Portainer interface rendered with a serif font.](https://user-images.githubusercontent.com/9086585/228631217-9fb24da1-f339-49d2-868a-2a40dcdae330.jpg)


###### After
![screenshot of the Portainer interface rendered with a sans-serif font.](https://user-images.githubusercontent.com/9086585/228631228-5c31e584-5272-4a53-be36-1d73d624302c.jpg)



