### PR TITLE
fix(images): fix image export request params for Docker API

### DIFF
--- a/app/react/docker/images/queries/useExportImageMutation.test.ts
+++ b/app/react/docker/images/queries/useExportImageMutation.test.ts
@@ -185,8 +185,8 @@ describe('exportImage', () => {
     });
 
     const url = new URL(requestUrl);
-    // Axios serializes array params with brackets: names[]=value1&names[]=value2
-    const names = url.searchParams.getAll('names[]');
+    // Docker API expects repeated params: names=value1&names=value2
+    const names = url.searchParams.getAll('names');
     expect(names).toEqual(['nginx:latest', 'redis:alpine']);
     expect(saveAs).toHaveBeenCalled();
   });
@@ -217,7 +217,7 @@ describe('exportImage', () => {
     });
 
     const url = new URL(requestUrl);
-    const names = url.searchParams.getAll('names[]');
+    const names = url.searchParams.getAll('names');
     expect(names).toEqual([
       'nginx:latest',
       'sha256:def456',

--- a/app/react/docker/images/queries/useExportImageMutation.ts
+++ b/app/react/docker/images/queries/useExportImageMutation.ts
@@ -7,6 +7,7 @@ import { EnvironmentId } from '@/react/portainer/environments/types';
 import { useEnvironmentId } from '@/react/hooks/useEnvironmentId';
 
 import { buildDockerProxyUrl } from '../../proxy/queries/buildDockerProxyUrl';
+import { formatArrayQueryParamsForDockerAPI } from '../../proxy/queries/utils';
 
 export function useExportMutation() {
   const environmentId = useEnvironmentId();
@@ -43,6 +44,7 @@ export async function exportImage({
         params: {
           names,
         },
+        paramsSerializer: formatArrayQueryParamsForDockerAPI,
       }
     );
 


### PR DESCRIPTION
closes #13084 <!-- Github issue number (remove if unknown) -->

### Changes:
- fixed image export params so Docker reads the selected images correctly
- stopped `names[]` from being sent, which was causing tiny (~3KB) export files
- updated tests to check the correct `names` query format