### PR TITLE
fix(ui): show selected volume name in create view

### DIFF
--- a/app/react/components/form-components/ReactSelect.css
+++ b/app/react/components/form-components/ReactSelect.css
@@ -110,7 +110,8 @@
 }
 
 .portainer-selector-root.sm .portainer-selector__input-container {
-  height: 20px;
+  min-height: 20px;
+  height: auto;
   @apply text-xs;
 }
 
@@ -134,6 +135,8 @@
 
 .portainer-selector-root.sm .portainer-selector__single-value {
   @apply text-xs;
+  min-height: 20px;
+  line-height: 20px;
 }
 
 .portainer-selector-root.md .portainer-selector__single-value {


### PR DESCRIPTION
closes #13181

### Changes:
- fix sm react-select css so the selected volume name is visible in the container create volumes tab.