### PR TITLE
fix(encryption): set correct default secret key path

### DIFF
--- a/api/cmd/portainer/main.go
+++ b/api/cmd/portainer/main.go
@@ -309,13 +309,13 @@ func initKeyPair(fileService portainer.FileService, signatureService portainer.D
 
 // dbSecretPath build the path to the file that contains the db encryption
 // secret. Normally in Docker this is built from the static path inside
-// /run/portainer for example: /run/portainer/<keyFilenameFlag> but for ease of
+// /run/secrets for example: /run/secrets/<keyFilenameFlag> but for ease of
 // use outside Docker it also accepts an absolute path
 func dbSecretPath(keyFilenameFlag string) string {
 	if path.IsAbs(keyFilenameFlag) {
 		return keyFilenameFlag
 	}
-	return path.Join("/run/portainer", keyFilenameFlag)
+	return path.Join("/run/secrets", keyFilenameFlag)
 }
 
 func loadEncryptionSecretKey(keyfilename string) []byte {

--- a/api/cmd/portainer/main_test.go
+++ b/api/cmd/portainer/main_test.go
@@ -43,12 +43,12 @@ func TestDBSecretPath(t *testing.T) {
 		keyFilenameFlag string
 		expected        string
 	}{
-		{keyFilenameFlag: "secret.txt", expected: "/run/portainer/secret.txt"},
+		{keyFilenameFlag: "secret.txt", expected: "/run/secrets/secret.txt"},
 		{keyFilenameFlag: "/tmp/secret.txt", expected: "/tmp/secret.txt"},
-		{keyFilenameFlag: "/run/portainer/secret.txt", expected: "/run/portainer/secret.txt"},
-		{keyFilenameFlag: "./secret.txt", expected: "/run/portainer/secret.txt"},
+		{keyFilenameFlag: "/run/secrets/secret.txt", expected: "/run/secrets/secret.txt"},
+		{keyFilenameFlag: "./secret.txt", expected: "/run/secrets/secret.txt"},
 		{keyFilenameFlag: "../secret.txt", expected: "/run/secret.txt"},
-		{keyFilenameFlag: "foo/bar/secret.txt", expected: "/run/portainer/foo/bar/secret.txt"},
+		{keyFilenameFlag: "foo/bar/secret.txt", expected: "/run/secrets/foo/bar/secret.txt"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
closes #12825

### Changes:
- Change default secret key path from `/run/portainer` to `/run/secrets`

### Comment:
- The [commit](https://github.com/portainer/portainer/commit/2cf1649c670b42479329f9db2de08a82efe6e1fd) on August 11th added the feature to set an absolute path as secret key path - particularly designed for non-docker setups. In that commit the default path was erroneously changed from `/run/secrets` to `/run/portainer`
- This fix keeps the feature to use an absolute secret key path but reverses the change of the default secret key path
- Tests and comments are also adjusted