### PR TITLE
Fix #10278 Bitbucket commit url was wrong

### DIFF
--- a/app/react/docker/stacks/ListView/StacksDatatable/columns/deployed-version.tsx
+++ b/app/react/docker/stacks/ListView/StacksDatatable/columns/deployed-version.tsx
@@ -1,6 +1,6 @@
 import { isExternalStack } from '@/react/docker/stacks/view-models/utils';
 
-import { columnHelper } from './helper';
+import { columnHelper, getGitCommitUrl } from './helper';
 
 export const deployedVersion = columnHelper.accessor(
   (item) => {
@@ -19,13 +19,11 @@ export const deployedVersion = columnHelper.accessor(
       }
 
       if (item.GitConfig) {
+        const gitUrl = getGitCommitUrl(item.GitConfig);
+
         return (
           <div className="text-center">
-            <a
-              target="_blank"
-              href={`${item.GitConfig.URL}/commit/${item.GitConfig.ConfigHash}`}
-              rel="noreferrer"
-            >
+            <a target="_blank" href={`${gitUrl}`} rel="noreferrer">
               {item.GitConfig.ConfigHash.slice(0, 7)}
             </a>
           </div>

--- a/app/react/docker/stacks/ListView/StacksDatatable/columns/helper.ts
+++ b/app/react/docker/stacks/ListView/StacksDatatable/columns/helper.ts
@@ -3,3 +3,16 @@ import { createColumnHelper } from '@tanstack/react-table';
 import { DecoratedStack } from '../types';
 
 export const columnHelper = createColumnHelper<DecoratedStack>();
+
+export const getGitCommitUrl = (gitObj: { URL: string; ConfigHash: string}): string => {
+  if (gitObj == null) {
+    return '';
+  }
+
+  const urlPaths = [gitObj.URL];
+  const isBitbucket = gitObj.URL.indexOf('bitbucket.org') !== -1;
+  urlPaths.push(isBitbucket ? 'commits' : 'commit');
+  urlPaths.push(gitObj.ConfigHash);
+
+  return urlPaths.join('/');
+};

--- a/app/react/edge/edge-stacks/ItemView/EnvironmentsDatatable/columns.tsx
+++ b/app/react/edge/edge-stacks/ItemView/EnvironmentsDatatable/columns.tsx
@@ -22,6 +22,22 @@ import { EdgeStackEnvironment } from './types';
 
 const columnHelper = createColumnHelper<EdgeStackEnvironment>();
 
+const getGitCommitUrl = (gitObj: {
+  GitConfigURL: string;
+  TargetCommitHash?: string | null;
+}): string => {
+  if (gitObj.TargetCommitHash == null) {
+    return '';
+  }
+
+  const urlPaths = [gitObj.GitConfigURL];
+  const isBitbucket = urlPaths[0].indexOf('bitbucket.org') !== -1;
+  urlPaths.push(isBitbucket ? 'commits' : 'commit');
+  urlPaths.push(gitObj.TargetCommitHash);
+
+  return urlPaths.join('/');
+};
+
 export const columns = _.compact([
   columnHelper.accessor('Name', {
     id: 'name',
@@ -178,7 +194,7 @@ function TargetVersionCell({
       {row.original.TargetCommitHash ? (
         <div>
           <a
-            href={`${row.original.GitConfigURL}/commit/${row.original.TargetCommitHash}`}
+            href={`${getGitCommitUrl(row.original)}`}
             target="_blank"
             rel="noreferrer"
           >
@@ -227,7 +243,7 @@ function DeployedVersionCell({
         <div>
           {statusIcon}
           <a
-            href={`${row.original.GitConfigURL}/commit/${row.original.TargetCommitHash}`}
+            href={`${getGitCommitUrl(row.original)}`}
             target="_blank"
             rel="noreferrer"
           >

--- a/app/react/edge/edge-stacks/ListView/EdgeStacksDatatable/columns.tsx
+++ b/app/react/edge/edge-stacks/ListView/EdgeStacksDatatable/columns.tsx
@@ -15,6 +15,22 @@ import { DeploymentCounter } from './DeploymentCounter';
 
 const columnHelper = createColumnHelper<DecoratedEdgeStack>();
 
+const getGitCommitUrl = (gitObj: {
+  URL: string;
+  ConfigHash?: string | null;
+}): string => {
+  if (gitObj.ConfigHash == null) {
+    return '';
+  }
+
+  const urlPaths = [gitObj.URL];
+  const isBitbucket = gitObj.URL.indexOf('bitbucket.org') !== -1;
+  urlPaths.push(isBitbucket ? 'commits' : 'commit');
+  urlPaths.push(gitObj.ConfigHash);
+
+  return urlPaths.join('/');
+};
+
 export const columns = _.compact([
   buildNameColumn<DecoratedEdgeStack>('Name', 'edge.stacks.edit', 'stackId'),
   columnHelper.accessor(
@@ -146,7 +162,7 @@ export const columns = _.compact([
               <div className="text-center">
                 <a
                   target="_blank"
-                  href={`${item.GitConfig.URL}/commit/${item.GitConfig.ConfigHash}`}
+                  href={`${getGitCommitUrl(item.GitConfig)}`}
                   rel="noreferrer"
                 >
                   {item.GitConfig.ConfigHash.slice(0, 7)}


### PR DESCRIPTION
closes #10278

### Changes:
Handles bitbucket commit url accordingly to their usage. Checks the base url of the commit, being bitbucket, we can assume that string `commits` is to be used instead of the generic `commit`.