### PR TITLE
fix(build): fix macOS build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ dev: ## Run both the client and server in development mode
 dev-client: ## Run the client in development mode 
 	yarn dev
 
-dev-server: build-server ## Run the server in development mode
+dev-server: ## Run the server in development mode
+	make PLATFORM=linux build-server
 	@./dev/run_container.sh
 
 

--- a/build/build_binary.sh
+++ b/build/build_binary.sh
@@ -36,7 +36,7 @@ BINARY_VERSION_FILE="../binary-version.json"
 echo "$ldflags"
 
 # the build takes 2 seconds
-GOOS=linux GOARCH=${2:-$(go env GOARCH)} CGO_ENABLED=0 go build \
+GOOS=${1:-$(go env GOOS)} GOARCH=${2:-$(go env GOARCH)} CGO_ENABLED=0 go build \
 	-trimpath \
 	--installsuffix cgo \
 	--ldflags "$ldflags" \

--- a/build/build_binary.sh
+++ b/build/build_binary.sh
@@ -36,7 +36,7 @@ BINARY_VERSION_FILE="../binary-version.json"
 echo "$ldflags"
 
 # the build takes 2 seconds
-GOOS=${1:-$(go env GOOS)} GOARCH=${2:-$(go env GOARCH)} CGO_ENABLED=0 go build \
+GOOS=linux GOARCH=${2:-$(go env GOARCH)} CGO_ENABLED=0 go build \
 	-trimpath \
 	--installsuffix cgo \
 	--ldflags "$ldflags" \


### PR DESCRIPTION
I was facing some issues with getting Portainer to build and run locally on my Mac. I was getting an error in the Portainer docker container logs saying ```exec /app/portainer: exec format error```.
Previously the Go binary would be compiled for macOS on a Mac and ran in the Linux Docker container. Since it was not a Linux binary, the exec format error would come up.

Changing the OS to Linux solves that problem and makes a Linux binary run in the Linux container.

### Changes:
Changed build platform for ```make dev-server``` to ```linux```