### PR TITLE
feat(containers): add per-container CPU, memory, and block I/O columns to container list

### DIFF
--- a/api/docker/stats/container_metrics.go
+++ b/api/docker/stats/container_metrics.go
@@ -1,0 +1,303 @@
+package stats
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/logs"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/rs/zerolog/log"
+	"github.com/segmentio/encoding/json"
+)
+
+// DockerStatsClient is the subset of the Docker client API used for fetching
+// per-container resource usage stats.
+type DockerStatsClient interface {
+	ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
+}
+
+// deltaEntry stores blkio cumulative counters so a bytes/second rate can be
+// derived on the next poll. Entries are lost on Portainer restart; the first
+// reading after restart shows 0 rate until the second poll.
+type deltaEntry struct {
+	blkRead   uint64
+	blkWrite  uint64
+	sampledAt time.Time
+}
+
+// MetricsCache is a process-scoped, in-memory store of previous blkio
+// readings keyed by "endpointID/containerID". It is pruned on every poll to
+// contain only currently-running containers.
+type MetricsCache struct {
+	mu    sync.Mutex
+	store map[string]deltaEntry
+}
+
+// NewMetricsCache allocates a ready-to-use MetricsCache.
+func NewMetricsCache() *MetricsCache {
+	return &MetricsCache{
+		store: make(map[string]deltaEntry),
+	}
+}
+
+// ContainerMetric is the per-container resource-usage payload returned by the
+// metrics endpoint.
+type ContainerMetric struct {
+	ContainerID    string  `json:"containerId"`
+	ContainerName  string  `json:"containerName"`
+	CPUPercent     float64 `json:"cpuPercent"`
+	CPUAvailable   bool    `json:"cpuAvailable"`
+	MemoryUsage    uint64  `json:"memoryUsage"`
+	MemoryLimit    uint64  `json:"memoryLimit"`
+	MemoryPercent  float64 `json:"memoryPercent"`
+	BlockReadRate  float64 `json:"blockReadRate"`
+	BlockWriteRate float64 `json:"blockWriteRate"`
+	BlkioAvailable bool    `json:"blkioAvailable"`
+}
+
+// dockerRawStats is the decode target for the Docker /containers/{id}/stats
+// stream=false JSON response. Only the fields we use are mapped.
+type dockerRawStats struct {
+	CPUStats    cpuStats    `json:"cpu_stats"`
+	PreCPUStats cpuStats    `json:"precpu_stats"`
+	MemoryStats memoryStats `json:"memory_stats"`
+	BlkioStats  blkioStats  `json:"blkio_stats"`
+}
+
+type cpuStats struct {
+	CPUUsage       cpuUsage `json:"cpu_usage"`
+	SystemCPUUsage uint64   `json:"system_cpu_usage"`
+	OnlineCPUs     int      `json:"online_cpus"`
+}
+
+type cpuUsage struct {
+	TotalUsage uint64 `json:"total_usage"`
+}
+
+type memoryStats struct {
+	Usage uint64            `json:"usage"`
+	Limit uint64            `json:"limit"`
+	Stats map[string]uint64 `json:"stats"`
+}
+
+type blkioStats struct {
+	IOServiceBytesRecursive []blkioEntry `json:"io_service_bytes_recursive"`
+}
+
+type blkioEntry struct {
+	Op    string `json:"op"`
+	Value uint64 `json:"value"`
+}
+
+// containerMetricResult carries both the public metric and the raw blkio
+// counters needed to update the delta cache.
+type containerMetricResult struct {
+	metric   ContainerMetric
+	rawRead  uint64
+	rawWrite uint64
+}
+
+// FetchContainerMetrics calls /containers/{id}/stats?stream=false for each
+// container concurrently (semaphore of 5, matching CalculateContainerStats).
+// Individual container failures are logged and skipped. The cache is pruned
+// after each poll so entries for stopped containers are removed.
+func FetchContainerMetrics(
+	ctx context.Context,
+	cli DockerStatsClient,
+	endpointID portainer.EndpointID,
+	containers []container.Summary,
+	cache *MetricsCache,
+) ([]ContainerMetric, error) {
+	var (
+		mu      sync.Mutex
+		wg      sync.WaitGroup
+		results = make([]containerMetricResult, 0, len(containers))
+	)
+
+	semaphore := make(chan struct{}, 5)
+
+	// Snapshot existing cache entries before the parallel fetch so every
+	// goroutine sees a consistent baseline from the previous poll.
+	cache.mu.Lock()
+	prevEntries := make(map[string]deltaEntry, len(cache.store))
+	for k, v := range cache.store {
+		prevEntries[k] = v
+	}
+	cache.mu.Unlock()
+
+	now := time.Now()
+
+	for i := range containers {
+		c := containers[i]
+		id := c.ID
+
+		// Derive a display name; Docker prepends "/" to container names.
+		nameLen := min(12, len(id))
+		name := id[:nameLen]
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+
+		semaphore <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-semaphore }()
+
+			key := cacheKey(endpointID, id)
+			result, err := fetchOneContainerMetric(ctx, cli, id, name, prevEntries[key], now)
+			if err != nil {
+				log.Warn().Err(err).Str("container", id).Msg("Unable to retrieve container metrics")
+				return
+			}
+
+			mu.Lock()
+			results = append(results, result)
+			mu.Unlock()
+		})
+	}
+
+	wg.Wait()
+
+	// Build the set of keys returned this poll so we can prune stale entries.
+	activeKeys := make(map[string]struct{}, len(results))
+	for _, r := range results {
+		activeKeys[cacheKey(endpointID, r.metric.ContainerID)] = struct{}{}
+	}
+
+	// Bulk-update cache: write new readings, delete entries for containers
+	// that are no longer running (stopped, removed, or failed to respond).
+	endpointPrefix := fmt.Sprintf("%d/", endpointID)
+	cache.mu.Lock()
+	for _, r := range results {
+		if r.metric.BlkioAvailable {
+			cache.store[cacheKey(endpointID, r.metric.ContainerID)] = deltaEntry{
+				blkRead:   r.rawRead,
+				blkWrite:  r.rawWrite,
+				sampledAt: now,
+			}
+		}
+	}
+	for k := range cache.store {
+		if strings.HasPrefix(k, endpointPrefix) {
+			if _, active := activeKeys[k]; !active {
+				delete(cache.store, k)
+			}
+		}
+	}
+	cache.mu.Unlock()
+
+	// Convert results to the public slice.
+	metrics := make([]ContainerMetric, len(results))
+	for i, r := range results {
+		metrics[i] = r.metric
+	}
+
+	return metrics, nil
+}
+
+func fetchOneContainerMetric(
+	ctx context.Context,
+	cli DockerStatsClient,
+	containerID, containerName string,
+	prev deltaEntry,
+	now time.Time,
+) (containerMetricResult, error) {
+	statsResp, err := cli.ContainerStats(ctx, containerID, false)
+	if err != nil {
+		return containerMetricResult{}, err
+	}
+	defer logs.CloseAndLogErr(statsResp.Body)
+
+	var raw dockerRawStats
+	if err := json.NewDecoder(statsResp.Body).Decode(&raw); err != nil {
+		return containerMetricResult{}, fmt.Errorf("decode stats for %s: %w", containerID, err)
+	}
+
+	metric := ContainerMetric{
+		ContainerID:   containerID,
+		ContainerName: containerName,
+	}
+
+	// --- CPU % ---
+	// precpu_stats is included by Docker in stream=false responses and
+	// represents the previous sample. When it is the first ever reading for
+	// this container, systemDelta will be 0 and we return 0% (same as
+	// `docker stats`).
+	// On Windows, system_cpu_usage is always 0 so CPU% cannot be calculated.
+	isWindows := statsResp.OSType == "windows"
+	metric.CPUAvailable = !isWindows
+	if !isWindows {
+		cpuDelta := float64(raw.CPUStats.CPUUsage.TotalUsage) - float64(raw.PreCPUStats.CPUUsage.TotalUsage)
+		systemDelta := float64(raw.CPUStats.SystemCPUUsage) - float64(raw.PreCPUStats.SystemCPUUsage)
+		if systemDelta > 0 && cpuDelta >= 0 {
+			onlineCPUs := raw.CPUStats.OnlineCPUs
+			if onlineCPUs == 0 {
+				onlineCPUs = 1
+			}
+			metric.CPUPercent = (cpuDelta / systemDelta) * float64(onlineCPUs) * 100.0
+		}
+	}
+
+	// --- Memory ---
+	// Subtract the page cache from usage to match `docker stats` output.
+	// On cgroup v1 the cache is in stats["cache"]; on cgroup v2 it is in
+	// stats["inactive_file"]. On Windows neither key is present.
+	memUsage := raw.MemoryStats.Usage
+	if v, ok := raw.MemoryStats.Stats["cache"]; ok && memUsage > v {
+		memUsage -= v
+	} else if v, ok := raw.MemoryStats.Stats["inactive_file"]; ok && memUsage > v {
+		memUsage -= v
+	}
+	metric.MemoryUsage = memUsage
+	metric.MemoryLimit = raw.MemoryStats.Limit
+	if raw.MemoryStats.Limit > 0 {
+		metric.MemoryPercent = float64(memUsage) / float64(raw.MemoryStats.Limit) * 100.0
+	}
+
+	// --- Block I/O ---
+	var blkRead, blkWrite uint64
+	for _, entry := range raw.BlkioStats.IOServiceBytesRecursive {
+		switch strings.ToLower(entry.Op) {
+		case "read":
+			blkRead += entry.Value
+		case "write":
+			blkWrite += entry.Value
+		}
+	}
+
+	// Mark as unavailable when the kernel / storage driver returns no data at
+	// all, or returns all-zeros (cgroupv1 hosts without blkio controller).
+	blkioAvailable := len(raw.BlkioStats.IOServiceBytesRecursive) > 0 && !(blkRead == 0 && blkWrite == 0)
+	metric.BlkioAvailable = blkioAvailable
+
+	if blkioAvailable && !prev.sampledAt.IsZero() {
+		elapsed := now.Sub(prev.sampledAt).Seconds()
+		if elapsed > 0 {
+			metric.BlockReadRate = float64(safeDelta(blkRead, prev.blkRead)) / elapsed
+			metric.BlockWriteRate = float64(safeDelta(blkWrite, prev.blkWrite)) / elapsed
+		}
+	}
+
+	return containerMetricResult{
+		metric:   metric,
+		rawRead:  blkRead,
+		rawWrite: blkWrite,
+	}, nil
+}
+
+// safeDelta returns curr - prev clamped to 0 to handle counter resets
+// (e.g. after a container restart).
+func safeDelta(curr, prev uint64) uint64 {
+	if curr < prev {
+		return 0
+	}
+	return curr - prev
+}
+
+func cacheKey(endpointID portainer.EndpointID, containerID string) string {
+	return fmt.Sprintf("%d/%s", endpointID, containerID)
+}

--- a/api/docker/stats/container_metrics_test.go
+++ b/api/docker/stats/container_metrics_test.go
@@ -1,0 +1,289 @@
+package stats
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStatsClient implements DockerStatsClient for unit testing.
+type mockStatsClient struct {
+	responses map[string]string // containerID -> JSON payload
+	err       map[string]error  // containerID -> error to return
+	osType    string            // reported OS type (defaults to "linux")
+}
+
+func (m *mockStatsClient) ContainerStats(_ context.Context, containerID string, _ bool) (container.StatsResponseReader, error) {
+	if err, ok := m.err[containerID]; ok {
+		return container.StatsResponseReader{}, err
+	}
+	payload, ok := m.responses[containerID]
+	if !ok {
+		return container.StatsResponseReader{}, fmt.Errorf("no mock response for container %s", containerID)
+	}
+	osType := m.osType
+	if osType == "" {
+		osType = "linux"
+	}
+	return container.StatsResponseReader{
+		Body:   io.NopCloser(strings.NewReader(payload)),
+		OSType: osType,
+	}, nil
+}
+
+// buildStatsJSON constructs a minimal Docker stats JSON payload.
+func buildStatsJSON(cpuTotal, preCPUTotal, systemCPU, preSystemCPU uint64, onlineCPUs int, memUsage, memLimit uint64, blkio []blkioEntry) string {
+	blkioJSON := "null"
+	if blkio != nil {
+		parts := make([]string, len(blkio))
+		for i, e := range blkio {
+			parts[i] = fmt.Sprintf(`{"op":%q,"value":%d,"major":0,"minor":0}`, e.Op, e.Value)
+		}
+		blkioJSON = "[" + strings.Join(parts, ",") + "]"
+	}
+	return fmt.Sprintf(`{
+		"cpu_stats":    {"cpu_usage":{"total_usage":%d},"system_cpu_usage":%d,"online_cpus":%d},
+		"precpu_stats": {"cpu_usage":{"total_usage":%d},"system_cpu_usage":%d},
+		"memory_stats": {"usage":%d,"limit":%d},
+		"blkio_stats":  {"io_service_bytes_recursive":%s}
+	}`, cpuTotal, systemCPU, onlineCPUs, preCPUTotal, preSystemCPU, memUsage, memLimit, blkioJSON)
+}
+
+func TestFetchContainerMetrics_CPUPercent(t *testing.T) {
+	// cpuDelta=200, systemDelta=1000, onlineCPUs=2 → 200/1000*2*100 = 40%
+	payload := buildStatsJSON(1200, 1000, 5000, 4000, 2, 0, 0, nil)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/myapp"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.InDelta(t, 40.0, metrics[0].CPUPercent, 0.001)
+	assert.Equal(t, "c1", metrics[0].ContainerID)
+	assert.Equal(t, "myapp", metrics[0].ContainerName)
+}
+
+func TestFetchContainerMetrics_CPUPercentZeroSystemDelta(t *testing.T) {
+	// systemDelta=0 (first ever reading) → CPU% must be 0, not NaN/Inf
+	payload := buildStatsJSON(1000, 1000, 0, 0, 2, 0, 0, nil)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.Equal(t, 0.0, metrics[0].CPUPercent)
+}
+
+func TestFetchContainerMetrics_Memory(t *testing.T) {
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 256*1024*1024, 1024*1024*1024, nil)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.Equal(t, uint64(256*1024*1024), metrics[0].MemoryUsage)
+	assert.Equal(t, uint64(1024*1024*1024), metrics[0].MemoryLimit)
+	assert.InDelta(t, 25.0, metrics[0].MemoryPercent, 0.001)
+}
+
+func TestFetchContainerMetrics_BlkioNilSlice(t *testing.T) {
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, nil)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.False(t, metrics[0].BlkioAvailable, "nil io_service_bytes_recursive should be unavailable")
+}
+
+func TestFetchContainerMetrics_BlkioBothZero(t *testing.T) {
+	// Slice present but all-zero — kernel without cgroup blkio controller.
+	blkio := []blkioEntry{{Op: "read", Value: 0}, {Op: "write", Value: 0}}
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, blkio)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.False(t, metrics[0].BlkioAvailable, "all-zero blkio should be unavailable")
+}
+
+func TestFetchContainerMetrics_BlkioRateOnSecondPoll(t *testing.T) {
+	blkio := []blkioEntry{{Op: "read", Value: 2048}, {Op: "write", Value: 1024}}
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, blkio)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	// First poll — no previous entry, rate should be 0 even though data is
+	// available.
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.True(t, metrics[0].BlkioAvailable)
+	assert.Equal(t, 0.0, metrics[0].BlockReadRate, "first poll should have no rate")
+	assert.Equal(t, 0.0, metrics[0].BlockWriteRate, "first poll should have no rate")
+
+	// Manually advance the cache timestamp by 2 seconds and bump the counters
+	// to simulate a second poll where 4096 read bytes and 2048 write bytes
+	// accumulated over 2 seconds → 2048 read/s, 1024 write/s.
+	blkio2 := []blkioEntry{{Op: "read", Value: 6144}, {Op: "write", Value: 3072}}
+	payload2 := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, blkio2)
+	cli.responses["c1"] = payload2
+
+	// Backdate the cache entry by 2 seconds to simulate elapsed time.
+	key := cacheKey(1, "c1")
+	cache.mu.Lock()
+	entry := cache.store[key]
+	entry.sampledAt = entry.sampledAt.Add(-2 * time.Second)
+	cache.store[key] = entry
+	cache.mu.Unlock()
+
+	metrics2, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics2, 1)
+	assert.True(t, metrics2[0].BlkioAvailable)
+	assert.InDelta(t, 2048.0, metrics2[0].BlockReadRate, 1.0, "read rate should be ~2048 B/s")
+	assert.InDelta(t, 1024.0, metrics2[0].BlockWriteRate, 1.0, "write rate should be ~1024 B/s")
+}
+
+func TestFetchContainerMetrics_BlkioNegativeDeltaClamped(t *testing.T) {
+	// Simulate a counter reset after container restart: current values are
+	// lower than the cached baseline.
+	cache := NewMetricsCache()
+	key := cacheKey(1, "c1")
+	cache.mu.Lock()
+	cache.store[key] = deltaEntry{
+		blkRead:   10000,
+		blkWrite:  5000,
+		sampledAt: time.Now().Add(-5 * time.Second),
+	}
+	cache.mu.Unlock()
+
+	// Current counters are lower than the cached ones → reset.
+	blkio := []blkioEntry{{Op: "read", Value: 100}, {Op: "write", Value: 50}}
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, blkio)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.Equal(t, 0.0, metrics[0].BlockReadRate, "negative delta should be clamped to 0")
+	assert.Equal(t, 0.0, metrics[0].BlockWriteRate, "negative delta should be clamped to 0")
+}
+
+func TestFetchContainerMetrics_ContainerErrorSkipped(t *testing.T) {
+	cli := &mockStatsClient{
+		responses: map[string]string{"c2": buildStatsJSON(200, 100, 1000, 500, 1, 0, 0, nil)},
+		err:       map[string]error{"c1": fmt.Errorf("connection refused")},
+	}
+	cache := NewMetricsCache()
+	containers := []container.Summary{
+		{ID: "c1", Names: []string{"/app1"}},
+		{ID: "c2", Names: []string{"/app2"}},
+	}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err, "individual container errors should not fail the request")
+	require.Len(t, metrics, 1, "failed container should be skipped")
+	assert.Equal(t, "c2", metrics[0].ContainerID)
+}
+
+func TestFetchContainerMetrics_WindowsCPUNotAvailable(t *testing.T) {
+	payload := buildStatsJSON(1200, 1000, 0, 0, 2, 0, 0, nil)
+	cli := &mockStatsClient{
+		responses: map[string]string{"c1": payload},
+		osType:    "windows",
+	}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.False(t, metrics[0].CPUAvailable, "Windows containers should report CPU as unavailable")
+	assert.Equal(t, 0.0, metrics[0].CPUPercent)
+}
+
+func TestFetchContainerMetrics_LinuxCPUAvailable(t *testing.T) {
+	payload := buildStatsJSON(1200, 1000, 5000, 4000, 2, 0, 0, nil)
+	cli := &mockStatsClient{responses: map[string]string{"c1": payload}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.True(t, metrics[0].CPUAvailable)
+}
+
+func TestFetchContainerMetrics_CachePrunesStoppedContainers(t *testing.T) {
+	payload := buildStatsJSON(0, 0, 0, 0, 1, 0, 0, []blkioEntry{{Op: "read", Value: 1024}, {Op: "write", Value: 512}})
+	cli := &mockStatsClient{responses: map[string]string{
+		"c1": payload,
+		"c2": payload,
+	}}
+	cache := NewMetricsCache()
+	both := []container.Summary{
+		{ID: "c1", Names: []string{"/app1"}},
+		{ID: "c2", Names: []string{"/app2"}},
+	}
+
+	// First poll: both containers running — both added to cache.
+	_, err := FetchContainerMetrics(context.Background(), cli, 1, both, cache)
+	require.NoError(t, err)
+	cache.mu.Lock()
+	assert.Len(t, cache.store, 2, "both containers should be in cache after first poll")
+	cache.mu.Unlock()
+
+	// Second poll: only c1 is running — c2's cache entry should be deleted.
+	onlyC1 := []container.Summary{{ID: "c1", Names: []string{"/app1"}}}
+	_, err = FetchContainerMetrics(context.Background(), cli, 1, onlyC1, cache)
+	require.NoError(t, err)
+	cache.mu.Lock()
+	assert.Len(t, cache.store, 1, "stopped container entry should be pruned")
+	_, c2Present := cache.store[cacheKey(1, "c2")]
+	cache.mu.Unlock()
+	assert.False(t, c2Present, "c2 entry should have been deleted")
+}
+
+func TestFetchContainerMetrics_MemoryPageCacheSubtracted(t *testing.T) {
+	// Build a payload where usage=300MB but cache=100MB → reported usage should be 200MB.
+	const usage = 300 * 1024 * 1024
+	const pageCache = 100 * 1024 * 1024
+	const limit = 1024 * 1024 * 1024
+
+	// Inline custom JSON to include memory_stats.stats.cache.
+	payloadWithCache := fmt.Sprintf(`{
+		"cpu_stats":    {"cpu_usage":{"total_usage":0},"system_cpu_usage":0,"online_cpus":1},
+		"precpu_stats": {"cpu_usage":{"total_usage":0},"system_cpu_usage":0},
+		"memory_stats": {"usage":%d,"limit":%d,"stats":{"cache":%d}},
+		"blkio_stats":  {"io_service_bytes_recursive":null}
+	}`, usage, limit, pageCache)
+
+	cli := &mockStatsClient{responses: map[string]string{"c1": payloadWithCache}}
+	cache := NewMetricsCache()
+	containers := []container.Summary{{ID: "c1", Names: []string{"/app"}}}
+
+	metrics, err := FetchContainerMetrics(context.Background(), cli, 1, containers, cache)
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	assert.Equal(t, uint64(usage-pageCache), metrics[0].MemoryUsage, "page cache should be subtracted from memory usage")
+}

--- a/api/http/handler/endpoints/endpoint_metrics_containers.go
+++ b/api/http/handler/endpoints/endpoint_metrics_containers.go
@@ -1,0 +1,67 @@
+package endpoints
+
+import (
+	"net/http"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/docker/stats"
+	"github.com/portainer/portainer/api/logs"
+	httperror "github.com/portainer/portainer/pkg/libhttp/error"
+	"github.com/portainer/portainer/pkg/libhttp/request"
+	"github.com/portainer/portainer/pkg/libhttp/response"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// @id endpointContainerMetricsCurrent
+// @summary Get current resource metrics for all running containers
+// @description Returns live CPU, memory, and block I/O usage for every running
+// @description container on the specified environment.
+// @description **Access policy**: authenticated
+// @tags endpoints
+// @security ApiKeyAuth
+// @security jwt
+// @produce json
+// @param id path int true "Environment identifier"
+// @success 200 {array} stats.ContainerMetric "Success"
+// @failure 400 "Invalid request"
+// @failure 403 "Permission denied"
+// @failure 404 "Environment not found"
+// @failure 500 "Server error"
+// @router /endpoints/{id}/metrics/containers/current [get]
+func (handler *Handler) endpointContainerMetricsCurrent(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	endpointID, err := request.RetrieveNumericRouteVariableValue(r, "id")
+	if err != nil {
+		return httperror.BadRequest("Invalid environment identifier route variable", err)
+	}
+
+	endpoint, err := handler.DataStore.Endpoint().Endpoint(portainer.EndpointID(endpointID))
+	if handler.DataStore.IsErrObjectNotFound(err) {
+		return httperror.NotFound("Unable to find an environment with the specified identifier inside the database", err)
+	} else if err != nil {
+		return httperror.InternalServerError("Unable to find an environment with the specified identifier inside the database", err)
+	}
+
+	err = handler.requestBouncer.AuthorizedEndpointOperation(r, endpoint)
+	if err != nil {
+		return httperror.Forbidden("Permission denied to access environment", err)
+	}
+
+	dockerClient, err := handler.DockerClientFactory.CreateClient(endpoint, "", nil)
+	if err != nil {
+		return httperror.InternalServerError("Unable to create Docker client", err)
+	}
+	defer logs.CloseAndLogErr(dockerClient)
+
+	containers, err := dockerClient.ContainerList(r.Context(), container.ListOptions{All: false})
+	if err != nil {
+		return httperror.InternalServerError("Unable to list containers", err)
+	}
+
+	metrics, err := stats.FetchContainerMetrics(r.Context(), dockerClient, portainer.EndpointID(endpointID), containers, handler.MetricsCache)
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve container metrics", err)
+	}
+
+	return response.JSON(w, metrics)
+}

--- a/api/http/handler/endpoints/handler.go
+++ b/api/http/handler/endpoints/handler.go
@@ -6,6 +6,7 @@ import (
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/dataservices"
 	dockerclient "github.com/portainer/portainer/api/docker/client"
+	dockerstats "github.com/portainer/portainer/api/docker/stats"
 	"github.com/portainer/portainer/api/http/proxy"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
@@ -36,6 +37,7 @@ type Handler struct {
 	ComposeStackManager    portainer.ComposeStackManager
 	AuthorizationService   *authorization.Service
 	DockerClientFactory    *dockerclient.ClientFactory
+	MetricsCache           *dockerstats.MetricsCache
 	BindAddress            string
 	BindAddressHTTPS       string
 	PendingActionsService  *pendingactions.PendingActionsService
@@ -83,6 +85,8 @@ func NewHandler(bouncer security.BouncerService) *Handler {
 	h.Handle("/endpoints/global-key", bouncer.PublicAccess(httperror.LoggerHandler(h.endpointCreateGlobalKey))).Methods(http.MethodPost)
 	h.Handle("/endpoints/{id}/forceupdateservice",
 		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.endpointForceUpdateService))).Methods(http.MethodPut)
+	h.Handle("/endpoints/{id}/metrics/containers/current",
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.endpointContainerMetricsCurrent))).Methods(http.MethodGet)
 
 	// DEPRECATED
 	h.Handle("/endpoints/{id}/status", bouncer.PublicAccess(httperror.LoggerHandler(h.endpointStatusInspect))).Methods(http.MethodGet)

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/users"
 	"github.com/portainer/portainer/api/http/handler/webhooks"
 	"github.com/portainer/portainer/api/http/handler/websocket"
+	dockerstats "github.com/portainer/portainer/api/docker/stats"
 	"github.com/portainer/portainer/api/http/middlewares"
 	"github.com/portainer/portainer/api/http/offlinegate"
 	"github.com/portainer/portainer/api/http/proxy"
@@ -186,6 +187,7 @@ func (server *Server) Start() error {
 	endpointHandler.BindAddressHTTPS = server.BindAddressHTTPS
 	endpointHandler.PendingActionsService = server.PendingActionsService
 	endpointHandler.PullLimitCheckDisabled = server.PullLimitCheckDisabled
+	endpointHandler.MetricsCache = dockerstats.NewMetricsCache()
 
 	var endpointEdgeHandler = endpointedge.NewHandler(requestBouncer, server.DataStore, server.FileService, server.ReverseTunnelService)
 

--- a/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
@@ -28,6 +28,7 @@ import { createStore } from './datatable-store';
 
 const storageKey = 'containers';
 const settingsStore = createStore(storageKey);
+const metricsColumnIds = ['cpu', 'memory', 'blockIO'];
 
 const actions = [
   buildAction('logs', 'Logs'),
@@ -54,8 +55,12 @@ export function ContainersDatatable({
     autoRefreshRate: tableState.autoRefreshRate * 1000,
   });
 
+  const isMetricsEnabled = !metricsColumnIds.every((id) =>
+    tableState.hiddenColumns.includes(id)
+  );
+
   return (
-    <RowProvider context={{ environment }}>
+    <RowProvider context={{ environment, isMetricsEnabled }}>
       <TableSettingsProvider settings={settingsStore}>
         <Datatable
           titleIcon={Box}

--- a/app/react/docker/containers/ListView/ContainersDatatable/RowContext.ts
+++ b/app/react/docker/containers/ListView/ContainersDatatable/RowContext.ts
@@ -4,6 +4,7 @@ import { createRowContext } from '@@/datatables/RowContext';
 
 interface RowContextState {
   environment: Environment;
+  isMetricsEnabled: boolean;
 }
 
 const { RowProvider, useRowContext } = createRowContext<RowContextState>();

--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/blockIO.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/blockIO.tsx
@@ -1,0 +1,42 @@
+import { CellContext } from '@tanstack/react-table';
+
+import type { ContainerListViewModel } from '@/react/docker/containers/types';
+import { useContainerMetricById } from '@/react/docker/containers/queries/useContainerMetrics';
+import { humanize } from '@/portainer/filters/filters';
+
+import { useRowContext } from '../RowContext';
+
+import { columnHelper } from './helper';
+
+export const blockIO = columnHelper.display({
+  header: 'Block I/O',
+  id: 'blockIO',
+  cell: BlockIOCell,
+  enableHiding: true,
+});
+
+function BlockIOCell({
+  row: { original: container },
+}: CellContext<ContainerListViewModel, unknown>) {
+  const { environment, isMetricsEnabled } = useRowContext();
+  const metricsQuery = useContainerMetricById(
+    environment.Id,
+    container.Id,
+    { enabled: isMetricsEnabled }
+  );
+
+  if (!metricsQuery.data) {
+    return null;
+  }
+
+  if (!metricsQuery.data.blkioAvailable) {
+    return <>Not Available</>;
+  }
+
+  const { blockReadRate, blockWriteRate } = metricsQuery.data;
+  return (
+    <>
+      {humanize(blockReadRate)}/s R / {humanize(blockWriteRate)}/s W
+    </>
+  );
+}

--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/cpu.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/cpu.tsx
@@ -1,0 +1,36 @@
+import { CellContext } from '@tanstack/react-table';
+
+import type { ContainerListViewModel } from '@/react/docker/containers/types';
+import { useContainerMetricById } from '@/react/docker/containers/queries/useContainerMetrics';
+
+import { useRowContext } from '../RowContext';
+
+import { columnHelper } from './helper';
+
+export const cpuPercent = columnHelper.display({
+  header: 'CPU %',
+  id: 'cpu',
+  cell: CpuCell,
+  enableHiding: true,
+});
+
+function CpuCell({
+  row: { original: container },
+}: CellContext<ContainerListViewModel, unknown>) {
+  const { environment, isMetricsEnabled } = useRowContext();
+  const metricsQuery = useContainerMetricById(
+    environment.Id,
+    container.Id,
+    { enabled: isMetricsEnabled }
+  );
+
+  if (!metricsQuery.data) {
+    return null;
+  }
+
+  if (!metricsQuery.data.cpuAvailable) {
+    return <>Not Available</>;
+  }
+
+  return <>{metricsQuery.data.cpuPercent.toFixed(2)}%</>;
+}

--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/index.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/index.tsx
@@ -14,6 +14,9 @@ import { quickActions } from './quick-actions';
 import { stack } from './stack';
 import { state } from './state';
 import { gpus } from './gpus';
+import { cpuPercent } from './cpu';
+import { memory } from './memory';
+import { blockIO } from './blockIO';
 
 export function useColumns(
   isHostColumnVisible: boolean,
@@ -32,6 +35,9 @@ export function useColumns(
         isHostColumnVisible && host,
         isGPUsColumnVisible && gpus,
         ports,
+        cpuPercent,
+        memory,
+        blockIO,
         createOwnershipColumn<ContainerListViewModel>(),
       ]),
     [isHostColumnVisible, isGPUsColumnVisible]

--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/memory.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/memory.tsx
@@ -1,0 +1,38 @@
+import { CellContext } from '@tanstack/react-table';
+
+import type { ContainerListViewModel } from '@/react/docker/containers/types';
+import { useContainerMetricById } from '@/react/docker/containers/queries/useContainerMetrics';
+import { humanize } from '@/portainer/filters/filters';
+
+import { useRowContext } from '../RowContext';
+
+import { columnHelper } from './helper';
+
+export const memory = columnHelper.display({
+  header: 'Memory',
+  id: 'memory',
+  cell: MemoryCell,
+  enableHiding: true,
+});
+
+function MemoryCell({
+  row: { original: container },
+}: CellContext<ContainerListViewModel, unknown>) {
+  const { environment, isMetricsEnabled } = useRowContext();
+  const metricsQuery = useContainerMetricById(
+    environment.Id,
+    container.Id,
+    { enabled: isMetricsEnabled }
+  );
+
+  if (!metricsQuery.data) {
+    return null;
+  }
+
+  const { memoryUsage, memoryLimit } = metricsQuery.data;
+  return (
+    <>
+      {humanize(memoryUsage)} / {humanize(memoryLimit)}
+    </>
+  );
+}

--- a/app/react/docker/containers/ListView/ContainersDatatable/datatable-store.ts
+++ b/app/react/docker/containers/ListView/ContainersDatatable/datatable-store.ts
@@ -11,7 +11,7 @@ export const TRUNCATE_LENGTH = 32;
 
 export function createStore(storageKey: string) {
   return createPersistedStore<TableSettings>(storageKey, 'name', (set) => ({
-    ...hiddenColumnsSettings(set),
+    ...hiddenColumnsSettings(set, ['cpu', 'memory', 'blockIO']),
     ...refreshableSettings(set),
     ...filteredColumnsSettings(set),
     truncateContainerName: TRUNCATE_LENGTH,

--- a/app/react/docker/containers/queries/useContainerMetrics.ts
+++ b/app/react/docker/containers/queries/useContainerMetrics.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { EnvironmentId } from '@/react/portainer/environments/types';
+import axios, { parseAxiosError } from '@/portainer/services/axios/axios';
+import { withGlobalError } from '@/react-tools/react-query';
+
+import { queryKeys as dockerQueryKeys } from '../../queries/utils';
+
+export interface ContainerMetric {
+  containerId: string;
+  containerName: string;
+  cpuPercent: number;
+  cpuAvailable: boolean;
+  memoryUsage: number;
+  memoryLimit: number;
+  memoryPercent: number;
+  blockReadRate: number;
+  blockWriteRate: number;
+  blkioAvailable: boolean;
+}
+
+const METRICS_REFETCH_INTERVAL_MS = 30_000;
+
+export const metricsQueryKeys = {
+  containers: (environmentId: EnvironmentId) =>
+    [...dockerQueryKeys.root(environmentId), 'metrics', 'containers'] as const,
+};
+
+async function getContainerMetrics(
+  environmentId: EnvironmentId
+): Promise<ContainerMetric[]> {
+  try {
+    const { data } = await axios.get<ContainerMetric[]>(
+      `/endpoints/${environmentId}/metrics/containers/current`
+    );
+    return data;
+  } catch (err) {
+    throw parseAxiosError(err, 'Unable to retrieve container metrics');
+  }
+}
+
+/**
+ * Fetches current CPU, memory, and block I/O metrics for a single container.
+ *
+ * All cells that call this hook share the same React Query cache entry
+ * (the query key does not include containerId), so only one network request
+ * is issued per render cycle regardless of how many metric columns are visible.
+ */
+export function useContainerMetricById(
+  environmentId: EnvironmentId,
+  containerId: string,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
+  return useQuery(
+    metricsQueryKeys.containers(environmentId),
+    () => getContainerMetrics(environmentId),
+    {
+      ...withGlobalError('Unable to retrieve container metrics'),
+      refetchInterval: enabled ? METRICS_REFETCH_INTERVAL_MS : false,
+      enabled,
+      select: (data) => data.find((m) => m.containerId === containerId),
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds three optional columns to the container list table: CPU %, Memory, and Block I/O. They are hidden by default and can be enabled via the existing "Show / Hide Columns" menu. Polling only starts when at least one column is visible.

This has been a recurring community request since 2017 (#611, #6998, Discussion #9833).

## Changes

### Backend

New endpoint at `GET /api/endpoints/{id}/metrics/containers/current` that lists running containers and calls `/containers/{id}/stats?stream=false` for each concurrently (semaphore of 5, matching the existing `CalculateContainerStats` pattern). Returns CPU %, memory usage/limit, and block I/O rate per container.

No new dependencies. No new storage. No deployment changes.

### Frontend

Three new column components following the existing `gpus.tsx` pattern. All three share a single React Query cache entry, so there is one network request per poll regardless of how many columns are visible. Default refresh interval is 30 seconds.

## Edge cases

- Block I/O shows "Not Available" when the host's cgroup/storage driver does not report it (common on cgroup v1)
- CPU shows "Not Available" on Windows Docker hosts where `system_cpu_usage` is always 0
- Memory subtracts page cache to match `docker stats` output (cgroup v1: `stats.cache`, cgroup v2: `stats.inactive_file`)
- Counter resets after container restart are clamped to 0 instead of showing negative rates
- In-memory delta cache is pruned every poll so stopped containers do not accumulate entries
- First reading after Portainer restart shows 0 rate until the second poll (no persistent storage needed)

## Out of scope

Historical data, server-level metrics, network I/O, alerting, charts. Each has its own design considerations. Server-level metrics in particular would change deployment requirements (additional volume mounts). This is scoped to the container stats already available via the Docker API.

## Files

**New (backend):**
- `api/docker/stats/container_metrics.go` - delta cache, concurrent fetching, CPU/memory/blkio math
- `api/docker/stats/container_metrics_test.go` - 11 unit tests
- `api/http/handler/endpoints/endpoint_metrics_containers.go` - HTTP handler

**Modified (backend):**
- `api/http/handler/endpoints/handler.go` - MetricsCache field + route
- `api/http/server.go` - wiring

**New (frontend):**
- `app/react/docker/containers/queries/useContainerMetrics.ts`
- `app/react/docker/containers/ListView/ContainersDatatable/columns/cpu.tsx`
- `app/react/docker/containers/ListView/ContainersDatatable/columns/memory.tsx`
- `app/react/docker/containers/ListView/ContainersDatatable/columns/blockIO.tsx`

**Modified (frontend):**
- `columns/index.tsx` - imports and includes the 3 new columns
- `datatable-store.ts` - hidden by default
- `RowContext.ts` - added isMetricsEnabled
- `ContainersDatatable.tsx` - visibility gate for polling

## Testing

All Go unit tests pass (`go test ./api/docker/stats/...`). Tests cover CPU formula, zero systemDelta, nil/zero blkio, rate on second poll, counter reset clamping, per-container error skipping, Windows CPU unavailability, cache pruning, and page cache subtraction.

The RFC notes a benchmarking gate: polling interval and concurrency limits should be validated on hosts with 50+ containers before merging.

## Disclosure

This was developed with AI assistance (Claude) for codebase research, architecture analysis, code generation, and review. The ideas, direction, and technical decisions are my own.

Related: #611, #6998, Discussion #9833 