### PR TITLE
fix(images): cache matched registries with the expected type

### DIFF
--- a/api/docker/images/registry.go
+++ b/api/docker/images/registry.go
@@ -121,7 +121,7 @@ func findBestMatchRegistry(repository string, registries []portainer.Registry) (
 		return nil, errors.New("no registries matched")
 	}
 
-	registriesCache.Set(repository, match, 0)
+	registriesCache.Set(repository, *match, 0)
 
 	return match, nil
 }

--- a/api/docker/images/registry_test.go
+++ b/api/docker/images/registry_test.go
@@ -57,6 +57,24 @@ func TestFindBestMatchNeedAuthRegistry(t *testing.T) {
 	})
 }
 
+func TestFindBestMatchRegistryCachesMatch(t *testing.T) {
+	registriesCache.Flush()
+	t.Cleanup(registriesCache.Flush)
+
+	image := "private.registry.example.com/library/nginx:latest"
+	registries := []portainer.Registry{
+		createNewRegistry("private.registry.example.com", "", true),
+	}
+
+	registry, err := findBestMatchRegistry(image, registries)
+	require.NoError(t, err)
+	require.Equal(t, "private.registry.example.com", registry.URL)
+
+	cached, err := cachedRegistry(image)
+	require.NoError(t, err)
+	require.Equal(t, registry, cached)
+}
+
 func createNewRegistry(domain, username string, auth bool) portainer.Registry {
 	registry := portainer.Registry{
 		URL:            domain,


### PR DESCRIPTION
Related: #10304, #12518

### Changes:
Fixes registry match caching in `api/docker/images`.

`findBestMatchRegistry` saved a `*portainer.Registry`, but `cachedRegistry` reads a `portainer.Registry`. So the cache was basically doing nothing, rip. No cloud quota or API limit needed here, any matched registry can hit this path.

Repro before the fix:
```sh
go test ./api/docker/images -run TestFindBestMatchRegistryCachesMatch -count=1
```

It failed with:
```text
no registry found in cache: private.registry.example.com/library/nginx:latest
```

After this patch:
```sh
go test ./api/docker/images -count=1
go test ./api/docker/images -race -run TestFindBestMatchRegistryCachesMatch -count=1
```

Both pass. tiny fix, actual cache now caches.