### PR TITLE
fix(ui): change label color for exit code 0

### DIFF
--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/state.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/state.tsx
@@ -65,6 +65,9 @@ function StatusCell({
       case ContainerStatus.Stopped:
       case ContainerStatus.Dead:
       case ContainerStatus.Exited:
+        if (extractExitCode(container.StatusText) == '0') {
+          return 'default'
+        }
         return 'danger';
       case ContainerStatus.Healthy:
       case ContainerStatus.Running:


### PR DESCRIPTION
### Changes:
This changes the label color from "danger" to "default" for exit code 0 to avoid implying that something went wrong.