### PR TITLE
docs(link) change installation link to CommunityEdition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Portainer CE is updated regularly. We aim to do an update release every couple o
 
 ## Getting started
 
-- [Deploy Portainer](https://docs.portainer.io/start/install)
+- [Deploy Portainer](https://docs.portainer.io/start/install-ce)
 - [Documentation](https://docs.portainer.io)
 - [Contribute to the project](https://docs.portainer.io/contribute/contribute)
 


### PR DESCRIPTION
### Changes:
Installation link from readme must link to CommunityEdition since this repository is for this portainer version, not BE.