### PR TITLE
fix: add org.opencontainers.image.source OCI label to Dockerfiles

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -37,6 +37,7 @@ LABEL git_commit=$GIT_COMMIT \
   org.opencontainers.image.vendor="Portainer.io" \
   org.opencontainers.image.url="https://www.portainer.io" \
   org.opencontainers.image.documentation="https://docs.portainer.io" \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   io.portainer.server="true"
 
 ENTRYPOINT ["/portainer"]

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -30,6 +30,7 @@ LABEL git_commit=$GIT_COMMIT \
   org.opencontainers.image.vendor="Portainer.io" \
   org.opencontainers.image.url="https://www.portainer.io" \
   org.opencontainers.image.documentation="https://docs.portainer.io" \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   io.portainer.server="true"
 
 ENTRYPOINT ["/portainer.exe"]


### PR DESCRIPTION
Adds the missing `org.opencontainers.image.source` OCI label to the Linux and Windows Dockerfiles.

This label is part of the [OCI image spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) and points to the source repository. Tools like Renovate use it to auto-detect the GitHub repo for changelog and release note lookups. Without it, Renovate shows no release notes when updating `portainer/portainer-ce` image references.

The change is purely additive with zero functional impact.