### PR TITLE
fix(oauth): fix format for the scope placeholder

### DIFF
--- a/app/portainer/oauth/components/oauth-settings/oauth-settings.html
+++ b/app/portainer/oauth/components/oauth-settings/oauth-settings.html
@@ -349,7 +349,7 @@
           class="form-control"
           id="oauth_scopes"
           ng-model="$ctrl.settings.Scopes"
-          placeholder="id,email,name"
+          placeholder="id email name"
           ng-class="['form-control', { 'limited-be': $ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom' }]"
           ng-disabled="$ctrl.isLimitedToBE && $ctrl.state.provider !== 'custom'"
         />


### PR DESCRIPTION
### Changes:

The `scope` field use spacing for separation of scopes instead of `,`