### PR TITLE
fix(nodes): allow standard users to get kube endpoints [EE-6125]

### DIFF
--- a/api/kubernetes/cli/role.go
+++ b/api/kubernetes/cli/role.go
@@ -12,7 +12,7 @@ func getPortainerUserDefaultPolicies() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			Verbs:     []string{"list", "get"},
-			Resources: []string{"namespaces", "nodes"},
+			Resources: []string{"namespaces", "nodes", "endpoints"},
 			APIGroups: []string{""},
 		},
 		{


### PR DESCRIPTION
Closes [EE-6125]

Give the standard user the same access to endpoints as in EE
https://github.com/portainer/portainer-ee/blob/5bea234ce78cc43c761791ee3d616ccf1f980e28/api/kubernetes/cli/role.go#L97

[EE-6125]: https://portainer.atlassian.net/browse/EE-6125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ