### PR TITLE
fix(kubernetes): make DescribeModal and CodeEditor resizable [FR-733]

### DIFF
--- a/app/react/components/CodeEditor/CodeEditor.module.css
+++ b/app/react/components/CodeEditor/CodeEditor.module.css
@@ -13,6 +13,9 @@
   --border-codemirror-cursor-color: var(--black-color);
   --bg-tooltip-color: var(--white-color);
   --text-tooltip-color: var(--black-color);
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 :global([theme='dark']) .root {
@@ -205,4 +208,10 @@
 /* override the default content */
 .root :global(.cm-editor .cm-collapsedLines:after) {
   content: '';
+}
+
+.codeEditor :global(.cm-editor) {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }

--- a/app/react/components/CodeEditor/CodeEditor.tsx
+++ b/app/react/components/CodeEditor/CodeEditor.tsx
@@ -135,7 +135,7 @@ export function CodeEditor({
           )}
         </div>
       )}
-      <div className="overflow-hidden rounded-lg border border-solid border-gray-5 th-dark:border-gray-7 th-highcontrast:border-gray-2">
+      <div className="flex flex-col flex-grow overflow-hidden rounded-lg border border-solid border-gray-5 th-dark:border-gray-7 th-highcontrast:border-gray-2">
         {fileName && (
           <FileNameHeaderRow>
             <FileNameHeader

--- a/app/react/components/modals/Modal/Modal.module.css
+++ b/app/react/components/modals/Modal/Modal.module.css
@@ -19,3 +19,10 @@
 [theme='highcontrast'] .modal-content {
   border: 1px solid var(--border-widget);
 }
+
+.modal-dialog.resizable {
+  resize: both;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/app/react/components/modals/Modal/Modal.tsx
+++ b/app/react/components/modals/Modal/Modal.tsx
@@ -23,6 +23,7 @@ interface Props {
   'aria-labelledby'?: string;
   size?: 'md' | 'lg' | 'xl';
   className?: string;
+  resizable?: boolean;
 }
 
 export function Modal({
@@ -32,6 +33,7 @@ export function Modal({
   'aria-labelledby': ariaLabelledBy,
   size = 'md',
   className,
+  resizable
 }: PropsWithChildren<Props>) {
   return (
     <Context.Provider value>
@@ -39,7 +41,7 @@ export function Modal({
         isOpen
         className={clsx(
           styles.overlay,
-          'flex items-center justify-center z-50'
+          'flex items-center justify-center z-50',
         )}
         onDismiss={onDismiss}
         role="dialog"
@@ -54,13 +56,14 @@ export function Modal({
               'w-[450px]': size === 'md',
               'w-[700px]': size === 'lg',
               'w-[1000px]': size === 'xl',
+              [styles.resizable]: resizable
             }
           )}
         >
           <div
             className={clsx(
               styles.modalContent,
-              'relative overflow-y-auto p-5 rounded-lg',
+              'relative overflow-y-auto p-5 rounded-lg flex flex-grow flex-col',
               className
             )}
           >

--- a/app/react/components/modals/Modal/ModalBody.module.css
+++ b/app/react/components/modals/Modal/ModalBody.module.css
@@ -1,4 +1,7 @@
 .modal-body {
   padding: 10px 0px;
   border-bottom: none;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }

--- a/app/react/kubernetes/helm/HelmApplicationView/ReleaseDetails/ResourcesTable/DescribeModal.tsx
+++ b/app/react/kubernetes/helm/HelmApplicationView/ReleaseDetails/ResourcesTable/DescribeModal.tsx
@@ -29,7 +29,7 @@ export function DescribeModal({
   );
 
   return (
-    <Modal onDismiss={onDismiss} size="lg" aria-label={title}>
+    <Modal onDismiss={onDismiss} size="lg" aria-label={title} resizable>
       <ModalHeader title={title} />
       <ModalBody>
         {isLoading ? (


### PR DESCRIPTION
closes #12785
closes [FR-733]

### Changes:

- add new `resizable` prop to Modal component
- adapt css of `Modal`, `DescribeModal`, and `CodeEditor` components to use flexbox and dynamic growth properties

Here is an image of the change, highlighting the resizing arrows of the Modal. In the image, the modal has been resized to a bigger size. One could also discuss about opening the DescribeModal with `xl` size instead of `lg` as default, but I'll leave this up to the maintainers to decide. 😊

<img width="2557" height="1116" alt="ResizingModal" src="https://github.com/user-attachments/assets/a78f1859-32ec-4617-8aa2-3cfe25f5caef" />


