### PR TITLE
docs(dashboard): update link for swarm node  [EE-6318]

### DIFF
--- a/app/docker/views/dashboard/dashboard.html
+++ b/app/docker/views/dashboard/dashboard.html
@@ -18,7 +18,7 @@
     <p class="text-muted" ng-if="applicationState.endpoint.mode.role === 'MANAGER'">
       <pr-icon icon="'alert-circle'" mode="'primary'"></pr-icon>
       Portainer is connected to a node that is part of a Swarm cluster. Some resources located on other nodes in the cluster might not be available for management, have a look at
-      <a href="https://docs.portainer.io/start/install/agent/swarm/linux" target="_blank">our agent setup</a> for more details.
+      <a href="https://docs.portainer.io/admin/environments/add/swarm/agent" target="_blank">our agent setup</a> for more details.
     </p>
     <p class="text-muted" ng-if="applicationState.endpoint.mode.role === 'WORKER'">
       <pr-icon icon="'alert-circle'" mode="'primary'"></pr-icon>


### PR DESCRIPTION
closes #10621   [EE-6318]

### Changes:

- update a dashboard reference link to point at the updated docs URL for Docker Swarm agent considerations

[EE-6318]: https://portainer.atlassian.net/browse/EE-6318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ