### PR TITLE
fix(git): stacks deployed version [EE-6346]

### DIFF
--- a/app/react/docker/stacks/ListView/StacksDatatable/columns/deployed-version.tsx
+++ b/app/react/docker/stacks/ListView/StacksDatatable/columns/deployed-version.tsx
@@ -1,4 +1,5 @@
 import { isExternalStack } from '@/react/docker/stacks/view-models/utils';
+import { cleanGitRepoUrl } from '@/react/portainer/gitops/utils';
 
 import { columnHelper } from './helper';
 
@@ -23,7 +24,9 @@ export const deployedVersion = columnHelper.accessor(
           <div className="text-center">
             <a
               target="_blank"
-              href={`${item.GitConfig.URL}/commit/${item.GitConfig.ConfigHash}`}
+              href={`${cleanGitRepoUrl(item.GitConfig.URL)}/commit/${
+                item.GitConfig.ConfigHash
+              }`}
               rel="noreferrer"
             >
               {item.GitConfig.ConfigHash.slice(0, 7)}


### PR DESCRIPTION
Closes [EE-6346]

The deployed version column isn't in the 2.19 release branch so there is a develop PR only

[EE-6346]: https://portainer.atlassian.net/browse/EE-6346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ