### PR TITLE
fix(database): fix encryption of existing database

### DIFF
--- a/api/datastore/backup.go
+++ b/api/datastore/backup.go
@@ -14,6 +14,15 @@ import (
 // corruption and if a path is not given a default is used.
 // The path or an error are returned.
 func (store *Store) Backup(path string) (string, error) {
+	encryptionReq, err := store.connection.NeedsEncryptionMigration()
+	if err != nil {
+		return "", err
+	}
+
+	if encryptionReq {
+		store.connection.SetEncrypted(false)
+	}
+
 	if err := store.createBackupPath(); err != nil {
 		return "", err
 	}
@@ -25,7 +34,7 @@ func (store *Store) Backup(path string) (string, error) {
 	log.Info().Str("from", store.connection.GetDatabaseFilePath()).Str("to", backupFilename).Msgf("Backing up database")
 
 	// Close the store before backing up
-	err := store.Close()
+	err = store.Close()
 	if err != nil {
 		return "", fmt.Errorf("failed to close store before backup: %w", err)
 	}
@@ -35,10 +44,12 @@ func (store *Store) Backup(path string) (string, error) {
 		return "", fmt.Errorf("failed to create backup file: %w", err)
 	}
 
-	// reopen the store
-	_, err = store.Open()
-	if err != nil {
-		return "", fmt.Errorf("failed to reopen store after backup: %w", err)
+	if !encryptionReq {
+		// reopen the store
+		_, err = store.Open()
+		if err != nil {
+			return "", fmt.Errorf("failed to reopen store after backup: %w", err)
+		}
 	}
 
 	return backupFilename, nil


### PR DESCRIPTION
closes #12765 

### Changes:
- Fixes the error _"failed to backup database prior to encrypting: failed to create backup file: File (/data/portainer.edb) doesn't exist"_ when trying to encrypt an existing Portainer database
- Checks at the beginning of the [Backup function](https://github.com/portainer/portainer/blob/8b73ad3b6f19e7635300f03d5e3f7e48235246e3/api/datastore/backup.go#L16) if the store needs encryption migration
- Uses the correct database filepath in case encryption migration is needed
- Avoids infinite store opening loop by not running store.Open() at the end of the Backup function while doing an encryption migration

### Steps to reproduce/test:
1. Create an empty directory called `portainer_12765` (or whatever)
2. Create a `compose.yml` file with this content:
```
services:
  portainer:
    image: portainer/portainer-ce:sts
    #secrets:
    #  - portainer
    volumes:
      - portainer-data:/data
    command: --secret-key-name=/run/secrets/portainer # This line is necessary because of issue #12825

secrets:
  portainer:
    environment: PORTAINER_SECRET

volumes:
  portainer-data:
```
3. Run `docker compose up -d --wait` (this will set up the non-encrypted database)
4. Run `docker compose down`
5. Uncomment the secrets lines in the `compose.yml` file
```
    secrets:
      - portainer
```
6. Run `PORTAINER_SECRET="this is a secret" docker compose up`

Expected behavior:
Portainer backs up the non-encrypted database and afterwards encrypts the database.
 
Actual behavior without fix:
Portainer fails creating the backup. Here are the logs:
```
portainer-1  | 2025/07/15 08:52AM INF github.com/portainer/portainer/api/datastore/backup.go:25 > Backing up database | from=/data/portainer.edb to=/data/backups/portainer.edb.bak
portainer-1  | 2025/07/15 08:52AM INF github.com/portainer/portainer/api/database/boltdb/db.go:156 > closing PortainerDB |
portainer-1  | 2025/07/15 08:52AM FTL github.com/portainer/portainer/api/cmd/portainer/main.go:103 > failed opening store | error="failed to backup database prior to encrypting: failed to create backup file: File (/data/portainer.edb) doesn't exist"
portainer-1 exited with code 1
```