### PR TITLE
fix(kube/apps): move namespace selector in apps view [EE-6612]

### DIFF
--- a/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
+++ b/app/kubernetes/components/datatables/applications-datatable/applicationsDatatable.html
@@ -113,7 +113,7 @@
     </div>
     <div class="toolBar !pt-0">
       <div class="w-full">
-        <div class="form-group !h-[30px] min-w-[140px] float-right">
+        <div class="form-group float-right !h-[30px] min-w-[140px] mr-2">
           <div class="input-group">
             <span class="input-group-addon">
               <div className="flex items-center gap-1">

--- a/app/react/kubernetes/applications/ListView/ApplicationsStacksDatatable/ApplicationsStacksDatatable.tsx
+++ b/app/react/kubernetes/applications/ListView/ApplicationsStacksDatatable/ApplicationsStacksDatatable.tsx
@@ -73,7 +73,7 @@ export function ApplicationsStacksDatatable({
       emptyContentLabel="No stack available."
       description={
         <div className="w-full">
-          <div className="min-w-[140px] float-right">
+          <div className="min-w-[140px] float-right mr-2">
             <NamespaceFilter
               namespaces={namespaces}
               value={namespace}


### PR DESCRIPTION
fix [EE-6612]


[EE-6612]: https://portainer.atlassian.net/browse/EE-6612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ