### PR TITLE
Fix Container Health Status Not Displayed Correctly in Dashboard #12319

### DIFF
--- a/api/docker/container_stats.go
+++ b/api/docker/container_stats.go
@@ -1,6 +1,11 @@
 package docker
 
-import "github.com/docker/docker/api/types"
+import (
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/rs/zerolog/log"
+)
 
 type ContainerStats struct {
 	Running   int `json:"running"`
@@ -13,17 +18,20 @@ type ContainerStats struct {
 func CalculateContainerStats(containers []types.Container) ContainerStats {
 	var running, stopped, healthy, unhealthy int
 	for _, container := range containers {
+		log.Debug().Str("containerId", container.ID).Str("state", container.State).Str("status", container.Status).Msg("Container info")
+
 		switch container.State {
 		case "running":
 			running++
-		case "healthy":
-			running++
-			healthy++
-		case "unhealthy":
-			running++
-			unhealthy++
 		case "exited", "stopped":
 			stopped++
+		}
+
+		if strings.Contains(container.Status, "(healthy)") {
+			healthy++
+		}
+		if strings.Contains(container.Status, "(unhealthy)") {
+			unhealthy++
 		}
 	}
 

--- a/api/docker/stats/container_stats.go
+++ b/api/docker/stats/container_stats.go
@@ -1,4 +1,4 @@
-package docker
+package stats
 
 import (
 	"strings"
@@ -20,18 +20,19 @@ func CalculateContainerStats(containers []types.Container) ContainerStats {
 	for _, container := range containers {
 		log.Debug().Str("containerId", container.ID).Str("state", container.State).Str("status", container.Status).Msg("Container info")
 
-		switch container.State {
-		case "running":
-			running++
-		case "exited", "stopped":
-			stopped++
-		}
-
 		if strings.Contains(container.Status, "(healthy)") {
+			running++
 			healthy++
-		}
-		if strings.Contains(container.Status, "(unhealthy)") {
+		} else if strings.Contains(container.Status, "(unhealthy)") {
+			running++
 			unhealthy++
+		} else {
+			switch container.State {
+			case "running":
+				running++
+			case "exited", "stopped":
+				stopped++
+			}
 		}
 	}
 

--- a/api/docker/stats/container_stats.go
+++ b/api/docker/stats/container_stats.go
@@ -20,19 +20,17 @@ func CalculateContainerStats(containers []types.Container) ContainerStats {
 	for _, container := range containers {
 		log.Debug().Str("containerId", container.ID).Str("state", container.State).Str("status", container.Status).Msg("Container info")
 
-		if strings.Contains(container.Status, "(healthy)") {
+		switch container.State {
+		case "running":
 			running++
+		case "exited", "stopped":
+			stopped++
+		}
+
+		if strings.Contains(container.Status, "(healthy)") {
 			healthy++
 		} else if strings.Contains(container.Status, "(unhealthy)") {
-			running++
 			unhealthy++
-		} else {
-			switch container.State {
-			case "running":
-				running++
-			case "exited", "stopped":
-				stopped++
-			}
 		}
 	}
 

--- a/api/docker/stats/container_stats_test.go
+++ b/api/docker/stats/container_stats_test.go
@@ -1,4 +1,4 @@
-package docker
+package stats
 
 import (
 	"testing"
@@ -10,11 +10,11 @@ import (
 func TestCalculateContainerStats(t *testing.T) {
 	containers := []types.Container{
 		{State: "running"},
-		{State: "running"},
+		{State: "running", Status: "Up 5 minutes (healthy)"},
 		{State: "exited"},
 		{State: "stopped"},
-		{State: "healthy"},
-		{State: "unhealthy"},
+		{State: "running", Status: "Up 10 minutes"},
+		{State: "running", Status: "Up about an hour (unhealthy)"},
 	}
 
 	stats := CalculateContainerStats(containers)

--- a/api/http/handler/docker/dashboard.go
+++ b/api/http/handler/docker/dashboard.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/dataservices"
-	"github.com/portainer/portainer/api/docker"
+	"github.com/portainer/portainer/api/docker/stats"
 	"github.com/portainer/portainer/api/http/errors"
 	"github.com/portainer/portainer/api/http/handler/docker/utils"
 	"github.com/portainer/portainer/api/http/middlewares"
@@ -26,12 +26,12 @@ type imagesCounters struct {
 }
 
 type dashboardResponse struct {
-	Containers docker.ContainerStats `json:"containers"`
-	Services   int                   `json:"services"`
-	Images     imagesCounters        `json:"images"`
-	Volumes    int                   `json:"volumes"`
-	Networks   int                   `json:"networks"`
-	Stacks     int                   `json:"stacks"`
+	Containers stats.ContainerStats `json:"containers"`
+	Services   int                  `json:"services"`
+	Images     imagesCounters       `json:"images"`
+	Volumes    int                  `json:"volumes"`
+	Networks   int                  `json:"networks"`
+	Stacks     int                  `json:"stacks"`
 }
 
 // @id dockerDashboard
@@ -150,7 +150,7 @@ func (h *Handler) dashboard(w http.ResponseWriter, r *http.Request) *httperror.H
 				Size:  totalSize,
 			},
 			Services:   len(services),
-			Containers: docker.CalculateContainerStats(containers),
+			Containers: stats.CalculateContainerStats(containers),
 			Networks:   len(networks),
 			Volumes:    len(volumes),
 			Stacks:     stackCount,

--- a/app/react/docker/DashboardView/ContainerStatus.tsx
+++ b/app/react/docker/DashboardView/ContainerStatus.tsx
@@ -30,7 +30,7 @@ export function ContainerStatus({ stats }: Props) {
           {stats.healthy} healthy
         </div>
         <div className="vertical-center space-right">
-          <Icon icon={Heart} mode="danger" size="sm" />
+          <Icon icon={Heart} mode="warning" size="sm" />
           {stats.unhealthy} unhealthy
         </div>
       </div>

--- a/pkg/snapshot/docker.go
+++ b/pkg/snapshot/docker.go
@@ -10,6 +10,7 @@ import (
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/docker/consts"
+	"github.com/portainer/portainer/api/docker/stats"
 	edgeutils "github.com/portainer/portainer/pkg/edge"
 	networkingutils "github.com/portainer/portainer/pkg/networking"
 
@@ -207,7 +208,7 @@ func dockerSnapshotContainers(snapshot *portainer.DockerSnapshot, cli *client.Cl
 	snapshot.GpuUseAll = gpuUseAll
 	snapshot.GpuUseList = gpuUseList
 
-	stats := calculateContainerStats(containers)
+	stats := stats.CalculateContainerStats(containers)
 
 	snapshot.ContainerCount = stats.Total
 	snapshot.RunningContainerCount = stats.Running
@@ -343,41 +344,4 @@ func isPodman(version types.Version) bool {
 	}
 
 	return false
-}
-
-type ContainerStats struct {
-	Running   int
-	Stopped   int
-	Healthy   int
-	Unhealthy int
-	Total     int
-}
-
-func calculateContainerStats(containers []types.Container) ContainerStats {
-	var running, stopped, healthy, unhealthy int
-	for _, container := range containers {
-		log.Debug().Str("containerId", container.ID).Str("state", container.State).Str("status", container.Status).Msg("Container info")
-
-		switch container.State {
-		case "running":
-			running++
-		case "exited", "stopped":
-			stopped++
-		}
-
-		if strings.Contains(container.Status, "(healthy)") {
-			healthy++
-		}
-		if strings.Contains(container.Status, "(unhealthy)") {
-			unhealthy++
-		}
-	}
-
-	return ContainerStats{
-		Running:   running,
-		Stopped:   stopped,
-		Healthy:   healthy,
-		Unhealthy: unhealthy,
-		Total:     len(containers),
-	}
 }

--- a/pkg/snapshot/docker.go
+++ b/pkg/snapshot/docker.go
@@ -356,17 +356,20 @@ type ContainerStats struct {
 func calculateContainerStats(containers []types.Container) ContainerStats {
 	var running, stopped, healthy, unhealthy int
 	for _, container := range containers {
+		log.Debug().Str("containerId", container.ID).Str("state", container.State).Str("status", container.Status).Msg("Container info")
+
 		switch container.State {
 		case "running":
 			running++
-		case "healthy":
-			running++
-			healthy++
-		case "unhealthy":
-			running++
-			unhealthy++
 		case "exited", "stopped":
 			stopped++
+		}
+
+		if strings.Contains(container.Status, "(healthy)") {
+			healthy++
+		}
+		if strings.Contains(container.Status, "(unhealthy)") {
+			unhealthy++
 		}
 	}
 


### PR DESCRIPTION
closes #12319

### Changes:

- Wrong "0" healthy/unhealthy container count in container stats
- Wrong "0" healthy/unhealthy container count in environment dashboard
- makes "unhealthy" icons in environment dashboard and container stats have the same color (warning)

### Remarks

Changing the docker healthy/unhealthy checks to be made on the `container.Status` string instead of `container.State`.

After the fix in this PR is applied, the stats look all good again:

<img width="1049" height="391" alt="Bildschirmfoto 2025-08-24 um 00 12 47" src="https://github.com/user-attachments/assets/b96ad10f-c37a-4513-b236-e2069144e121" />
<img width="1045" height="301" alt="Bildschirmfoto 2025-08-24 um 00 13 04" src="https://github.com/user-attachments/assets/c40486b4-20dc-4230-9beb-ac52c95a36a8" />
<img width="1042" height="356" alt="Bildschirmfoto 2025-08-24 um 00 13 16" src="https://github.com/user-attachments/assets/24bbb200-84c9-4929-9b04-31cfa35cae86" />

Debug logs of the containers:

```
2025/08/23 09:54PM INF github.com/portainer/portainer/pkg/snapshot/docker.go:359 > Container info | containerId=93a814e02576f3a08c396cb8ddb13c4bf8f79a540063f2aacb983a784f685c56 state=running status="Up Less than a second"
2025/08/23 09:54PM INF github.com/portainer/portainer/pkg/snapshot/docker.go:359 > Container info | containerId=6b22220bdee30cf0876d0ff94c405cf9cd9b5432c1b74bc7fc2f7192b6ef0dc6 state=running status="Up 21 minutes (healthy)"
2025/08/23 09:54PM INF github.com/portainer/portainer/pkg/snapshot/docker.go:359 > Container info | containerId=4329633e1df3cf907ac922ab9cff81ed92c7b95c7cf3db1fa09b7aad31c55a13 state=running status="Up 27 minutes (unhealthy)"
2025/08/23 09:58PM INF github.com/portainer/portainer/api/docker/container_stats.go:21 > Container info | containerId=93a814e02576f3a08c396cb8ddb13c4bf8f79a540063f2aacb983a784f685c56 state=running status="Up 3 minutes"
2025/08/23 09:58PM INF github.com/portainer/portainer/api/docker/container_stats.go:21 > Container info | containerId=6b22220bdee30cf0876d0ff94c405cf9cd9b5432c1b74bc7fc2f7192b6ef0dc6 state=running status="Up 25 minutes (healthy)"
2025/08/23 09:58PM INF github.com/portainer/portainer/api/docker/container_stats.go:21 > Container info | containerId=4329633e1df3cf907ac922ab9cff81ed92c7b95c7cf3db1fa09b7aad31c55a13 state=running status="Up 31 minutes (unhealthy)"
```
