### PR TITLE
service: update stop grace period description

### DIFF
--- a/app/docker/views/services/edit/includes/container-specs.html
+++ b/app/docker/views/services/edit/includes/container-specs.html
@@ -40,7 +40,9 @@
             <td>Stop grace period</td>
             <td>{{ service.StopGracePeriod }}</td>
             <td>
-              <p class="small text-muted" style="margin-top: 10px"> Time to wait before force killing a container (default none). </p>
+              <p class="small text-muted" style="margin-top: 10px">
+                The duration to wait before forcefully terminating a container (default: 10 seconds as defined by the Docker engine).
+              </p>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
This PR replaces https://github.com/portainer/portainer/pull/10628 and introduces a clearer description for the StopGracePeriod parameter of a service.

Thanks @PzaThief for the contribution.

Related to https://linear.app/portainer/issue/BE-10125/[community-contribution]-consider-10s-stopgraceperiod-for-docker