### PR TITLE
fix(api/endpoint): filter status for async devices [EE-6958]

### DIFF
--- a/api/http/handler/endpoints/filter.go
+++ b/api/http/handler/endpoints/filter.go
@@ -19,8 +19,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const edgeIntervalUseDefault = -1
-
 type EnvironmentsQuery struct {
 	search           string
 	types            []portainer.EndpointType
@@ -637,6 +635,7 @@ func getEdgeStackStatusParam(r *http.Request) (*portainer.EdgeStackStatusType, e
 }
 
 func getShortestAsyncInterval(endpoint *portainer.Endpoint, settings *portainer.Settings) int {
+	var edgeIntervalUseDefault int = -1
 	pingInterval := endpoint.Edge.PingInterval
 	if pingInterval == edgeIntervalUseDefault {
 		pingInterval = settings.Edge.PingInterval

--- a/api/http/handler/endpoints/filter.go
+++ b/api/http/handler/endpoints/filter.go
@@ -19,6 +19,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const edgeIntervalUseDefault = -1
+
 type EnvironmentsQuery struct {
 	search           string
 	types            []portainer.EndpointType
@@ -334,9 +336,14 @@ func filterEndpointsByStatuses(endpoints []portainer.Endpoint, statuses []portai
 		status := endpoint.Status
 		if endpointutils.IsEdgeEndpoint(&endpoint) {
 			isCheckValid := false
+
 			edgeCheckinInterval := endpoint.EdgeCheckinInterval
-			if endpoint.EdgeCheckinInterval == 0 {
+			if edgeCheckinInterval == 0 {
 				edgeCheckinInterval = settings.EdgeAgentCheckinInterval
+			}
+
+			if endpoint.Edge.AsyncMode {
+				edgeCheckinInterval = getShortestAsyncInterval(&endpoint, settings)
 			}
 
 			if edgeCheckinInterval != 0 && endpoint.LastCheckInDate != 0 {
@@ -627,4 +634,29 @@ func getEdgeStackStatusParam(r *http.Request) (*portainer.EdgeStackStatusType, e
 	}
 
 	return &edgeStackStatus, nil
+}
+
+func getShortestAsyncInterval(endpoint *portainer.Endpoint, settings *portainer.Settings) int {
+	pingInterval := endpoint.Edge.PingInterval
+	if pingInterval == edgeIntervalUseDefault {
+		pingInterval = settings.Edge.PingInterval
+	}
+	shortestAsyncInterval := pingInterval
+
+	snapshotInterval := endpoint.Edge.SnapshotInterval
+	if snapshotInterval == edgeIntervalUseDefault {
+		snapshotInterval = settings.Edge.SnapshotInterval
+	}
+	if shortestAsyncInterval > snapshotInterval {
+		shortestAsyncInterval = snapshotInterval
+	}
+
+	commandInterval := endpoint.Edge.CommandInterval
+	if commandInterval == edgeIntervalUseDefault {
+		commandInterval = settings.Edge.CommandInterval
+	}
+	if shortestAsyncInterval > commandInterval {
+		shortestAsyncInterval = commandInterval
+	}
+	return shortestAsyncInterval
 }


### PR DESCRIPTION


closes [EE-6958]

[EE-6958]: https://portainer.atlassian.net/browse/EE-6958?