### PR TITLE
Aquire lock before calling getTunnelDetails

### DIFF
--- a/api/chisel/tunnel.go
+++ b/api/chisel/tunnel.go
@@ -147,10 +147,10 @@ func (service *Service) SetTunnelStatusToIdle(endpointID portainer.EndpointID) {
 func (service *Service) SetTunnelStatusToRequired(endpointID portainer.EndpointID) error {
 	defer cache.Del(endpointID)
 
-	tunnel := service.getTunnelDetails(endpointID)
-
 	service.mu.Lock()
 	defer service.mu.Unlock()
+
+	tunnel := service.getTunnelDetails(endpointID)
 
 	if tunnel.Port == 0 {
 		endpoint, err := service.dataStore.Endpoint().Endpoint(endpointID)


### PR DESCRIPTION
Note: Logically it si reasoned to fix the linked issue, but feedback on this PR is much appreciated. 

Tries to closes #11787

### Changes:
As per note above `getTunnelDetails`, a lock must be aquired before calling the method. In `SetTunnelStatusToRequired` this does not happen, and can potentially cause #11787. This PR reorders the the calls to precent the method being called without the lock