### PR TITLE
fix(swarm/services): avoid sending credSpec object when empty [EE-6322]

### DIFF
--- a/app/docker/views/services/edit/serviceController.js
+++ b/app/docker/views/services/edit/serviceController.js
@@ -474,7 +474,7 @@ angular.module('portainer.docker').controller('ServiceController', [
         '';
       if (oldCredSpecId && !credSpecId) {
         delete config.TaskTemplate.ContainerSpec.Privileges.CredentialSpec;
-      } else if (oldCredSpecId !== credSpec) {
+      } else if (credSpec && oldCredSpecId !== credSpec) {
         config.TaskTemplate.ContainerSpec.Privileges = {
           ...(config.TaskTemplate.ContainerSpec.Privileges || {}),
           CredentialSpec: {
@@ -854,6 +854,10 @@ angular.module('portainer.docker').controller('ServiceController', [
 
     $scope.filterConfigs = filterConfigs;
     function filterConfigs(configs) {
+      if (!configs) {
+        return [];
+      }
+
       return configs.filter((config) => $scope.service.ServiceConfigs.every((serviceConfig) => config.Id !== serviceConfig.Id));
     }
 


### PR DESCRIPTION
fix  [EE-6322]
related to [EE-6178]

[EE-6322]: https://portainer.atlassian.net/browse/EE-6322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EE-6178]: https://portainer.atlassian.net/browse/EE-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ