### PR TITLE
chore(docker): add OCI source annotation as a label to the Docker images

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -2,6 +2,7 @@ FROM portainer/base as production
 
 LABEL org.opencontainers.image.title="Portainer" \
   org.opencontainers.image.description="Docker container management made simple, with the world’s most popular GUI-based container management platform." \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   org.opencontainers.image.vendor="Portainer.io" \
   com.docker.desktop.extension.api.version=">= 0.2.2" \
   com.docker.desktop.extension.icon="https://portainer-io-assets.sfo2.cdn.digitaloceanspaces.com/logos/portainer.png" \

--- a/build/linux/alpine.Dockerfile
+++ b/build/linux/alpine.Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:latest as production
 
 LABEL org.opencontainers.image.title="Portainer" \
     org.opencontainers.image.description="Docker container management made simple, with the world’s most popular GUI-based container management platform." \
+    org.opencontainers.image.source="https://github.com/portainer/portainer" \
     org.opencontainers.image.vendor="Portainer.io" \
     com.docker.desktop.extension.api.version=">= 0.2.2" \
     com.docker.desktop.extension.icon="https://portainer-io-assets.sfo2.cdn.digitaloceanspaces.com/logos/portainer.png" \


### PR DESCRIPTION
closes #12271 

### Changes:

Add new Docker label `org.opencontainers.image.source` with this repositories URL as the value to the Docker images. 

This improves the integration with dependency management tools, as described in the related issue https://github.com/orgs/portainer/discussions/12271
