### PR TITLE
fix(edgestack): repull image not work in git autoupdate [EE-6430]

### DIFF
--- a/api/edge/edge.go
+++ b/api/edge/edge.go
@@ -51,6 +51,10 @@ type (
 		// Used only for EE
 		// EnvVars is a list of environment variables to inject into the stack
 		EnvVars []portainer.Pair
+
+		// Used only for EE async edge agent
+		// ReadyRePullImage is a flag to indicate whether the auto update is trigger to re-pull image
+		ReadyRePullImage bool
 	}
 
 	// RegistryCredentials holds the credentials for a Docker registry.

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -354,6 +354,8 @@ type (
 		EndpointID EndpointID
 		// EE only feature
 		DeploymentInfo StackDeploymentInfo
+		// ReadyRePullImage is a flag to indicate whether the auto update is trigger to re-pull image
+		ReadyRePullImage bool
 
 		// Deprecated
 		Details EdgeStackStatusDetails


### PR DESCRIPTION


Proposal for the new solution with introducing the new field ReadyRePullImage

closes [EE-6430]

[EE-6430]: https://portainer.atlassian.net/browse/EE-6430?