### PR TITLE
Add Chinese language support framework

### DIFF
--- a/app/i18n.ts
+++ b/app/i18n.ts
@@ -10,8 +10,13 @@ i18n
   .init({
     debug: true,
     fallbackLng: 'en',
+    supportedLngs: ['en', 'zh'],
     interpolation: {
       escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'htmlTag', 'path', 'navigator'],
+      lookupLocalStorage: 'i18nextLng',
     },
   });
 

--- a/app/portainer/components/index.js
+++ b/app/portainer/components/index.js
@@ -9,8 +9,11 @@ import { beFeatureIndicator } from './BEFeatureIndicator';
 import { InformationPanelAngular } from './InformationPanel';
 import { gitFormModule } from './forms/git-form';
 import { tlsFieldsetModule } from './tls-fieldset';
+import './language-settings/language-settings.js'; // Import the new component
 
 export default angular
   .module('portainer.app.components', [boxSelectorModule, widgetModule, gitFormModule, porAccessManagementModule, formComponentsModule, tlsFieldsetModule])
   .component('informationPanel', InformationPanelAngular)
-  .component('beFeatureIndicator', beFeatureIndicator).name;
+  .component('beFeatureIndicator', beFeatureIndicator)
+  // No need to register languageSettings here as it's done in language-settings.js
+  .name;

--- a/app/portainer/components/language-settings/language-settings.controller.js
+++ b/app/portainer/components/language-settings/language-settings.controller.js
@@ -1,0 +1,24 @@
+class LanguageSettingsController {
+  /* @ngInject */
+  constructor(LocalStorage, $window, $i18next) {
+    this.LocalStorage = LocalStorage;
+    this.$window = $window;
+    this.i18n = $i18next;
+
+    this.state = {
+      selectedLanguage: LocalStorage.get('i18nextLng') || 'en',
+    };
+
+    this.changeLanguage = this.changeLanguage.bind(this);
+  }
+
+  changeLanguage() {
+    this.LocalStorage.set('i18nextLng', this.state.selectedLanguage);
+    this.i18n.changeLanguage(this.state.selectedLanguage).then(() => {
+      this.$window.location.reload();
+    });
+  }
+}
+
+export default LanguageSettingsController;
+angular.module('portainer.app').controller('LanguageSettingsController', LanguageSettingsController);

--- a/app/portainer/components/language-settings/language-settings.html
+++ b/app/portainer/components/language-settings/language-settings.html
@@ -1,0 +1,25 @@
+<div class="mt-6">
+  <rd-widget>
+    <rd-widget-header icon="globe" title-text="Language Settings"></rd-widget-header>
+    <rd-widget-body>
+      <form class="form-horizontal">
+        <div class="form-group">
+          <label for="languageSelect" class="col-sm-3 col-lg-2 control-label text-left">
+            Select Language
+          </label>
+          <div class="col-sm-9 col-lg-10">
+            <select
+              id="languageSelect"
+              class="form-control"
+              ng-model="$ctrl.state.selectedLanguage"
+              ng-change="$ctrl.changeLanguage()"
+            >
+              <option value="en">English</option>
+              <option value="zh">中文 (Chinese)</option>
+            </select>
+          </div>
+        </div>
+      </form>
+    </rd-widget-body>
+  </rd-widget>
+</div>

--- a/app/portainer/components/language-settings/language-settings.js
+++ b/app/portainer/components/language-settings/language-settings.js
@@ -1,0 +1,6 @@
+import controller from './language-settings.controller';
+
+angular.module('portainer.app').component('languageSettings', {
+  templateUrl: './language-settings.html',
+  controller,
+});

--- a/app/portainer/views/account/account.html
+++ b/app/portainer/views/account/account.html
@@ -8,6 +8,12 @@
 
 <div class="row">
   <div class="col-lg-12 col-md-12 col-xs-12">
+    <language-settings></language-settings>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-12 col-md-12 col-xs-12">
     <rd-widget>
       <rd-widget-header icon="lock" title-text="Change user password"></rd-widget-header>
       <rd-widget-body>

--- a/translations/zh/translation.json
+++ b/translations/zh/translation.json
@@ -1,0 +1,30 @@
+{
+  "reactExample": {
+    "registries": {
+      "link": "Registries <strong>Link</strong>",
+      "useSref": "Registries useSref"
+    }
+  },
+  "users": {
+    "access-tokens": {
+      "create": {
+        "add-button": "Add access token",
+        "description-field-label": "Description",
+        "done-button": "Done",
+        "form": {
+          "description-field": {
+            "error": {
+              "required": "this field is required"
+            },
+            "label": "Description"
+          }
+        },
+        "new-access-token": {
+          "copy-button": "Copy access token",
+          "explanation": "Please copy the new access token. You won't be able to view the token again.",
+          "title": "New access token"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change introduces the basic framework for Chinese language support in Portainer.

Key changes:
- Added a Chinese (zh) translation file (initially a copy of the English version) at `translations/zh/translation.json`.
- Updated `app/i18n.ts` to include 'zh' as a supported language and configured the language detector to use `localStorage` (key: `i18nextLng`), HTML tag, path, and browser navigator for language preference.
- Added a new Angular component `languageSettings` that allows you to switch between English and Chinese.
- Integrated the `languageSettings` component into the Account settings page (`app/portainer/views/account/account.html`).

The actual translation of UI strings into Chinese will be handled in subsequent efforts.

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
