### PR TITLE
refactor(docker/containers): remove EndpointProvider from container service [EE-6180]

### DIFF
--- a/app/docker/rest/container.js
+++ b/app/docker/rest/container.js
@@ -3,14 +3,13 @@ import { genericHandler, logsHandler } from './response/handlers';
 angular.module('portainer.docker').factory('Container', [
   '$resource',
   'API_ENDPOINT_ENDPOINTS',
-  'EndpointProvider',
-  function ContainerFactory($resource, API_ENDPOINT_ENDPOINTS, EndpointProvider) {
+  function ContainerFactory($resource, API_ENDPOINT_ENDPOINTS) {
     'use strict';
     return $resource(
-      API_ENDPOINT_ENDPOINTS + '/:endpointId/docker/containers/:id/:action',
+      API_ENDPOINT_ENDPOINTS + '/:environmentId/docker/containers/:id/:action',
       {
         name: '@name',
-        endpointId: EndpointProvider.endpointID,
+        environmentId: '@environmentId',
       },
       {
         query: {

--- a/app/docker/services/imageService.js
+++ b/app/docker/services/imageService.js
@@ -33,11 +33,11 @@ angular.module('portainer.docker').factory('ImageService', [
       return deferred.promise;
     };
 
-    service.images = function (withUsage) {
+    service.images = function ({ environmentId, withUsage } = {}) {
       var deferred = $q.defer();
 
       $q.all({
-        containers: withUsage ? ContainerService.containers(1) : [],
+        containers: withUsage ? ContainerService.containers(environmentId, 1) : [],
         images: Image.query({}).$promise,
       })
         .then(function success(data) {

--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -15,6 +15,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
   'LocalStorage',
   'CONSOLE_COMMANDS_LABEL_PREFIX',
   'SidebarService',
+  'endpoint',
   function (
     $scope,
     $state,
@@ -27,7 +28,8 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
     HttpRequestHelper,
     LocalStorage,
     CONSOLE_COMMANDS_LABEL_PREFIX,
-    SidebarService
+    SidebarService,
+    endpoint
   ) {
     var socket, term;
 
@@ -58,7 +60,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
 
       let attachId = $transition$.params().id;
 
-      ContainerService.container(attachId)
+      ContainerService.container(endpoint.Id, attachId)
         .then((details) => {
           if (!details.State.Running) {
             Notifications.error('Failure', details, 'Container ' + attachId + ' is not running!');
@@ -79,7 +81,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
               .map((k) => k + '=' + params[k])
               .join('&');
 
-          initTerm(url, ContainerService.resizeTTY.bind(this, attachId));
+          initTerm(url, ContainerService.resizeTTY.bind(this, endpoint.Id, attachId));
         })
         .catch(function error(err) {
           Notifications.error('Error', err, 'Unable to retrieve container details');
@@ -104,7 +106,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
         Cmd: commandStringToArray(command),
       };
 
-      ContainerService.createExec(execConfig)
+      ContainerService.createExec(endpoint.Id, execConfig)
         .then(function success(data) {
           const params = {
             endpointId: $state.params.endpointId,
@@ -217,7 +219,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
 
     $scope.initView = function () {
       HttpRequestHelper.setPortainerAgentTargetHeader($transition$.params().nodeName);
-      return ContainerService.container($transition$.params().id)
+      return ContainerService.container(endpoint.Id, $transition$.params().id)
         .then(function success(data) {
           var container = data;
           $scope.container = container;

--- a/app/docker/views/containers/create/createContainerController.js
+++ b/app/docker/views/containers/create/createContainerController.js
@@ -528,7 +528,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       function removeNewContainer() {
         return findCurrentContainer().then(function onContainerLoaded(container) {
           if (container && (!oldContainer || container.Id !== oldContainer.Id)) {
-            return ContainerService.remove(container, true);
+            return ContainerService.remove(endpoint.Id, container, true);
           }
         });
       }
@@ -537,7 +537,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
         if (!oldContainer) {
           return;
         }
-        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0]);
+        return ContainerService.renameContainer(endpoint.Id, oldContainer.Id, oldContainer.Names[0]);
       }
 
       function confirmCreateContainer(container) {
@@ -573,11 +573,11 @@ angular.module('portainer.docker').controller('CreateContainerController', [
         if (oldContainer.State !== 'running') {
           return $q.when();
         }
-        return ContainerService.stopContainer(oldContainer.Id);
+        return ContainerService.stopContainer(endpoint.Id, oldContainer.Id);
       }
 
       function renameContainer() {
-        return ContainerService.renameContainer(oldContainer.Id, oldContainer.Names[0] + '-old');
+        return ContainerService.renameContainer(endpoint.Id, oldContainer.Id, oldContainer.Names[0] + '-old');
       }
 
       function pullImageIfNeeded() {
@@ -587,7 +587,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
       function createNewContainer() {
         return $async(async () => {
           const config = prepareConfiguration();
-          return await ContainerService.createAndStartContainer(config);
+          return await ContainerService.createAndStartContainer(endpoint.Id, config);
         });
       }
 
@@ -639,7 +639,7 @@ angular.module('portainer.docker').controller('CreateContainerController', [
           return;
         }
 
-        ContainerService.remove(oldContainer, true).then(notifyOnRemoval).catch(notifyOnRemoveError);
+        ContainerService.remove(endpoint.Id, oldContainer, true).then(notifyOnRemoval).catch(notifyOnRemoveError);
 
         return deferred.promise;
 

--- a/app/docker/views/containers/edit/containerController.js
+++ b/app/docker/views/containers/edit/containerController.js
@@ -99,7 +99,7 @@ angular.module('portainer.docker').controller('ContainerController', [
       HttpRequestHelper.setPortainerAgentTargetHeader(nodeName);
       $scope.nodeName = nodeName;
 
-      ContainerService.container($transition$.params().id)
+      ContainerService.container(endpoint.Id, $transition$.params().id)
         .then(function success(data) {
           var container = data;
           $scope.container = container;
@@ -158,7 +158,7 @@ angular.module('portainer.docker').controller('ContainerController', [
     };
 
     function executeContainerAction(id, action, successMessage, errorMessage) {
-      action(id)
+      action(endpoint.Id, id)
         .then(function success() {
           Notifications.success(successMessage, id);
           update();
@@ -210,7 +210,7 @@ angular.module('portainer.docker').controller('ContainerController', [
         $scope.container.edit = false;
         return;
       }
-      ContainerService.renameContainer($transition$.params().id, container.newContainerName)
+      ContainerService.renameContainer(endpoint.Id, $transition$.params().id, container.newContainerName)
         .then(function success() {
           container.Name = container.newContainerName;
           Notifications.success('Container successfully renamed', container.Name);
@@ -292,7 +292,7 @@ angular.module('portainer.docker').controller('ContainerController', [
     };
 
     function removeContainer(cleanAssociatedVolumes) {
-      ContainerService.remove($scope.container, cleanAssociatedVolumes)
+      ContainerService.remove(endpoint.Id, $scope.container.Id, cleanAssociatedVolumes)
         .then(function success() {
           Notifications.success('Success', 'Container successfully removed');
           $state.go('docker.containers', {}, { reload: true });
@@ -306,7 +306,7 @@ angular.module('portainer.docker').controller('ContainerController', [
       var container = $scope.container;
       $scope.state.recreateContainerInProgress = true;
 
-      return ContainerService.recreateContainer(container.Id, pullImage).then(notifyAndChangeView).catch(notifyOnError);
+      return ContainerService.recreateContainer(endpoint.Id, container.Id, pullImage).then(notifyAndChangeView).catch(notifyOnError);
 
       function notifyAndChangeView() {
         Notifications.success('Success', 'Container successfully re-created');
@@ -333,7 +333,7 @@ angular.module('portainer.docker').controller('ContainerController', [
     function updateRestartPolicy(restartPolicy, maximumRetryCount) {
       maximumRetryCount = restartPolicy === 'on-failure' ? maximumRetryCount : undefined;
 
-      return ContainerService.updateRestartPolicy($scope.container.Id, restartPolicy, maximumRetryCount).then(onUpdateSuccess).catch(notifyOnError);
+      return ContainerService.updateRestartPolicy(endpoint.Id, $scope.container.Id, restartPolicy, maximumRetryCount).then(onUpdateSuccess).catch(notifyOnError);
 
       function onUpdateSuccess() {
         $scope.container.HostConfig.RestartPolicy = {

--- a/app/docker/views/containers/inspect/containerInspectController.js
+++ b/app/docker/views/containers/inspect/containerInspectController.js
@@ -4,7 +4,8 @@ angular.module('portainer.docker').controller('ContainerInspectController', [
   'Notifications',
   'ContainerService',
   'HttpRequestHelper',
-  function ($scope, $transition$, Notifications, ContainerService, HttpRequestHelper) {
+  'endpoint',
+  function ($scope, $transition$, Notifications, ContainerService, HttpRequestHelper, endpoint) {
     $scope.state = {
       DisplayTextView: false,
     };
@@ -12,7 +13,7 @@ angular.module('portainer.docker').controller('ContainerInspectController', [
 
     function initView() {
       HttpRequestHelper.setPortainerAgentTargetHeader($transition$.params().nodeName);
-      ContainerService.inspect($transition$.params().id)
+      ContainerService.inspect(endpoint.Id, $transition$.params().id)
         .then(function success(d) {
           $scope.containerInfo = d;
         })

--- a/app/docker/views/containers/logs/containerLogsController.js
+++ b/app/docker/views/containers/logs/containerLogsController.js
@@ -7,7 +7,8 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
   'ContainerService',
   'Notifications',
   'HttpRequestHelper',
-  function ($scope, $transition$, $interval, ContainerService, Notifications, HttpRequestHelper) {
+  'endpoint',
+  function ($scope, $transition$, $interval, ContainerService, Notifications, HttpRequestHelper, endpoint) {
     $scope.state = {
       refreshRate: 3,
       lineCount: 100,
@@ -39,6 +40,7 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
       var refreshRate = $scope.state.refreshRate;
       $scope.repeater = $interval(function () {
         ContainerService.logs(
+          endpoint.Id,
           $transition$.params().id,
           1,
           1,
@@ -58,7 +60,16 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
     }
 
     function startLogPolling(skipHeaders) {
-      ContainerService.logs($transition$.params().id, 1, 1, $scope.state.displayTimestamps ? 1 : 0, moment($scope.state.sinceTimestamp).unix(), $scope.state.lineCount, skipHeaders)
+      ContainerService.logs(
+        endpoint.Id,
+        $transition$.params().id,
+        1,
+        1,
+        $scope.state.displayTimestamps ? 1 : 0,
+        moment($scope.state.sinceTimestamp).unix(),
+        $scope.state.lineCount,
+        skipHeaders
+      )
         .then(function success(data) {
           $scope.logs = data;
           setUpdateRepeater(skipHeaders);
@@ -71,7 +82,7 @@ angular.module('portainer.docker').controller('ContainerLogsController', [
 
     function initView() {
       HttpRequestHelper.setPortainerAgentTargetHeader($transition$.params().nodeName);
-      ContainerService.container($transition$.params().id)
+      ContainerService.container(endpoint.Id, $transition$.params().id)
         .then(function success(data) {
           var container = data;
           $scope.container = container;

--- a/app/docker/views/containers/stats/containerStatsController.js
+++ b/app/docker/views/containers/stats/containerStatsController.js
@@ -10,7 +10,8 @@ angular.module('portainer.docker').controller('ContainerStatsController', [
   'ChartService',
   'Notifications',
   'HttpRequestHelper',
-  function ($q, $scope, $transition$, $document, $interval, ContainerService, ChartService, Notifications, HttpRequestHelper) {
+  'endpoint',
+  function ($q, $scope, $transition$, $document, $interval, ContainerService, ChartService, Notifications, HttpRequestHelper, endpoint) {
     $scope.state = {
       refreshRate: '5',
       networkStatsUnavailable: false,
@@ -95,8 +96,8 @@ angular.module('portainer.docker').controller('ContainerStatsController', [
 
     function startChartUpdate(networkChart, cpuChart, memoryChart, ioChart) {
       $q.all({
-        stats: ContainerService.containerStats($transition$.params().id),
-        top: ContainerService.containerTop($transition$.params().id),
+        stats: ContainerService.containerStats(endpoint.Id, $transition$.params().id),
+        top: ContainerService.containerTop(endpoint.Id, $transition$.params().id),
       })
         .then(function success(data) {
           var stats = data.stats;
@@ -123,8 +124,8 @@ angular.module('portainer.docker').controller('ContainerStatsController', [
       var refreshRate = $scope.state.refreshRate;
       $scope.repeater = $interval(function () {
         $q.all({
-          stats: ContainerService.containerStats($transition$.params().id),
-          top: ContainerService.containerTop($transition$.params().id),
+          stats: ContainerService.containerStats(endpoint.Id, $transition$.params().id),
+          top: ContainerService.containerTop(endpoint.Id, $transition$.params().id),
         })
           .then(function success(data) {
             var stats = data.stats;
@@ -163,7 +164,7 @@ angular.module('portainer.docker').controller('ContainerStatsController', [
 
     function initView() {
       HttpRequestHelper.setPortainerAgentTargetHeader($transition$.params().nodeName);
-      ContainerService.container($transition$.params().id)
+      ContainerService.container(endpoint.Id, $transition$.params().id)
         .then(function success(data) {
           $scope.container = data;
         })

--- a/app/docker/views/dashboard/dashboardController.js
+++ b/app/docker/views/dashboard/dashboardController.js
@@ -79,8 +79,8 @@ angular.module('portainer.docker').controller('DashboardController', [
       $scope.showStacks = await shouldShowStacks();
       $scope.showEnvUrl = endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnDockerEnvironment && endpoint.Type !== PortainerEndpointTypes.EdgeAgentOnKubernetesEnvironment;
       $q.all({
-        containers: ContainerService.containers(1),
-        images: ImageService.images(false),
+        containers: ContainerService.containers(endpoint.Id, 1),
+        images: ImageService.images(),
         volumes: VolumeService.volumes(),
         networks: NetworkService.networks(true, true, true),
         services: endpointMode.provider === 'DOCKER_SWARM_MODE' && endpointMode.role === 'MANAGER' ? ServiceService.services() : [],

--- a/app/docker/views/host/host-view-controller.js
+++ b/app/docker/views/host/host-view-controller.js
@@ -4,9 +4,8 @@ angular.module('portainer.docker').controller('HostViewController', [
   'Notifications',
   'StateManager',
   'AgentService',
-  'ContainerService',
   'Authentication',
-  function HostViewController($q, SystemService, Notifications, StateManager, AgentService, ContainerService, Authentication) {
+  function HostViewController($q, SystemService, Notifications, StateManager, AgentService, Authentication) {
     var ctrl = this;
 
     this.$onInit = initView;
@@ -32,12 +31,10 @@ angular.module('portainer.docker').controller('HostViewController', [
       $q.all({
         version: SystemService.version(),
         info: SystemService.info(),
-        jobs: ctrl.state.isAdmin ? ContainerService.containers(true, { label: ['io.portainer.job.endpoint'] }) : [],
       })
         .then(function success(data) {
           ctrl.engineDetails = buildEngineDetails(data);
           ctrl.hostDetails = buildHostDetails(data.info);
-          ctrl.jobs = data.jobs;
 
           if (ctrl.state.isAgent && agentApiVersion > 1 && ctrl.state.enableHostManagementFeatures) {
             return AgentService.hostInfo(ctrl.endpoint.Id).then(function onHostInfoLoad(agentHostInfo) {

--- a/app/docker/views/nodes/node-details/node-details-view-controller.js
+++ b/app/docker/views/nodes/node-details/node-details-view-controller.js
@@ -4,9 +4,8 @@ angular.module('portainer.docker').controller('NodeDetailsViewController', [
   'NodeService',
   'StateManager',
   'AgentService',
-  'ContainerService',
   'Authentication',
-  function NodeDetailsViewController($q, $stateParams, NodeService, StateManager, AgentService, ContainerService, Authentication) {
+  function NodeDetailsViewController($q, $stateParams, NodeService, StateManager, AgentService, Authentication) {
     var ctrl = this;
 
     ctrl.$onInit = initView;
@@ -22,19 +21,15 @@ angular.module('portainer.docker').controller('NodeDetailsViewController', [
       ctrl.state.isAdmin = Authentication.isAdmin();
       ctrl.state.enableHostManagementFeatures = ctrl.endpoint.SecuritySettings.enableHostManagementFeatures;
 
-      var fetchJobs = ctrl.state.isAdmin && ctrl.state.isAgent;
-
       var nodeId = $stateParams.id;
       $q.all({
         node: NodeService.node(nodeId),
-        jobs: fetchJobs ? ContainerService.containers(true, { label: ['io.portainer.job.endpoint'] }) : [],
       }).then(function (data) {
         var node = data.node;
         ctrl.originalNode = node;
         ctrl.hostDetails = buildHostDetails(node);
         ctrl.engineDetails = buildEngineDetails(node);
         ctrl.nodeDetails = buildNodeDetails(node);
-        ctrl.jobs = data.jobs;
         if (ctrl.state.isAgent) {
           var agentApiVersion = applicationState.endpoint.agentApiVersion;
           ctrl.state.agentApiVersion = agentApiVersion;

--- a/app/docker/views/nodes/node-details/node-details-view.html
+++ b/app/docker/views/nodes/node-details/node-details-view.html
@@ -7,10 +7,7 @@
   devices="$ctrl.devices"
   refresh-url="docker.nodes.node"
   browse-url="docker.nodes.node.browse"
-  is-job-enabled="$ctrl.state.isAdmin && $ctrl.state.isAgent"
   host-features-enabled="$ctrl.state.enableHostManagementFeatures"
-  job-url="docker.nodes.node.job"
-  jobs="$ctrl.jobs"
 >
   <swarm-node-details-panel details="$ctrl.nodeDetails" original-node="$ctrl.originalNode"></swarm-node-details-panel>
 </host-overview>

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -736,7 +736,7 @@ angular.module('portainer.docker').controller('ServiceController', [
           return $q.all({
             volumes: VolumeService.volumes(),
             tasks: TaskService.tasks({ service: [service.Name] }),
-            containers: agentProxy ? ContainerService.containers() : [],
+            containers: agentProxy ? ContainerService.containers(endpoint.Id) : [],
             nodes: NodeService.nodes(),
             secrets: apiVersion >= 1.25 ? SecretService.secrets() : [],
             configs: apiVersion >= 1.3 ? ConfigService.configs(endpoint.Id) : [],

--- a/app/docker/views/services/servicesController.js
+++ b/app/docker/views/services/servicesController.js
@@ -20,7 +20,7 @@ angular.module('portainer.docker').controller('ServicesController', [
         .all({
           services: ServiceService.services(),
           tasks: TaskService.tasks(),
-          containers: agentProxy ? ContainerService.containers(1) : [],
+          containers: agentProxy ? ContainerService.containers(endpoint.Id, 1) : [],
           nodes: NodeService.nodes(),
         })
         .then(function success(data) {

--- a/app/docker/views/volumes/edit/volumeController.js
+++ b/app/docker/views/volumes/edit/volumeController.js
@@ -9,7 +9,8 @@ angular.module('portainer.docker').controller('VolumeController', [
   'ContainerService',
   'Notifications',
   'HttpRequestHelper',
-  function ($scope, $state, $transition$, VolumeService, ContainerService, Notifications, HttpRequestHelper) {
+  'endpoint',
+  function ($scope, $state, $transition$, VolumeService, ContainerService, Notifications, HttpRequestHelper, endpoint) {
     $scope.resourceType = ResourceControlType.Volume;
 
     $scope.onUpdateResourceControlSuccess = function () {
@@ -46,7 +47,7 @@ angular.module('portainer.docker').controller('VolumeController', [
           $scope.volume = volume;
           var containerFilter = { volume: [volume.Id] };
 
-          return ContainerService.containers(1, containerFilter);
+          return ContainerService.containers(endpoint.Id, 1, containerFilter);
         })
         .then(function success(data) {
           var dataContainers = $scope.isCioDriver ? data.containers : data;

--- a/app/portainer/services/api/stackService.js
+++ b/app/portainer/services/api/stackService.js
@@ -126,10 +126,10 @@ angular.module('portainer.app').factory('StackService', [
       return deferred.promise;
     };
 
-    service.externalComposeStacks = function () {
+    service.externalComposeStacks = function (environmentId) {
       var deferred = $q.defer();
 
-      ContainerService.containers(1)
+      ContainerService.containers(environmentId, 1)
         .then(function success(containers) {
           deferred.resolve(StackHelper.getExternalStacksFromContainers(containers));
         })
@@ -160,7 +160,7 @@ angular.module('portainer.app').factory('StackService', [
 
       $q.all({
         stacks: Stack.query({ filters: filters }).$promise,
-        externalStacks: includeExternalStacks ? service.externalComposeStacks() : [],
+        externalStacks: includeExternalStacks ? service.externalComposeStacks(endpointId) : [],
       })
         .then(function success(data) {
           var stacks = data.stacks.map(function (item) {

--- a/app/portainer/views/stacks/create/createStackController.js
+++ b/app/portainer/views/stacks/create/createStackController.js
@@ -345,7 +345,7 @@ angular
 
         $scope.composeSyntaxMaxVersion = endpoint.ComposeSyntaxMaxVersion;
         try {
-          const containers = await ContainerService.containers(true);
+          const containers = await ContainerService.containers(endpoint.Id, true);
           $scope.containerNames = ContainerHelper.getContainerNames(containers);
         } catch (err) {
           Notifications.error('Failure', err, 'Unable to retrieve Containers');

--- a/app/portainer/views/stacks/edit/stackController.js
+++ b/app/portainer/views/stacks/edit/stackController.js
@@ -332,7 +332,7 @@ angular.module('portainer.app').controller('StackController', [
         $q.all({
           stack: StackService.stack(id),
           groups: GroupService.groups(),
-          containers: ContainerService.containers(true),
+          containers: ContainerService.containers(endpoint.Id, true),
         })
           .then(function success(data) {
             var stack = data.stack;
@@ -386,7 +386,7 @@ angular.module('portainer.app').controller('StackController', [
       return $q.all({
         services: ServiceService.services(stackFilter),
         tasks: TaskService.tasks(stackFilter),
-        containers: agentProxy ? ContainerService.containers(1) : [],
+        containers: agentProxy ? ContainerService.containers(endpoint.Id, 1) : [],
         nodes: NodeService.nodes(),
       });
     }
@@ -419,7 +419,7 @@ angular.module('portainer.app').controller('StackController', [
       };
 
       return $q.all({
-        containers: ContainerService.containers(1, stackFilter),
+        containers: ContainerService.containers(endpoint.Id, 1, stackFilter),
       });
     }
 

--- a/app/portainer/views/templates/templatesController.js
+++ b/app/portainer/views/templates/templatesController.js
@@ -110,7 +110,7 @@ angular.module('portainer.app').controller('TemplatesController', [
           return ImageService.pullImage(template.RegistryModel, true);
         })
         .then(function success() {
-          return ContainerService.createAndStartContainer(templateConfiguration);
+          return ContainerService.createAndStartContainer(endpoint.Id, templateConfiguration);
         })
         .then(function success(data) {
           const resourceControl = data.Portainer.ResourceControl;


### PR DESCRIPTION
[EE-6180]

## affected views:
docker dashboard
images view - used/unused tags
containers:
  container view - start/stop/kill/restart/pause/resume/rename/remove/update-restart-policy/recreate
  attach
  exec
  stats
host view (standalone)
node view (swarm)
services view
service view
volume view
stacks view
create stack view
stack view
app templates view - deploy container template


[EE-5546]: https://portainer.atlassian.net/browse/EE-5546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EE-6180]: https://portainer.atlassian.net/browse/EE-6180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ