### PR TITLE
feat(image-details): display image digest

### DIFF
--- a/app/docker/models/imageDetails.ts
+++ b/app/docker/models/imageDetails.ts
@@ -5,6 +5,8 @@ type ImageInspectConfig = NonNullable<ImageInspect['Config']>;
 export class ImageDetailsViewModel {
   Id: ImageInspect['Id'];
 
+  RepoDigests: ImageInspect['RepoDigests'];
+
   Parent: ImageInspect['Parent'];
 
   Created: ImageInspect['Created'];
@@ -41,6 +43,7 @@ export class ImageDetailsViewModel {
 
   constructor(data: ImageInspect) {
     this.Id = data.Id;
+    this.RepoDigests = data.RepoDigests;
     // this.Tag = data.Tag; // doesn't seem to be used?
     this.Parent = data.Parent;
     this.Created = data.Created;

--- a/app/docker/views/images/edit/image.html
+++ b/app/docker/views/images/edit/image.html
@@ -122,6 +122,17 @@
                 </button>
               </td>
             </tr>
+            <tr ng-if="image.RepoDigests.length > 0">
+              <td>Digests</td>
+              <td class="datatable">
+                <table class="table-bordered table-condensed table">
+                  <tr ng-repeat="d in image.RepoDigests">
+                    <td>{{ d.includes('@') ? d.substring(0, d.indexOf('@')) : '' }}</td>
+                    <td>{{ d.includes('@') ? d.substring(d.indexOf('@') + 1) : d }}</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
             <tr ng-if="image.Parent">
               <td>Parent</td>
               <td


### PR DESCRIPTION
closes #3554

### Changes:
- **exposed image `RepoDigests` in the image details view**

Screenshots:
- image with no digest
![image](https://github.com/user-attachments/assets/b37eeb7a-a4eb-46b1-95b8-9151ce7c21ac)

- image with digest
![image](https://github.com/user-attachments/assets/73900ccf-6ffd-4109-92d2-7aaf4aac8b02)

### Notes
- if the image has no digest, the row is hidden
- since an image may have more than one digest, the right column is itself a table. Currently this is true even if there's only one digest. We could change this, so that if there's only one digest in the array, a normal row will be shown with _**Digest**_ key on the left and the digest value on the right, and only show _**Digests**_ with a table on the right when there are more than one digests. This would, however, mean almost duplicating the row html code.
- I made the digests table `datatable` class, which removes the bottom margine, which is simmilar to the environmental variables table which also has that class. However, the labels table doesn't have this class and thus has a bottom margin of 20px, is this intentional, or was the `datatable` class missed for that?

**PS**. Force push was to amend the issue reference in the commit message (changed from discussion reference #9595 to issue reference #3554)

26-04-15 Force push: Dropped commits that fixed Dockerfile styling, since those have already been addressed and were causing merge conflicts. Also rebased with the latest branch.
