### PR TITLE
fix(templates): RAM displays should be base 2

### DIFF
--- a/app/docker/components/host-view-panels/host-details-panel/host-details-panel.html
+++ b/app/docker/components/host-view-panels/host-details-panel/host-details-panel.html
@@ -23,7 +23,7 @@
             </tr>
             <tr>
               <td>Total memory</td>
-              <td>{{ $ctrl.host.totalMemory | humansize }}</td>
+              <td>{{ $ctrl.host.totalMemory | humansize:0:2 }}</td>
             </tr>
             <tr ng-if="$ctrl.isBrowseEnabled">
               <td colspan="2">

--- a/app/react/docker/DashboardView/EnvironmentInfo.SnapshotStats.tsx
+++ b/app/react/docker/DashboardView/EnvironmentInfo.SnapshotStats.tsx
@@ -23,7 +23,7 @@ export function SnapshotStats({
       </span>
       <span className="flex gap-1 items-center">
         <Icon icon={memoryIcon} />
-        {humanize(snapshot.TotalMemory)}
+        {humanize(snapshot.TotalMemory, 0, 2)}
       </span>
     </span>
   );

--- a/app/react/portainer/HomeView/EnvironmentList/EnvironmentItem/EnvironmentStatsDocker.tsx
+++ b/app/react/portainer/HomeView/EnvironmentList/EnvironmentItem/EnvironmentStatsDocker.tsx
@@ -57,7 +57,7 @@ export function EnvironmentStatsDocker({ snapshot }: Props) {
 
       <StatsItem
         icon={Memory}
-        value={`${humanize(snapshot.TotalMemory)} RAM`}
+        value={`${humanize(snapshot.TotalMemory, 0, 2)} RAM`}
       />
 
       {snapshot.Swarm && (


### PR DESCRIPTION
closes #4497

### Changes:
Updates locations where RAM was being displayed to use base 2 logic. This prevents RAM from being over-reported, with it now showing the same RAM that `top` displays for the system its running on.

Before:
![image](https://github.com/user-attachments/assets/494ee776-7df2-4141-9227-44894e887104)

After:
![image](https://github.com/user-attachments/assets/c19cb9b6-f25a-4201-a63e-f478f77bc8ea)
