### PR TITLE
chore(build): add error if jq is not present

### DIFF
--- a/build/download_binaries.sh
+++ b/build/download_binaries.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if ! [ -x "$(command -v jq)" ]; then
-  echo 'Error: jq is not installed. Get it here: https://stedolan.github.io/jq/download/' >&2
+  echo 'Error: jq is not installed. Get it here: https://jqlang.github.io/jq/download/' >&2
   exit 1
 fi
 

--- a/build/download_binaries.sh
+++ b/build/download_binaries.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if ! [ -x "$(command -v jq)" ]; then
-  echo 'Error: jq is not installed. Get it here: https://jqlang.github.io/jq/download/' >&2
+  echo 'Error: jq is not installed. Please install jq before building Portainer. Get it here: https://jqlang.github.io/jq/download/' >&2
   exit 1
 fi
 

--- a/build/download_binaries.sh
+++ b/build/download_binaries.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! [ -x "$(command -v jq)" ]; then
+  echo 'Error: jq is not installed. Get it here: https://stedolan.github.io/jq/download/' >&2
+  exit 1
+fi
 
 PLATFORM=${1:-"linux"}
 ARCH=${2:-"amd64"}


### PR DESCRIPTION
### Changes:
```jq``` is required in the ```build/download_binaries.sh``` file. This pull request adds an error to tell the person trying to build Portainer to install ```jq``` first before continuing with the build.