### PR TITLE
fix(app): replace fields removed by Docker 25 and 26

### DIFF
--- a/app/docker/models/image.js
+++ b/app/docker/models/image.js
@@ -14,7 +14,7 @@ export function ImageViewModel(data) {
     }
   }
 
-  this.VirtualSize = data.VirtualSize;
+  this.Size = data.Size;
   this.Used = data.Used;
 
   if (data.Portainer && data.Portainer.Agent && data.Portainer.Agent.NodeName) {

--- a/app/docker/models/imageDetails.js
+++ b/app/docker/models/imageDetails.js
@@ -6,7 +6,7 @@ export function ImageDetailsViewModel(data) {
   this.Created = data.Created;
   this.Checked = false;
   this.RepoTags = data.RepoTags;
-  this.VirtualSize = data.VirtualSize;
+  this.Size = data.Size;
   this.DockerVersion = data.DockerVersion;
   this.Os = data.Os;
   this.Architecture = data.Architecture;

--- a/app/docker/models/imageDetails.js
+++ b/app/docker/models/imageDetails.js
@@ -12,9 +12,16 @@ export function ImageDetailsViewModel(data) {
   this.Architecture = data.Architecture;
   this.Author = data.Author;
   this.Command = data.Config.Cmd;
-  this.Entrypoint = data.ContainerConfig.Entrypoint ? data.ContainerConfig.Entrypoint : '';
-  this.ExposedPorts = data.ContainerConfig.ExposedPorts ? Object.keys(data.ContainerConfig.ExposedPorts) : [];
-  this.Volumes = data.ContainerConfig.Volumes ? Object.keys(data.ContainerConfig.Volumes) : [];
-  this.Env = data.ContainerConfig.Env ? data.ContainerConfig.Env : [];
-  this.Labels = data.ContainerConfig.Labels;
+
+  let config = {};
+  if (data.Config) {
+    config = data.Config; // this is part of OCI images-spec
+  } else if (data.ContainerConfig != null) {
+    config = data.ContainerConfig; // not OCI ; has been removed in Docker 26 (API v1.45) along with .Container
+  }
+  this.Entrypoint = config.Entrypoint ? config.Entrypoint : '';
+  this.ExposedPorts = config.ExposedPorts ? Object.keys(config.ExposedPorts) : [];
+  this.Volumes = config.Volumes ? Object.keys(config.Volumes) : [];
+  this.Env = config.Env ? config.Env : [];
+  this.Labels = config.Labels;
 }

--- a/app/docker/views/dashboard/dashboardController.js
+++ b/app/docker/views/dashboard/dashboardController.js
@@ -137,5 +137,5 @@ angular.module('portainer.docker').controller('DashboardController', [
 ]);
 
 function imagesTotalSize(images) {
-  return images.reduce((acc, image) => acc + image.VirtualSize, 0);
+  return images.reduce((acc, image) => acc + image.Size, 0);
 }

--- a/app/docker/views/images/edit/image.html
+++ b/app/docker/views/images/edit/image.html
@@ -130,7 +130,7 @@
             </tr>
             <tr>
               <td>Size</td>
-              <td>{{ image.VirtualSize | humansize }}</td>
+              <td>{{ image.Size | humansize }}</td>
             </tr>
             <tr>
               <td>Created</td>

--- a/app/react/docker/images/types/response.ts
+++ b/app/react/docker/images/types/response.ts
@@ -10,6 +10,5 @@ export type DockerImageResponse = {
   RepoTags: string[];
   SharedSize: number;
   Size: number;
-  VirtualSize: number;
   Portainer?: PortainerMetadata;
 };


### PR DESCRIPTION
Port to 2.21
---
Close [EE-6801]
Related to #10983

Close [EE-6934]
Related to #6294 / #6295 
Related to #11436 

* Moved from `image.VirtualSize` to `image.Size` as `VirtualSize` has been [removed](https://github.com/moby/moby/pull/45469) in Docker 25 (API v1.44)
This change is backward compatible [up to Docker 1.10](https://github.com/moby/moby/issues/43862#:~:text=VirtualSize%20was%20a,for%20VirtualSize.)

* Made `image.Container`, `image.Config` and `image.ContainerConfig` optional as `Container` and `ContainerConfig` have been [removed](https://github.com/moby/moby/pull/47430) in Docker 26 (API v1.45) and `Config` may not exist, [per OCI specs](https://github.com/opencontainers/image-spec/blob/b5998bad35aecf0f058b80fefec69d6792d0da8d/specs-go/v1/config.go#L103-L104) (trying to destructure it will error)

[EE-6801]: https://portainer.atlassian.net/browse/EE-6801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EE-6934]: https://portainer.atlassian.net/browse/EE-6934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ