### PR TITLE
fix: Docker API negotiation when Docker 29 raises its minimum version

### DIFF
--- a/app/portainer/services/dockerMaxApiVersionInterceptor.test.ts
+++ b/app/portainer/services/dockerMaxApiVersionInterceptor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDockerApiVersionOverride } from './dockerMaxApiVersionInterceptor';
+
+describe('getDockerApiVersionOverride', () => {
+  it('returns null when the api version is within supported range', () => {
+    expect(getDockerApiVersionOverride(1.3, 0, 1.41)).toBeNull();
+  });
+
+  it('limits the version to the configured maximum', () => {
+    expect(getDockerApiVersionOverride(1.5, 0, 1.41)).toBe(1.41);
+  });
+
+  it('never downgrades below Docker minimum API version', () => {
+    expect(getDockerApiVersionOverride(1.5, 1.44, 1.41)).toBe(1.44);
+  });
+
+  it('returns null when docker minimum equals the negotiated version', () => {
+    expect(getDockerApiVersionOverride(1.44, 1.44, 1.41)).toBeNull();
+  });
+
+  it('returns null when the api version is missing', () => {
+    expect(getDockerApiVersionOverride(0, 1.44, 1.41)).toBeNull();
+  });
+});

--- a/app/portainer/services/dockerMaxApiVersionInterceptor.ts
+++ b/app/portainer/services/dockerMaxApiVersionInterceptor.ts
@@ -43,12 +43,21 @@ export async function dockerMaxAPIVersionInterceptor(
       );
 
       const apiVersion = parseFloat(data.ApiVersion ?? '0');
+      const minApiVersion = parseFloat(
+        (data as SystemVersion & { MinAPIVersion?: string }).MinAPIVersion ?? '0'
+      );
       const { maxDockerAPIVersion } = config;
 
-      if (apiVersion > maxDockerAPIVersion) {
+      const versionOverride = getDockerApiVersionOverride(
+        apiVersion,
+        minApiVersion,
+        maxDockerAPIVersion
+      );
+
+      if (versionOverride) {
         config.url = config.url?.replace(
           /docker/,
-          `docker/v${maxDockerAPIVersion}`
+          `docker/v${versionOverride}`
         );
       }
     }
@@ -57,4 +66,32 @@ export async function dockerMaxAPIVersionInterceptor(
     // if the interceptor errors, return the original config
     return rawConfig;
   }
+}
+
+export function getDockerApiVersionOverride(
+  apiVersion: number,
+  minApiVersion: number,
+  maxDockerApiVersion: number
+) {
+  const parsedApi = Number.isFinite(apiVersion) ? apiVersion : 0;
+  const parsedMin = Number.isFinite(minApiVersion) ? minApiVersion : 0;
+  const parsedMax = Number.isFinite(maxDockerApiVersion)
+    ? maxDockerApiVersion
+    : 0;
+
+  if (!parsedApi || !parsedMax) {
+    return null;
+  }
+
+  let desiredVersion = Math.min(parsedApi, parsedMax);
+
+  if (parsedMin > 0 && desiredVersion < parsedMin) {
+    desiredVersion = parsedMin;
+  }
+
+  if (desiredVersion === parsedApi) {
+    return null;
+  }
+
+  return desiredVersion;
 }


### PR DESCRIPTION
closes #12939 #12936 #12928 

### Changes:

## Summary
- read Docker’s reported `MinAPIVersion` when negotiating through the axios interceptor
- clamp the requested version so it never drops below Docker’s minimum while still honoring Portainer’s max
- add focused vitest coverage for the new helper

## Testing
- yarn vitest app/portainer/services/dockerMaxApiVersionInterceptor.test.ts
