### PR TITLE
fix(stacks): add support for reading Azure DevOps Server url from env

### DIFF
--- a/api/git/azure.go
+++ b/api/git/azure.go
@@ -28,7 +28,7 @@ func isAzureUrl(s string) bool {
 	condition := strings.Contains(s, azureDevOpsHost) ||
 		strings.Contains(s, visualStudioHostSuffix)
 	azureDevOpsServerURL, azureDevOpsServerURLOK := os.LookupEnv("AZURE_DEVOPS_SERVER_URL")
-	if azureDevOpsServerHostOK {
+	if azureDevOpsServerURLOK {
 		return condition || strings.Contains(s, azureDevOpsServerURL)
 	}
 	return condition

--- a/api/git/azure.go
+++ b/api/git/azure.go
@@ -253,18 +253,19 @@ func parseHttpUrl(rawUrl string) (*azureOptions, error) {
 		return nil, errors.Wrap(err, "failed to parse HTTP url")
 	}
 	azureDevOpsServerURL, azureDevOpsServerURLOK := os.LookupEnv("AZURE_DEVOPS_SERVER_URL")
+	var azureDevOpsServerParsedURL *url.URL
 	if azureDevOpsServerURLOK {
-		azureDevOpsServerParsedURL, err := url.Parse(rawUrl)
+		azureDevOpsServerParsedURL, err = url.Parse(azureDevOpsServerURL)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse Azure DevOps Server url")
 		}
 	}
 	opt := azureOptions{}
 	switch {
-	case azureDevOpsServerURLOK && u.Host == azureDevOpsServerParsedURL.host:
-		path = strings.Split(strings.ReplaceAll(u.Path, azureDevOpsServerParsedURL.path, ""), "/")
+	case azureDevOpsServerURLOK && azureDevOpsServerParsedURL != nil && u.Host == azureDevOpsServerParsedURL.Host:
+		path := strings.Split(strings.ReplaceAll(u.Path, azureDevOpsServerParsedURL.Path, ""), "/")
 		if len(path) != 5 {
-			expectedUrl =  azureDevOpsServerURL + "/{Collection}/{Project}/_git/{Repository}"
+			expectedUrl := azureDevOpsServerURL + "/{Collection}/{Project}/_git/{Repository}"
 			return nil, errors.Errorf("want url %s, got %s", expectedUrl, u)
 		}
 		opt.organisation = path[1] //In case of AzureDevops Server Organisation is replaced with Collection but their logic is the same


### PR DESCRIPTION
closes #10866  <!-- Github issue number (remove if unknown) -->

### Changes:
Add an option to pass Azure DevOps Server address and base url via environment variables.