### PR TITLE
fix(ui/networks): ipvlan IPv6 config missing

### DIFF
--- a/app/docker/views/networks/create/createnetwork.html
+++ b/app/docker/views/networks/create/createnetwork.html
@@ -147,7 +147,7 @@
               </div>
             </div>
           </div>
-          <div ng-show="config.Driver === 'bridge' || (config.Driver === 'macvlan' && formValues.Macvlan.Scope !== 'swarm')">
+          <div ng-show="config.Driver === 'bridge' || config.Driver === 'ipvlan' || (config.Driver === 'macvlan' && formValues.Macvlan.Scope !== 'swarm')">
             <div class="col-sm-12 form-section-title"> IPV6 Network configuration </div>
             <!-- subnet-gateway-inputs -->
             <div class="form-group">


### PR DESCRIPTION
closes #12531 


### Changes:

When creating a new ipvlan network, the IPv6 address fields are not shown. This commit changes the UI to show and act on IPv6 addresses when creating a new ipvlan network.