### PR TITLE
Added 2.20.0 to bug report version option dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -93,6 +93,7 @@ body:
       description: We only provide support for the most recent version of Portainer and the previous 3 versions. If you are on an older version of Portainer we recommend [upgrading first](https://docs.portainer.io/start/upgrade) in case your bug has already been fixed.
       multiple: false
       options:
+        - '2.20.0'
         - '2.19.4'
         - '2.19.3'
         - '2.19.2'


### PR DESCRIPTION
### Changes:

- Added 2.20.0 as an option to the bug report version dropdown field.