### PR TITLE
removes ioutil

### DIFF
--- a/pkg/libhttp/request/request.go
+++ b/pkg/libhttp/request/request.go
@@ -6,7 +6,7 @@ package request
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -33,7 +33,7 @@ func RetrieveMultiPartFormFile(request *http.Request, requestParameter string) (
 	}
 	defer file.Close()
 
-	fileContent, err := ioutil.ReadAll(file)
+	fileContent, err := io.ReadAll(file)
 	if err != nil {
 		return nil, "", err
 	}

--- a/third_party/digest/digest.go
+++ b/third_party/digest/digest.go
@@ -49,7 +49,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -243,13 +242,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// We need two reader for the body.
 	if req.Body != nil {
-		tmp, err := ioutil.ReadAll(req.Body)
+		tmp, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
 
-		reqBody01 := ioutil.NopCloser(bytes.NewBuffer(tmp))
-		reqBody02 := ioutil.NopCloser(bytes.NewBuffer(tmp))
+		reqBody01 := io.NopCloser(bytes.NewBuffer(tmp))
+		reqBody02 := io.NopCloser(bytes.NewBuffer(tmp))
 
 		req.Body = reqBody01
 		req2.Body = reqBody02


### PR DESCRIPTION
ioutil was deprecated. In the instances where it was used, io was used as a drop-in replacement.

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
