### PR TITLE
Add `org.opencontainers.image.source` OCI label to Dockerfile

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -36,6 +36,7 @@ LABEL git_commit=$GIT_COMMIT \
   org.opencontainers.image.description="Portainer Community Edition server." \
   org.opencontainers.image.vendor="Portainer.io" \
   org.opencontainers.image.url="https://www.portainer.io" \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   org.opencontainers.image.documentation="https://docs.portainer.io" \
   io.portainer.server="true"
 

--- a/build/linux/alpine.Dockerfile
+++ b/build/linux/alpine.Dockerfile
@@ -36,6 +36,7 @@ LABEL git_commit=$GIT_COMMIT \
   org.opencontainers.image.description="Portainer Community Edition server." \
   org.opencontainers.image.vendor="Portainer.io" \
   org.opencontainers.image.url="https://www.portainer.io" \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   org.opencontainers.image.documentation="https://docs.portainer.io" \
   io.portainer.server="true"
 

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -29,6 +29,7 @@ LABEL git_commit=$GIT_COMMIT \
   org.opencontainers.image.description="Portainer Community Edition server." \
   org.opencontainers.image.vendor="Portainer.io" \
   org.opencontainers.image.url="https://www.portainer.io" \
+  org.opencontainers.image.source="https://github.com/portainer/portainer" \
   org.opencontainers.image.documentation="https://docs.portainer.io" \
   io.portainer.server="true"
 


### PR DESCRIPTION
Tools like [Renovate](https://docs.renovatebot.com/modules/datasource/docker/) use the `org.opencontainers.image.source` OCI label to locate the upstream source repository and include release notes in dependency update PRs. Without it, users who manage the `portainer/portainer-ce` image via Renovate have to add a manual `sourceUrl` override in their config.

The other standard OCI labels are already present, this adds the missing one.