### PR TITLE
#13178 fix(stacks): allow force removal of stack records when undeploy fails

### DIFF
--- a/api/http/handler/stacks/stack_delete.go
+++ b/api/http/handler/stacks/stack_delete.go
@@ -30,6 +30,7 @@ import (
 // @param id path int true "Stack identifier"
 // @param external query boolean false "Set to true to delete an external stack. Only external Swarm stacks are supported"
 // @param endpointId query int true "Environment identifier"
+// @param force query boolean false "Set to true to remove the Portainer stack record even when the underlying compose/swarm undeploy fails (e.g. when the Docker daemon is unreachable). Any orphaned containers must be cleaned up separately."
 // @success 204 "Success"
 // @failure 400 "Invalid request"
 // @failure 403 "Permission denied"
@@ -112,13 +113,18 @@ func (handler *Handler) stackDelete(w http.ResponseWriter, r *http.Request) *htt
 		return httperror.Forbidden(errMsg, errors.New(errMsg))
 	}
 
+	force, _ := request.RetrieveBooleanQueryParameter(r, "force", true)
+
 	// stop scheduler updates of the stack before removal
 	if stack.AutoUpdate != nil {
 		deployments.StopAutoupdate(stack.ID, stack.AutoUpdate.JobID, handler.Scheduler)
 	}
 
 	if err := handler.deleteStack(r.Context(), securityContext.UserID, stack, endpoint); err != nil {
-		return httperror.InternalServerError(err.Error(), err)
+		if !force {
+			return httperror.InternalServerError(err.Error(), err)
+		}
+		log.Warn().Err(err).Int("stackId", id).Msg("undeploy failed but force=true was set; proceeding to remove the Portainer stack record. Any orphaned containers must be cleaned up manually.")
 	}
 
 	if err := handler.DataStore.Stack().Delete(portainer.StackID(id)); err != nil {

--- a/api/http/handler/stacks/stack_delete_test.go
+++ b/api/http/handler/stacks/stack_delete_test.go
@@ -1,0 +1,112 @@
+package stacks
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/datastore"
+	"github.com/portainer/portainer/api/filesystem"
+	"github.com/portainer/portainer/api/internal/testhelpers"
+	"github.com/portainer/portainer/api/stacks/deployments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDeleteStackDeployer struct {
+	deployments.StackDeployer
+	undeployErr error
+}
+
+func (s *stubDeleteStackDeployer) UndeployComposeStack(_ context.Context, _ *portainer.Stack, _ *portainer.Endpoint) error {
+	return s.undeployErr
+}
+
+func stackDeleteRequest(stackID portainer.StackID, endpointID portainer.EndpointID, force bool) *http.Request {
+	url := "/stacks/" + strconv.Itoa(int(stackID)) + "?endpointId=" + strconv.Itoa(int(endpointID))
+	if force {
+		url += "&force=true"
+	}
+	return mockCreateStackRequestWithSecurityContext(http.MethodDelete, url, nil)
+}
+
+func newDeleteStackHandler(t *testing.T, undeployErr error) (*Handler, *datastore.Store) {
+	t.Helper()
+	_, store := datastore.MustNewTestStore(t, true, false)
+	fileService, err := filesystem.NewService(filesystem.JoinPaths(t.TempDir()), "")
+	require.NoError(t, err)
+	h := NewHandler(testhelpers.NewTestRequestBouncer())
+	h.DataStore = store
+	h.ComposeStackManager = &stubComposeStackManager{}
+	h.StackDeployer = &stubDeleteStackDeployer{undeployErr: undeployErr}
+	h.FileService = fileService
+	return h, store
+}
+
+func newDeletableComposeStack(endpointID portainer.EndpointID) *portainer.Stack {
+	return &portainer.Stack{
+		ID:         1,
+		EndpointID: endpointID,
+		Type:       portainer.DockerComposeStack,
+		Name:       "test-stack",
+	}
+}
+
+func TestStackDelete_UndeploySuccess_RemovesRecord(t *testing.T) {
+	t.Parallel()
+	h, store := newDeleteStackHandler(t, nil)
+	_, err := mockCreateUser(store)
+	require.NoError(t, err)
+	endpoint, err := mockCreateEndpoint(store)
+	require.NoError(t, err)
+	stack := newDeletableComposeStack(endpoint.ID)
+	require.NoError(t, store.Stack().Create(stack))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, stackDeleteRequest(stack.ID, endpoint.ID, false))
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	_, err = store.Stack().Read(stack.ID)
+	require.True(t, store.IsErrObjectNotFound(err), "stack record should be removed from the database")
+}
+
+func TestStackDelete_UndeployFails_NoForce_PreservesRecord(t *testing.T) {
+	t.Parallel()
+	h, store := newDeleteStackHandler(t, errors.New("compose down operation failed: Cannot connect to the Docker daemon"))
+	_, err := mockCreateUser(store)
+	require.NoError(t, err)
+	endpoint, err := mockCreateEndpoint(store)
+	require.NoError(t, err)
+	stack := newDeletableComposeStack(endpoint.ID)
+	require.NoError(t, store.Stack().Create(stack))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, stackDeleteRequest(stack.ID, endpoint.ID, false))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	persisted, err := store.Stack().Read(stack.ID)
+	require.NoError(t, err, "stack record should still exist when undeploy fails without force")
+	assert.Equal(t, stack.ID, persisted.ID)
+}
+
+func TestStackDelete_UndeployFails_WithForce_RemovesRecord(t *testing.T) {
+	t.Parallel()
+	h, store := newDeleteStackHandler(t, errors.New("compose down operation failed: Cannot connect to the Docker daemon"))
+	_, err := mockCreateUser(store)
+	require.NoError(t, err)
+	endpoint, err := mockCreateEndpoint(store)
+	require.NoError(t, err)
+	stack := newDeletableComposeStack(endpoint.ID)
+	require.NoError(t, store.Stack().Create(stack))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, stackDeleteRequest(stack.ID, endpoint.ID, true))
+
+	require.Equal(t, http.StatusNoContent, w.Code, "force=true should allow record removal even when undeploy fails")
+	_, err = store.Stack().Read(stack.ID)
+	require.True(t, store.IsErrObjectNotFound(err), "stack record should be removed from the database when force=true")
+}


### PR DESCRIPTION
closes #13178

### Summary

When the Docker daemon is unreachable from the Portainer container (e.g. the socket is not mounted), compose down fails — and because that failure also blocks DataStore.Stack().Delete(), the broken stack becomes undeletable through the UI. The user is stuck with a stack record that points to nothing and cannot be cleaned up without fixing socket connectivity first.

This change adds a force=true query parameter to DELETE /stacks/{id} that, when set, proceeds with the Portainer-side cleanup (DB record, resource control, project files) even if the underlying undeploy step returns an error. Default behavior is unchanged: without force, the existing 500 response and record-preserved behavior is identical to today.

### Why an explicit opt-in

Silently force-deleting on any docker failure could leak running containers — the daemon may have been only briefly unavailable, in which case unstop'd containers would remain after the Portainer record is gone. Surfacing the choice as a query parameter lets the caller accept that risk only when they need to.

### Changes

- api/http/handler/stacks/stack_delete.go: read force query parameter; on undeploy error, log a warning and continue with record/file cleanup when force=true. Swagger annotation updated.
- api/http/handler/stacks/stack_delete_test.go: new tests covering the three cases (success, failure without force = 500 + record retained, failure with force = 204 + record removed).

### Follow-up (not in this PR)

The frontend currently has no way to send force=true. A small UI follow-up to expose this as a confirmation option in the stack delete flow would make sense once the API shape is settled — happy to submit that as a separate PR after this one is reviewed.

### Test plan

- [x] go test ./api/http/handler/stacks/... passes locally
- [x] go vet ./api/http/handler/stacks/... clean
- [x] go build ./... clean
- [ ] Manual verification against a Portainer instance with the docker socket intentionally unmounted