### PR TITLE
fix(jwt): handle kubeconfig with no expiry [EE-7044]

### DIFF
--- a/api/jwt/jwt.go
+++ b/api/jwt/jwt.go
@@ -188,7 +188,7 @@ func (service *Service) generateSignedToken(data *portainer.TokenData, expiresAt
 	}
 
 	// If expiresAt is set to a zero value, the token should never expire
-	if expiresAt == time.Unix(0, 0) {
+	if expiresAt.IsZero() {
 		cl.RegisteredClaims.ExpiresAt = nil
 	}
 

--- a/api/jwt/jwt.go
+++ b/api/jwt/jwt.go
@@ -123,7 +123,7 @@ func (service *Service) ParseAndVerifyToken(token string) (*portainer.TokenData,
 			if err != nil {
 				return nil, errInvalidJWTToken
 			}
-			if user.TokenIssueAt > cl.RegisteredClaims.ExpiresAt.Unix() {
+			if user.TokenIssueAt > cl.RegisteredClaims.IssuedAt.Unix() {
 				return nil, errInvalidJWTToken
 			}
 
@@ -181,13 +181,15 @@ func (service *Service) generateSignedToken(data *portainer.TokenData, expiresAt
 		Role:                int(data.Role),
 		Scope:               scope,
 		ForceChangePassword: data.ForceChangePassword,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+		},
 	}
 
-	if !expiresAt.IsZero() {
-		cl.RegisteredClaims = jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(expiresAt),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-		}
+	// If expiresAt is set to a zero value, the token should never expire
+	if expiresAt == time.Unix(0, 0) {
+		cl.RegisteredClaims.ExpiresAt = nil
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, cl)

--- a/api/jwt/jwt_kubeconfig.go
+++ b/api/jwt/jwt_kubeconfig.go
@@ -20,7 +20,7 @@ func (service *Service) GenerateTokenForKubeconfig(data *portainer.TokenData) (s
 
 	expiryAt := time.Now().Add(expiryDuration)
 	if expiryDuration == time.Duration(0) {
-		expiryAt = time.Time{}
+		expiryAt = time.Unix(0, 0)
 	}
 
 	return service.generateSignedToken(data, expiryAt, kubeConfigScope)

--- a/api/jwt/jwt_kubeconfig.go
+++ b/api/jwt/jwt_kubeconfig.go
@@ -18,9 +18,10 @@ func (service *Service) GenerateTokenForKubeconfig(data *portainer.TokenData) (s
 		return "", err
 	}
 
-	expiryAt := time.Now().Add(expiryDuration)
-	if expiryDuration == time.Duration(0) {
-		expiryAt = time.Unix(0, 0)
+	// https://go.dev/play/p/bOrt6cQpA0I time.Time defaults to a zero value which is 0001-01-01 00:00:00 +0000 UTC
+	var expiryAt time.Time
+	if expiryDuration > time.Duration(0) {
+		expiryAt = time.Now().Add(expiryDuration)
 	}
 
 	return service.generateSignedToken(data, expiryAt, kubeConfigScope)


### PR DESCRIPTION
Closes [EE-7044]

[EE-7044]: https://portainer.atlassian.net/browse/EE-7044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ