### PR TITLE
Fix CE Deploy link to correct CE install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Portainer CE is updated regularly. We aim to do an update release every couple o
 
 ## Getting started
 
-- [Deploy Portainer](https://docs.portainer.io/start/install)
+- [Deploy Portainer](https://docs.portainer.io/start/install-ce)
 - [Documentation](https://docs.portainer.io)
 - [Contribute to the project](https://docs.portainer.io/contribute/contribute)
 


### PR DESCRIPTION
Hey, I just noticed the link right under the CE latest version is to the install docs for Business Edition. Since this is the CE repo, it should be to the CE deploy instructions.

### Changes:
Fix deploy link to correct documentation.