### PR TITLE
fix(invalidate): keep invalidate default behaviour [BE-11064]

### DIFF
--- a/app/react-tools/react-query.ts
+++ b/app/react-tools/react-query.ts
@@ -37,9 +37,7 @@ export function withInvalidate(
   return {
     onSuccess() {
       const promise = Promise.all(
-        queryKeysToInvalidate.map((keys) =>
-          queryClient.invalidateQueries(keys, { refetchType: 'none' })
-        )
+        queryKeysToInvalidate.map((keys) => queryClient.invalidateQueries(keys))
       );
       return skipRefresh
         ? undefined // don't wait for queries to refresh before setting state to success


### PR DESCRIPTION
Fixes BE-11064
Ref BE-10957

Revert withInvalidate to use the default invalidate settings again.
https://tanstack.com/query/v4/docs/reference/QueryClient/#queryclientinvalidatequeries