### PR TITLE
fix(encryption): open-encrypted-database-connection-before-import

### DIFF
--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -155,6 +155,15 @@ func (store *Store) encryptDB() error {
 		return err
 	}
 
+	store.connection.SetEncrypted(true)
+	if err := store.connection.Open(); err != nil {
+		return err
+	}
+
+	if err := store.initServices(); err != nil {
+		return err
+	}
+
 	if err := store.Import(exportFilename); err != nil {
 		log.Error().Err(err).Msg("failed to import database backup")
 


### PR DESCRIPTION
closes #12765

### Changes:
- Fix error `"database not open"` when trying to import the exported json file into the encrypted database.
- Set connection encryption to true, re-open the connection and restart services before import

### Steps to reproduce/test:
1. Create an empty directory called `portainer_12765` (or whatever)
2. Create a `compose.yml` file with this content:
```
services:
  portainer:
    image: portainer/portainer-ce:lts
    #secrets:
    #  - portainer
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock

secrets:
  portainer:
    environment: PORTAINER_SECRET
```
3. Run `docker compose up --wait` (this will set up the non-encrypted database)
4. Uncomment the secrets lines in the `compose.yml` file
```
    secrets:
      - portainer
```
5. Run `PORTAINER_SECRET="this is a secret" docker compose up`

Expected behavior: Database gets encrypted and Portainer starts

Actual behavior: Empty encrypted database gets created, the data from the old database does not get imported.

Logs:
```
INF github.com/portainer/portainer/api/datastore/backup.go:45 > Backing up database | from=/data/portainer.db to=/data/backups/portainer.db.bak
INF github.com/portainer/portainer/api/database/boltdb/db.go:137 > loading PortainerDB | filename=portainer.db
INF github.com/portainer/portainer/api/datastore/datastore.go:138 > encrypting database |
INF github.com/portainer/portainer/api/datastore/datastore.go:143 > exporting database backup | filename=/data/portainer.db.backup-1772147604.json
INF github.com/portainer/portainer/api/datastore/datastore.go:151 > database backup exported |
INF github.com/portainer/portainer/api/database/boltdb/db.go:173 > closing PortainerDB |
ERR github.com/portainer/portainer/api/datastore/datastore.go:159 > failed to import database backup | error="database not open"
FTL github.com/portainer/portainer/api/datastore/datastore.go:166 > error="importing backup failed"
```