### PR TITLE
fix(contexthelp): remove extra slash from contexthelp docs link [EE-6780]

### DIFF
--- a/app/react/components/PageHeader/ContextHelp/ContextHelp.tsx
+++ b/app/react/components/PageHeader/ContextHelp/ContextHelp.tsx
@@ -50,7 +50,7 @@ function useDocsUrl(): string {
     const parts = ServerVersion.split('.');
     if (parts.length >= 2) {
       const version = parts.slice(0, 2).join('.');
-      url += `v/${version}/`;
+      url += `v/${version}`;
     }
   }
 


### PR DESCRIPTION
[EE-6780]

[EE-6780]: https://portainer.atlassian.net/browse/EE-6780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ