### PR TITLE
Fix typo in csp

### DIFF
--- a/api/http/security/bouncer.go
+++ b/api/http/security/bouncer.go
@@ -535,7 +535,7 @@ func MWSecureHeaders(next http.Handler, hsts, csp bool) http.Handler {
 		}
 
 		if csp {
-			w.Header().Set("Content-Security-Policy", "script-src 'self' cdn.matomo.cloud js.hsforms.net https://www.google.com/recaptcha/, https://www.gstatic.com/recaptcha/; object-src 'none'; frame-ancestors 'none'; frame-src https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/")
+			w.Header().Set("Content-Security-Policy", "script-src 'self' cdn.matomo.cloud js.hsforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; object-src 'none'; frame-ancestors 'none'; frame-src https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/")
 		}
 
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION


In https://github.com/portainer/portainer/commit/f91a2e3b6582fc7829ce3f661296cb217609e864 some endpoints were added to the Content-Security-Policy Header for recaptcha. I believe this comit has a typo  comma though. `https://www.google.com/recaptcha/,` should be ` https://www.google.com/recaptcha/` unless the path actually begins with a comma, from checking other sites it doesn't seem to and I don't have recaptcha on my instance to test.

### Changes:

small typo fix
