### PR TITLE
fix(db): fix missing portainer.edb in backups when encrypted portainer db is used [EE-6417]

### DIFF
--- a/api/backup/backup.go
+++ b/api/backup/backup.go
@@ -82,7 +82,8 @@ func CreateBackupArchive(password string, gate *offlinegate.OfflineGate, datasto
 }
 
 func backupDb(backupDirPath string, datastore dataservices.DataStore) error {
-	_, err := datastore.Backup(filepath.Join(backupDirPath, "portainer.db"))
+	dbFileName := datastore.Connection().GetDatabaseFileName()
+	_, err := datastore.Backup(filepath.Join(backupDirPath, dbFileName))
 	return err
 }
 

--- a/api/dataservices/interface.go
+++ b/api/dataservices/interface.go
@@ -36,6 +36,7 @@ type (
 	}
 
 	DataStore interface {
+		Connection() portainer.Connection
 		Open() (newStore bool, err error)
 		Init() error
 		Close() error

--- a/api/internal/testhelpers/datastore.go
+++ b/api/internal/testhelpers/datastore.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/database"
 	"github.com/portainer/portainer/api/dataservices"
 	"github.com/portainer/portainer/api/dataservices/errors"
 )
@@ -34,6 +35,7 @@ type testDatastore struct {
 	version                 dataservices.VersionService
 	webhook                 dataservices.WebhookService
 	pendingActionsService   dataservices.PendingActionsService
+	connection              portainer.Connection
 }
 
 func (d *testDatastore) Backup(path string) (string, error)                  { return "", nil }
@@ -88,6 +90,10 @@ func (d *testDatastore) PendingActions() dataservices.PendingActionsService {
 	return d.pendingActionsService
 }
 
+func (d *testDatastore) Connection() portainer.Connection {
+	return d.connection
+}
+
 func (d *testDatastore) IsErrObjectNotFound(e error) bool {
 	return false
 }
@@ -105,7 +111,8 @@ type datastoreOption = func(d *testDatastore)
 // NewDatastore creates new instance of testDatastore.
 // Will apply options before returning, opts will be applied from left to right.
 func NewDatastore(options ...datastoreOption) *testDatastore {
-	d := testDatastore{}
+	conn, _ := database.NewDatabase("boltdb", "", nil)
+	d := testDatastore{connection: conn}
 	for _, o := range options {
 		o(&d)
 	}


### PR DESCRIPTION
 [EE-6417]

[EE-6417]: https://portainer.atlassian.net/browse/EE-6417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ