### PR TITLE
docs(contributing): add jq to dependency list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ The feature request process is similar to the bug report process but has an extr
 
 ## Build and run Portainer locally
 
-Ensure you have Docker, Node.js, yarn, and Golang installed in the correct versions.
+Ensure you have Docker, Node.js, yarn, Golang, and the command-line utility jq installed in the correct versions.
 
 Install dependencies:
 


### PR DESCRIPTION
### Changes:
```jq``` is required in the ```build/download_binaries.sh``` file. This pull request adds ```jq``` to the list of dependencies to install before building and running Portainer locally to inform people that they need it to build and run Portainer.