### PR TITLE
fix: remove dead html5shim.googlecode.com script reference

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,11 +11,6 @@
     <meta name="robots" content="noindex" />
     <base id="base" />
 
-    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
     <!-- Fav and touch icons -->
     <link rel="apple-touch-icon" sizes="180x180" href="<%=require('./assets/ico/apple-touch-icon.png')%>" />
     <link rel="icon" type="image/png" sizes="32x32" href="<%=require('./assets/ico/favicon-32x32.png')%>" />


### PR DESCRIPTION
## Summary

Removes the conditional comment loading `html5shim.googlecode.com/svn/trunk/html5.js` from `app/index.html`.

## Problem

The `html5shim.googlecode.com` domain was shut down by Google in 2016. The domain has since been flagged by Google Safe Browsing as a source of potentially malicious content, causing Chrome to display a "Dangerous site" warning when loading Portainer.

This script was an IE6-8 compatibility shim that is completely unnecessary for any modern browser.

## Changes

- Removed the `<!--[if lt IE 9]>` conditional comment block and its contents from `app/index.html`

## Testing

- Verified the referenced URL (`html5shim.googlecode.com/svn/trunk/html5.js`) returns a 404
- The conditional comment only ever executed in IE9 or below, so removal has no impact on any supported browser

Closes #13118