### PR TITLE
Revert "fix(app): avoid 'no label' error when deleting external app [EE-6019]"

### DIFF
--- a/app/kubernetes/views/applications/applicationsController.js
+++ b/app/kubernetes/views/applications/applicationsController.js
@@ -95,7 +95,7 @@ class KubernetesApplicationsController {
         } else {
           await this.KubernetesApplicationService.delete(application);
 
-          if (application.Metadata.labels && application.Metadata.labels[KubernetesPortainerApplicationStackNameLabel]) {
+          if (application.Metadata.labels[KubernetesPortainerApplicationStackNameLabel]) {
             // Update applications in stack
             const stack = this.state.stacks.find((x) => x.Name === application.StackName);
             const index = stack.Applications.indexOf(application);


### PR DESCRIPTION
Reverts portainer/portainer#11672

Reverting because this ticket targets 2.20.3, not 2.20.2