### PR TITLE
fix(containers): correct base URL construction for console access

### DIFF
--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -57,7 +57,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
             id: attachId,
           };
 
-          const base = window.location.origin.startsWith('http') ? `${window.location.origin}${baseHref()}` : baseHref();
+          const base = window.location.origin.startsWith('http') && !window.ddExtension ? `${window.location.origin}${baseHref()}` : baseHref();
           var url =
             base +
             'api/websocket/attach?' +
@@ -96,7 +96,7 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
             id: data.Id,
           };
 
-          const base = window.location.origin.startsWith('http') ? `${window.location.origin}${baseHref()}` : baseHref();
+          const base = window.location.origin.startsWith('http') && !window.ddExtension ? `${window.location.origin}${baseHref()}` : baseHref();
           var url =
             base +
             'api/websocket/exec?' +

--- a/app/docker/views/containers/console/containerConsoleController.js
+++ b/app/docker/views/containers/console/containerConsoleController.js
@@ -23,6 +23,10 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
       connected: 2,
     });
 
+    const isHttpOrigin = window.location.origin.startsWith('http');
+    const isNotDdExtension = !window.ddExtension;
+    const base = isHttpOrigin && isNotDdExtension ? `${window.location.origin}${baseHref()}` : baseHref();
+
     $scope.loaded = false;
     $scope.states = states;
     $scope.state = states.disconnected;
@@ -57,7 +61,6 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
             id: attachId,
           };
 
-          const base = window.location.origin.startsWith('http') && !window.ddExtension ? `${window.location.origin}${baseHref()}` : baseHref();
           var url =
             base +
             'api/websocket/attach?' +
@@ -96,7 +99,6 @@ angular.module('portainer.docker').controller('ContainerConsoleController', [
             id: data.Id,
           };
 
-          const base = window.location.origin.startsWith('http') && !window.ddExtension ? `${window.location.origin}${baseHref()}` : baseHref();
           var url =
             base +
             'api/websocket/exec?' +


### PR DESCRIPTION
closes #12190 <!-- Github issue number (remove if unknown) -->
 <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:

Fixed an issue where the base URL for WebSocket connection in the console was being duplicated. The base href and window.location.origin were both set to "http://localhost:49000", resulting in a duplicated URL like "http://localhost:49000http://localhost:49000". 

This fix ensures that the base URL is properly constructed without duplication.


This is my first contribution to any open-source project, so I look forward to your feedback and guidance!
