### PR TITLE
refactor: fix linting issues across the codebase

### DIFF
--- a/api/http/handler/endpointedge/endpointedge_status_inspect_test.go
+++ b/api/http/handler/endpointedge/endpointedge_status_inspect_test.go
@@ -152,7 +152,7 @@ func TestMissingEdgeIdentifier(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusForbidden {
-		t.Fatalf(fmt.Sprintf("expected a %d response, found: %d without Edge identifier", http.StatusForbidden, rec.Code))
+		t.Fatalf("expected a %d response, found: %d without Edge identifier", http.StatusForbidden, rec.Code)
 	}
 }
 
@@ -177,7 +177,7 @@ func TestWithEndpoints(t *testing.T) {
 		handler.ServeHTTP(rec, req)
 
 		if rec.Code != test.expectedStatusCode {
-			t.Fatalf(fmt.Sprintf("expected a %d response, found: %d for endpoint ID: %d", test.expectedStatusCode, rec.Code, test.endpoint.ID))
+			t.Fatalf("expected a %d response, found: %d for endpoint ID: %d", test.expectedStatusCode, rec.Code, test.endpoint.ID)
 		}
 	}
 }
@@ -217,7 +217,7 @@ func TestLastCheckInDateIncreases(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf(fmt.Sprintf("expected a %d response, found: %d", http.StatusOK, rec.Code))
+		t.Fatalf("expected a %d response, found: %d", http.StatusOK, rec.Code)
 	}
 
 	updatedEndpoint, err := handler.DataStore.Endpoint().Endpoint(endpoint.ID)
@@ -260,7 +260,7 @@ func TestEmptyEdgeIdWithAgentPlatformHeader(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf(fmt.Sprintf("expected a %d response, found: %d with empty edge ID", http.StatusOK, rec.Code))
+		t.Fatalf("expected a %d response, found: %d with empty edge ID", http.StatusOK, rec.Code)
 	}
 
 	updatedEndpoint, err := handler.DataStore.Endpoint().Endpoint(endpoint.ID)
@@ -326,7 +326,7 @@ func TestEdgeStackStatus(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf(fmt.Sprintf("expected a %d response, found: %d", http.StatusOK, rec.Code))
+		t.Fatalf("expected a %d response, found: %d", http.StatusOK, rec.Code)
 	}
 
 	var data endpointEdgeStatusInspectResponse
@@ -390,7 +390,7 @@ func TestEdgeJobsResponse(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf(fmt.Sprintf("expected a %d response, found: %d", http.StatusOK, rec.Code))
+		t.Fatalf("expected a %d response, found: %d", http.StatusOK, rec.Code)
 	}
 
 	var data endpointEdgeStatusInspectResponse

--- a/api/http/handler/stacks/stack_associate.go
+++ b/api/http/handler/stacks/stack_associate.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/stacks/stackutils"
@@ -94,8 +95,8 @@ func (handler *Handler) stackAssociate(w http.ResponseWriter, r *http.Request) *
 		return httperror.InternalServerError("Unable to verify user authorizations to validate stack deletion", err)
 	}
 	if !canManage {
-		errMsg := "Stack management is disabled for non-admin users"
-		return httperror.Forbidden(errMsg, fmt.Errorf(errMsg))
+		errMsg := "stack management is disabled for non-admin users"
+		return httperror.Forbidden(errMsg, errors.New(errMsg))
 	}
 
 	stack.EndpointID = portainer.EndpointID(endpointID)

--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -109,7 +109,7 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 	}
 	if !canManage {
 		errMsg := "stack deletion is disabled for non-admin users"
-		return httperror.Forbidden(errMsg, fmt.Errorf(errMsg))
+		return httperror.Forbidden(errMsg, errors.New(errMsg))
 	}
 
 	// stop scheduler updates of the stack before removal
@@ -307,7 +307,7 @@ func (handler *Handler) stackDeleteKubernetesByName(w http.ResponseWriter, r *ht
 		}
 		if !canManage {
 			errMsg := "stack deletion is disabled for non-admin users"
-			return httperror.Forbidden(errMsg, fmt.Errorf(errMsg))
+			return httperror.Forbidden(errMsg, errors.New(errMsg))
 		}
 
 		stacksToDelete = append(stacksToDelete, stack)


### PR DESCRIPTION
This PR addresses the linting issues on the server side that are reported when running a recent version of golangci-lint.