### PR TITLE
fix(docker/service): show default value of StopGracePeriod

### DIFF
--- a/app/docker/views/services/edit/includes/container-specs.html
+++ b/app/docker/views/services/edit/includes/container-specs.html
@@ -40,7 +40,7 @@
             <td>Stop grace period</td>
             <td>{{ service.StopGracePeriod }}</td>
             <td>
-              <p class="small text-muted" style="margin-top: 10px"> Time to wait before force killing a container (default none). </p>
+              <p class="small text-muted" style="margin-top: 10px"> Time to wait before force killing a container (default 10s by engine). </p>
             </td>
           </tr>
         </tbody>

--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -711,7 +711,7 @@ angular.module('portainer.docker').controller('ServiceController', [
       service.RestartDelay = ServiceHelper.translateNanosToHumanDuration(service.RestartDelay) || '5s';
       service.RestartWindow = ServiceHelper.translateNanosToHumanDuration(service.RestartWindow) || '0s';
       service.UpdateDelay = ServiceHelper.translateNanosToHumanDuration(service.UpdateDelay) || '0s';
-      service.StopGracePeriod = service.StopGracePeriod ? ServiceHelper.translateNanosToHumanDuration(service.StopGracePeriod) : '';
+      service.StopGracePeriod = service.StopGracePeriod ? ServiceHelper.translateNanosToHumanDuration(service.StopGracePeriod) : '10s';
     }
 
     function initView() {


### PR DESCRIPTION
### Changes:
Show default value of StopGracePeriod that engine will use. ([link](https://github.com/moby/moby/blob/d006242d737843977ca751711a13df77c813b0a0/container/container_unix.go#L31))
Even if the container spec dose not have real StopGracePeriod value, in user perspective, it is more intuitive to know how stop operation works