### PR TITLE
fix(matomo): stop oauth link event [EE-6779]

### DIFF
--- a/app/angulartics.matomo/index.js
+++ b/app/angulartics.matomo/index.js
@@ -82,6 +82,7 @@ function config($analyticsProvider, $windowProvider) {
     push('setReferrerUrl', '');
     push('setCustomUrl', basePath + path);
     push('trackPageView');
+    push('enableLinkTracking');
   });
 
   /**

--- a/app/matomo-setup.js
+++ b/app/matomo-setup.js
@@ -1,6 +1,5 @@
 const _paq = (window._paq = window._paq || []);
 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-_paq.push(['enableLinkTracking']);
 
 var u = 'https://portainer-ce.matomo.cloud/';
 _paq.push(['setTrackerUrl', u + 'matomo.php']);


### PR DESCRIPTION
Closes [EE-6779]

[EE-6779]: https://portainer.atlassian.net/browse/EE-6779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ