### PR TITLE
fix(app/container): handle empty health log array in HealthStatus

### DIFF
--- a/app/react/docker/containers/ItemView/HealthStatus.tsx
+++ b/app/react/docker/containers/ItemView/HealthStatus.tsx
@@ -44,7 +44,7 @@ export function HealthStatus({ health }: Props) {
           <div className="vertical-center">{health.FailingStreak}</div>
         </DetailsTable.Row>
 
-        {!!health.Log && (
+        {!!health.Log && health.Log.length > 0 && (
           <DetailsTable.Row label="Last output">
             {health.Log[health.Log.length - 1].Output}
           </DetailsTable.Row>


### PR DESCRIPTION
Fixes #13077

### Changes:
- Added check for non-empty health log array before accessing the last element in `HealthStatus.tsx`

The issue occurred when a container had an empty `health.Log` array. The existing condition `!!health.Log` would pass for empty arrays, but accessing `health.Log[health.Log.length - 1]` returns `undefined`, causing a TypeError when trying to read `.Output`.

The fix adds `health.Log.length > 0` to the condition to ensure the array has at least one element before attempting to access it.

```diff
-        {!!health.Log && (
+        {!!health.Log && health.Log.length > 0 && (
```