### PR TITLE
fix(helm): allow libhelm search to use a forward proxy server [EE-6145]

### DIFF
--- a/pkg/libhelm/binary/search_repo.go
+++ b/pkg/libhelm/binary/search_repo.go
@@ -57,7 +57,8 @@ func (hbpm *helmBinaryPackageManager) SearchRepo(searchRepoOpts options.SearchRe
 		// I'm seeing 3 - 4s over wifi.
 		// Give ample time but timeout for now.  Can be improved in the future
 		client = &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout:   60 * time.Second,
+			Transport: http.DefaultTransport,
 		}
 	}
 


### PR DESCRIPTION
[EE-6145]

[EE-6145]: https://portainer.atlassian.net/browse/EE-6145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ