### PR TITLE
fix(errors): display kube confgimap and secret errors [EE-5558]

### DIFF
--- a/app/react/kubernetes/configs/configmap.service.ts
+++ b/app/react/kubernetes/configs/configmap.service.ts
@@ -10,7 +10,6 @@ import {
 } from '@/portainer/services/notifications';
 import { isFulfilled, isRejected } from '@/portainer/helpers/promise-utils';
 import { pluralize } from '@/portainer/helpers/strings';
-import PortainerError from '@/portainer/error';
 
 import { parseKubernetesAxiosError } from '../axiosError';
 
@@ -122,14 +121,10 @@ async function getConfigMapsForCluster(
   environmentId: EnvironmentId,
   namespaces: string[]
 ) {
-  try {
-    const configMaps = await Promise.all(
-      namespaces.map((namespace) => getConfigMaps(environmentId, namespace))
-    );
-    return configMaps.flat();
-  } catch (e) {
-    throw new PortainerError('Unable to retrieve ConfigMaps', e);
-  }
+  const configMaps = await Promise.all(
+    namespaces.map((namespace) => getConfigMaps(environmentId, namespace))
+  );
+  return configMaps.flat();
 }
 
 // get all configmaps for a namespace

--- a/app/react/kubernetes/configs/secret.service.ts
+++ b/app/react/kubernetes/configs/secret.service.ts
@@ -10,7 +10,6 @@ import {
 } from '@/portainer/services/notifications';
 import { isFulfilled, isRejected } from '@/portainer/helpers/promise-utils';
 import { pluralize } from '@/portainer/helpers/strings';
-import PortainerError from '@/portainer/error';
 
 import { parseKubernetesAxiosError } from '../axiosError';
 
@@ -118,14 +117,10 @@ async function getSecretsForCluster(
   environmentId: EnvironmentId,
   namespaces: string[]
 ) {
-  try {
-    const secrets = await Promise.all(
-      namespaces.map((namespace) => getSecrets(environmentId, namespace))
-    );
-    return secrets.flat();
-  } catch (e) {
-    throw new PortainerError('Unable to retrieve secrets for cluster', e);
-  }
+  const secrets = await Promise.all(
+    namespaces.map((namespace) => getSecrets(environmentId, namespace))
+  );
+  return secrets.flat();
 }
 
 // get all secrets for a namespace


### PR DESCRIPTION
Closes [EE-5558]

Allow configmap and secret errors through by not overwriting them with a PortainerError

[EE-5558]: https://portainer.atlassian.net/browse/EE-5558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ