### PR TITLE
fix(system): reduce log verbosity for Docker connection error [EE-5372]

### DIFF
--- a/api/platform/platform.go
+++ b/api/platform/platform.go
@@ -65,7 +65,7 @@ func DetermineContainerPlatform() (ContainerPlatform, error) {
 	info, err := dockerCli.Info(context.Background())
 	if err != nil {
 		if client.IsErrConnectionFailed(err) {
-			log.Warn().
+			log.Debug().
 				Err(err).
 				Msg("failed to retrieve docker info")
 			return "", nil


### PR DESCRIPTION
This simple PR fixes the long standing bug described in #8806.

A Docker socket is not always directly available to the Portainer process. This is common and normal when using remote Portainer agents, and causes excessive, useless and confusing logging messages in Portainer.

This PR changes the logging level for those normal/expected error messages to Debug.
This is aligned with other Debug-level error messages present in Portainer. For example:
```
2024/06/13 09:37PM DBG github.com/portainer/portainer/api/http/security/bouncer.go:286 > HTTP error | error=Unauthorized msg="Invalid JWT token" status_code=401
2024/06/13 09:37PM DBG github.com/portainer/portainer/api/http/middlewares/slow_request_logger.go:33 > slow request | elapsed_ms=138.166153 method=POST url=/api/auth
2024/06/13 09:37PM DBG github.com/portainer/portainer/api/platform/platform.go:70 > failed to retrieve docker info | error="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
2024/06/13 09:37PM DBG github.com/portainer/portainer/api/http/security/bouncer.go:255 > HTTP error | error="unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" msg="Unable to initiate communications with environment" status_code=500
2024/06/13 09:37PM DBG github.com/portainer/portainer/api/http/security/bouncer.go:255 > HTTP error | error="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?" msg="Unable to initiate communications with environment" status_code=500
2024/06/13 09:38PM DBG github.com/portainer/portainer/api/platform/platform.go:70 > failed to retrieve docker info | error="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
```

Closes #8806 
Closes EE-5372 (taken from the linked issue)