### PR TITLE
fix(images): consider stopped containers for unused label [EE-6983]

### DIFF
--- a/api/http/handler/docker/images/images_list.go
+++ b/api/http/handler/docker/images/images_list.go
@@ -64,7 +64,9 @@ func (handler *Handler) imagesList(w http.ResponseWriter, r *http.Request) *http
 
 	imageUsageSet := set.Set[string]{}
 	if withUsage {
-		containers, err := cli.ContainerList(r.Context(), container.ListOptions{})
+		containers, err := cli.ContainerList(r.Context(), container.ListOptions{
+			All: true,
+		})
 		if err != nil {
 			return httperror.InternalServerError("Unable to retrieve Docker containers", err)
 		}


### PR DESCRIPTION
[EE-6983]

Merge after 2.20.3 version bump.

[EE-6983]: https://portainer.atlassian.net/browse/EE-6983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ