### PR TITLE
fix(views/auth): update autocomplete attributes for username an…

### DIFF
--- a/app/portainer/views/auth/auth.html
+++ b/app/portainer/views/auth/auth.html
@@ -69,6 +69,7 @@
                 class="form-control"
                 name="username"
                 ng-model="ctrl.formValues.Username"
+                autocomplete="username"
                 auto-focus
                 placeholder="Enter your username"
               />
@@ -84,7 +85,7 @@
                   class="form-control pr-10"
                   name="password"
                   ng-model="ctrl.formValues.Password"
-                  autocomplete="off"
+                  autocomplete="current-password"
                   data-cy="auth-passwordInput"
                   placeholder="Enter your password"
                   ng-trim="false"


### PR DESCRIPTION
…d password fields

closes #8681

### Changes:
This PR changes the autocomplete attributes on the auth page to allow for browser autofill of username and password.
Follows WHATWG spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-current-password