### PR TITLE
debugging Azure/Entra-ID returned claims

### DIFF
--- a/api/oauth/oauth.go
+++ b/api/oauth/oauth.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -105,6 +106,7 @@ func getIdToken(token *oauth2.Token) (map[string]interface{}, error) {
 	}
 
 	if claims, ok := t.Claims.(jwt.MapClaims); ok {
+		log.Debug().Str("obj", fmt.Sprintf("%#v", claims)).Msg("JSON Web Token (parsed)")
 		for k, v := range claims {
 			tokenData[k] = v
 		}


### PR DESCRIPTION
it is a very simple PR, it just enables the debugging of SSO integration
 that turned out to be pretty challening without extra logging

as for instance, by default Azure/Entra-ID is returning IDs and not group names

I'm attempting to select different output informations from the SSO,
 but I need to see what's being received on Portainer's end