### PR TITLE
feat: update semver matching

### DIFF
--- a/api/datastore/migrate_data_test.go
+++ b/api/datastore/migrate_data_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/database/boltdb"
 	"github.com/portainer/portainer/api/database/models"

--- a/api/datastore/migrator/migrate_ce.go
+++ b/api/datastore/migrator/migrate_ce.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	portainer "github.com/portainer/portainer/api"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog/log"
 )
 

--- a/api/datastore/migrator/migrator.go
+++ b/api/datastore/migrator/migrator.go
@@ -3,7 +3,7 @@ package migrator
 import (
 	"errors"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/database/models"
 	"github.com/portainer/portainer/api/dataservices/dockerhub"

--- a/api/docker/container.go
+++ b/api/docker/container.go
@@ -9,7 +9,7 @@ import (
 	dockerclient "github.com/portainer/portainer/api/docker/client"
 	"github.com/portainer/portainer/api/docker/images"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"

--- a/api/http/handler/system/version.go
+++ b/api/http/handler/system/version.go
@@ -11,7 +11,7 @@ import (
 	httperror "github.com/portainer/portainer/pkg/libhttp/error"
 	"github.com/portainer/portainer/pkg/libhttp/response"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog/log"
 	"github.com/segmentio/encoding/json"
 )
@@ -119,7 +119,7 @@ func HasNewerVersion(currentVersion, latestVersion string) bool {
 		return false
 	}
 
-	return currentVersionSemver.LessThan(*latestVersionSemver)
+	return currentVersionSemver.LessThan(latestVersionSemver)
 }
 
 // @id Version

--- a/api/http/handler/system/version_test.go
+++ b/api/http/handler/system/version_test.go
@@ -18,6 +18,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHasNewerVersion(t *testing.T) {
+	// Test cases
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		expected       bool
+	}{
+		{
+			name:           "current version is less than latest version",
+			currentVersion: "2.22.0",
+			latestVersion:  "v2.22.1",
+			expected:       true,
+		},
+		{
+			name:           "current version is equal to latest version",
+			currentVersion: "2.22.0",
+			latestVersion:  "v2.22.0",
+			expected:       false,
+		},
+		{
+			name:           "current version is greater than latest version",
+			currentVersion: "v2.22.2",
+			latestVersion:  "v2.22.1",
+			expected:       false,
+		},
+		{
+			name:           "invalid current version",
+			currentVersion: "invalid",
+			latestVersion:  "v2.22.0",
+			expected:       false,
+		},
+		{
+			name:           "invalid latest version",
+			currentVersion: "2.22.0",
+			latestVersion:  "invalid",
+			expected:       false,
+		},
+		{
+			name:           "both versions are invalid",
+			currentVersion: "invalid",
+			latestVersion:  "invalid",
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasNewerVersion(tt.currentVersion, tt.latestVersion)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func Test_getSystemVersion(t *testing.T) {
 	is := assert.New(t)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/portainer/portainer
 go 1.22.7
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/VictoriaMetrics/fastcache v1.12.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
@@ -12,7 +12,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.14.0
 	github.com/cbroglie/mustache v1.4.0
 	github.com/containers/image/v5 v5.30.1
-	github.com/coreos/go-semver v0.3.0
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/docker/cli v26.0.1+incompatible
 	github.com/docker/docker v26.1.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
@@ -77,8 +77,6 @@ github.com/containers/ocicrypt v1.1.9 h1:2Csfba4jse85Raxk5HIyEk8OwZNjRvfkhEGijOj
 github.com/containers/ocicrypt v1.1.9/go.mod h1:dTKx1918d8TDkxXvarscpNVY+lyPakPNFN4jwA9GBys=
 github.com/containers/storage v1.53.0 h1:VSES3C/u1pxjTJIXvLrSmyP7OBtDky04oGu07UvdTEA=
 github.com/containers/storage v1.53.0/go.mod h1:pujcoOSc+upx15Jirdkebhtd8uJiLwbSd/mYT6zDJK8=
-github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
-github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=


### PR DESCRIPTION
Related to https://linear.app/portainer/issue/BE-11280/cve-2024-33662

This PR introduces the following changes:

* Replace the use of the coreos-gosemver library to standardize on Masterminds/semver
* Standardize to use "github.com/Masterminds/semver/v3" across all the codebase
* Introduce unit tests for the HasNewerVersion logic