### PR TITLE
fix(volumes): typo

### DIFF
--- a/app/kubernetes/components/datatables/volumes-datatable/volumesDatatable.html
+++ b/app/kubernetes/components/datatables/volumes-datatable/volumesDatatable.html
@@ -202,7 +202,7 @@
           <td colspan="6" class="text-muted text-center">Loading...</td>
         </tr>
         <tr ng-if="$ctrl.state.filteredDataSet.length === 0">
-          <td colspan="6" class="text-muted text-center">No volume available.</td>
+          <td colspan="6" class="text-muted text-center">No volumes available.</td>
         </tr>
       </tbody>
     </table>

--- a/app/react/docker/volumes/ListView/VolumesDatatable/VolumesDatatable.tsx
+++ b/app/react/docker/volumes/ListView/VolumesDatatable/VolumesDatatable.tsx
@@ -51,7 +51,7 @@ export function VolumesDatatable({
       dataset={dataset || []}
       isLoading={!dataset}
       settingsManager={tableState}
-      emptyContentLabel="No volume available."
+      emptyContentLabel="No volumes available."
       renderTableActions={(selectedItems) => (
         <TableActions selectedItems={selectedItems} onRemove={onRemove} />
       )}


### PR DESCRIPTION
### Changes:
Fixes a typo for when there are no volumes available to the user.
`No volume available.` -> `No volumes available.`