### PR TITLE
fix(compose): pass project to start opts for secrets to work again

### DIFF
--- a/pkg/libstack/compose/composeplugin.go
+++ b/pkg/libstack/compose/composeplugin.go
@@ -142,7 +142,11 @@ func (c *ComposeDeployer) Deploy(ctx context.Context, filePaths []string, option
 
 		project = project.WithoutUnnecessaryResources()
 
-		var opts api.UpOptions
+		opts := api.UpOptions{
+			Start: api.StartOptions{
+				Project: project, 
+			},
+		}
 		if options.ForceRecreate {
 			opts.Create.Recreate = api.RecreateForce
 		}


### PR DESCRIPTION
closes #12909

### Changes:
- explicitly pass project to start options on deployment to fix missing secrets and configs

### Reasoning
With the upgrade to docker compose v2.40.2 in portainer the deployment of secrets and configs broke.
After some testing I found out that the breaking change was introduced in v2.37.3 of docker compose.
In 2.37.3 the secrets and configs are injected when containers get started not when they get created.
I immediately assumed that it must have to do something with the passed options and I was right.
Passing the actual project via options solved the issue.

Link to commit diff in docker compose: https://github.com/docker/compose/compare/v2.37.2...v2.37.3
Link to commit commit in docker compose: https://github.com/docker/compose/commit/aadce87b16a496c8dd575e99bfeb46bd7fe590c0
