### PR TITLE
Revert "fix(logs): add NOCOLOR option for use when exporting to greylog etc [EE-6696]"

### DIFF
--- a/api/cli/cli.go
+++ b/api/cli/cli.go
@@ -62,7 +62,7 @@ func (*Service) ParseFlags(version string) (*portainer.CLIFlags, error) {
 		MaxBatchDelay:             kingpin.Flag("max-batch-delay", "Maximum delay before a batch starts").Duration(),
 		SecretKeyName:             kingpin.Flag("secret-key-name", "Secret key name for encryption and will be used as /run/secrets/<secret-key-name>.").Default(defaultSecretKeyName).String(),
 		LogLevel:                  kingpin.Flag("log-level", "Set the minimum logging level to show").Default("INFO").Enum("DEBUG", "INFO", "WARN", "ERROR"),
-		LogMode:                   kingpin.Flag("log-mode", "Set the logging output mode").Default("PRETTY").Enum("NOCOLOR", "PRETTY", "JSON"),
+		LogMode:                   kingpin.Flag("log-mode", "Set the logging output mode").Default("PRETTY").Enum("PRETTY", "JSON"),
 	}
 
 	kingpin.Parse()

--- a/api/cmd/portainer/log.go
+++ b/api/cmd/portainer/log.go
@@ -42,13 +42,6 @@ func setLoggingMode(mode string) {
 			TimeFormat:    "2006/01/02 03:04PM",
 			FormatMessage: formatMessage,
 		})
-	case "NOCOLOR":
-		log.Logger = log.Output(zerolog.ConsoleWriter{
-			Out:           os.Stderr,
-			TimeFormat:    "2006/01/02 03:04PM",
-			FormatMessage: formatMessage,
-			NoColor:       true,
-		})
 	case "JSON":
 		log.Logger = log.Output(os.Stderr)
 	}


### PR DESCRIPTION
Reverts portainer/portainer#11107