### PR TITLE
chore(deps): upgrade golangci [EE-5685]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,6 @@ jobs:
       - name: GolangCI-Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.1
           working-directory: api
           args: --timeout=10m -c .golangci.yaml

--- a/api/.golangci.yaml
+++ b/api/.golangci.yaml
@@ -10,19 +10,21 @@ linters:
     - exportloopref
 linters-settings:
   depguard:
-    list-type: denylist
-    include-go-root: true
-    packages:
-      - github.com/sirupsen/logrus
-      - golang.org/x/exp
-      - github.com/portainer/libcrypto
-      - github.com/portainer/libhttp
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: 'logging is allowed only by github.com/rs/zerolog'
-    ignore-file-rules:
-      - '**/*_test.go'
-      - '**/base.go'
-      - '**/base_tx.go'
+    rules:
+      main:
+        deny:
+          - pkg: 'github.com/sirupsen/logrus'
+            desc: 'logging is allowed only by github.com/rs/zerolog'
+          - pkg: 'golang.org/x/exp'
+            desc: 'exp is not allowed'
+          - pkg: 'github.com/portainer/libcrypto'
+            desc: 'use github.com/portainer/portainer/pkg/libcrypto'
+          - pkg: 'github.com/portainer/libhttp'
+            desc: 'use github.com/portainer/portainer/pkg/libhttp'
+        files:
+          - '!**/*_test.go'
+          - '!**/base.go'
+          - '!**/base_tx.go'
 
 # errorlint is causing a typecheck error for some reason. The go compiler will report these
 # anyway, so ignore them from the linter


### PR DESCRIPTION
fix [EE-5685]

upgrade golangci to 1.54.1


[EE-5685]: https://portainer.atlassian.net/browse/EE-5685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ