### PR TITLE
fix(ui): ambiguous OIDC placeholder (#12539)

### DIFF
--- a/app/portainer/oauth/components/oauth-settings/oauth-settings.html
+++ b/app/portainer/oauth/components/oauth-settings/oauth-settings.html
@@ -349,7 +349,7 @@
           class="form-control"
           id="oauth_scopes"
           ng-model="$ctrl.settings.Scopes"
-          placeholder="id,email,name"
+          placeholder="openid profile email"
           ng-class="['form-control', { 'limited-be': $ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom' }]"
           ng-disabled="$ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom'"
         />


### PR DESCRIPTION
closes #12539

### Changes:

- Replaces commas with whitespaces in "Scopes" field placeholder.