### PR TITLE
fix(linter): fix some minor issues and remove seed.Rand [EE-6470]

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -3,11 +3,9 @@ package main
 import (
 	"context"
 	"crypto/sha256"
-	"math/rand"
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/apikey"
@@ -631,8 +629,6 @@ func buildServer(flags *portainer.CLIFlags) portainer.Server {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	configureLogger()
 	setLoggingMode("PRETTY")
 

--- a/api/http/handler/auth/authenticate.go
+++ b/api/http/handler/auth/authenticate.go
@@ -200,7 +200,7 @@ func (handler *Handler) syncUserTeamsWithLDAPGroups(user *portainer.User, settin
 
 func teamExists(teamName string, ldapGroups []string) bool {
 	for _, group := range ldapGroups {
-		if strings.ToLower(group) == strings.ToLower(teamName) {
+		if strings.EqualFold(group, teamName) {
 			return true
 		}
 	}

--- a/api/http/middlewares/endpoint.go
+++ b/api/http/middlewares/endpoint.go
@@ -13,7 +13,15 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const contextEndpoint = "endpoint"
+// Note: context keys must be distinct types to prevent collisions. They are NOT key/value map's internally
+// See: https://go.dev/blog/context#TOC_3.2.
+
+// This avoids staticcheck error:
+// SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
+// https://stackoverflow.com/questions/40891345/fix-should-not-use-basic-type-string-as-key-in-context-withvalue-golint
+type key int
+
+const contextEndpoint key = 0
 
 func WithEndpoint(endpointService dataservices.EndpointService, endpointIDParam string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {

--- a/api/stacks/deployments/deployer_remote.go
+++ b/api/stacks/deployments/deployer_remote.go
@@ -198,7 +198,6 @@ func (d *stackDeployer) remoteStack(stack *portainer.Stack, endpoint *portainer.
 		Str("cmd", strings.Join(cmd, " ")).
 		Msg("running unpacker")
 
-	rand.Seed(time.Now().UnixNano())
 	unpackerContainer, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: image,
 		Cmd:   cmd,


### PR DESCRIPTION
Remove seed.Random which is now the default and deprecated.
Fix some minor linting issues when we enable staticcheck linter.

[EE-6470]

[EE-6470]: https://portainer.atlassian.net/browse/EE-6470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ