### PR TITLE
fix(helm): switch selector to filter instead [EE-6299]

### DIFF
--- a/app/kubernetes/views/applications/helm/helm.controller.js
+++ b/app/kubernetes/views/applications/helm/helm.controller.js
@@ -16,7 +16,7 @@ export default class KubernetesHelmApplicationController {
   async getHelmApplication() {
     try {
       this.state.dataLoading = true;
-      const releases = await this.HelmService.listReleases(this.endpoint.Id, { selector: `name=${this.state.params.name}`, namespace: this.state.params.namespace });
+      const releases = await this.HelmService.listReleases(this.endpoint.Id, { filter: `^${this.state.params.name}$`, namespace: this.state.params.namespace });
       if (releases.length > 0) {
         this.state.release = releases[0];
       } else {


### PR DESCRIPTION
selector no longer works with name. It can only now be used with configmaps/secrets.
Need to use a regular expression filter instead.
[EE-6299](https://portainer.atlassian.net/browse/EE-6299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[EE-6299]: https://portainer.atlassian.net/browse/EE-6299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ