### PR TITLE
fix(oauth): show asterisks placeholder in secret key input field EE-5664

### DIFF
--- a/app/portainer/oauth/components/oauth-settings/oauth-settings.html
+++ b/app/portainer/oauth/components/oauth-settings/oauth-settings.html
@@ -406,7 +406,7 @@
             class="form-control"
             id="oauth_client_secret"
             ng-model="$ctrl.settings.ClientSecret"
-            placeholder="xxxxxxxxxxxxxxxxxxxx"
+            placeholder="*******"
             autocomplete="new-password"
             ng-class="['form-control', { 'limited-be': $ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom' }]"
             ng-disabled="$ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom'"


### PR DESCRIPTION
fixes [EE-5664]

[EE-5664]: https://portainer.atlassian.net/browse/EE-5664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ