### PR TITLE
fix(templates): render env var description as tooltip in app templates

### DIFF
--- a/app/react/portainer/templates/app-templates/DeployFormWidget/EnvVarsFieldset.test.tsx
+++ b/app/react/portainer/templates/app-templates/DeployFormWidget/EnvVarsFieldset.test.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
@@ -7,6 +8,15 @@ import {
   getDefaultValues,
   envVarsFieldsetValidation,
 } from './EnvVarsFieldset';
+
+// Tippy renders tooltip content in a portal which is not accessible without
+// user interaction in jsdom. Mock Tooltip to render its message inline so
+// tests can assert on the message text.
+vi.mock('@@/Tip/Tooltip/Tooltip', () => ({
+  Tooltip: ({ message }: { message: ReactNode }) => (
+    <span data-cy="tooltip">{message}</span>
+  ),
+}));
 
 test('renders EnvVarsFieldset component', () => {
   const onChange = vi.fn();
@@ -32,6 +42,49 @@ test('renders EnvVarsFieldset component', () => {
     const inputElement = screen.getByDisplayValue(value[option.name]);
     expect(inputElement).toBeInTheDocument();
   });
+});
+
+test('renders the env var description as a tooltip', () => {
+  const onChange = vi.fn();
+  const options = [
+    {
+      name: 'VAR1',
+      label: 'Variable 1',
+      description: 'Helpful description for variable 1',
+      preset: false,
+    },
+  ];
+  const value = { VAR1: 'Value 1' };
+
+  render(
+    <EnvVarsFieldset
+      onChange={onChange}
+      options={options}
+      values={value}
+      errors={{}}
+    />
+  );
+
+  expect(
+    screen.getByText('Helpful description for variable 1')
+  ).toBeInTheDocument();
+});
+
+test('does not render a tooltip when the env var has no description', () => {
+  const onChange = vi.fn();
+  const options = [{ name: 'VAR1', label: 'Variable 1', preset: false }];
+  const value = { VAR1: 'Value 1' };
+
+  render(
+    <EnvVarsFieldset
+      onChange={onChange}
+      options={options}
+      values={value}
+      errors={{}}
+    />
+  );
+
+  expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
 });
 
 test('calls onChange when input value changes', async () => {

--- a/app/react/portainer/templates/app-templates/DeployFormWidget/EnvVarsFieldset.tsx
+++ b/app/react/portainer/templates/app-templates/DeployFormWidget/EnvVarsFieldset.tsx
@@ -55,6 +55,7 @@ function Item({
   return (
     <FormControl
       label={option.label || option.name}
+      tooltip={option.description}
       required={false}
       errors={errors}
       inputId={inputId}


### PR DESCRIPTION
## Description

In Application Templates, the `description` field of an environment variable
was never rendered as a tooltip next to the input label.

The root cause is in `EnvVarsFieldset.tsx`: the `Item` component passed `label`
to `FormControl` but never passed `description`. `FormControl` only renders the
tooltip icon when it receives a `tooltip` prop, so the description was missing
from the DOM entirely.

The `TemplateEnv` type already documents `description` as *"Content of the
tooltip that will be generated in the UI"*, confirming the intended behavior.

## Fix

Pass `option.description` as the `FormControl` `tooltip` prop.

## Tests

Added two unit tests to `EnvVarsFieldset.test.tsx`:
- renders the env var description as a tooltip when present
- does not render a tooltip when the env var has no description

Local checks: `pnpm test` (7/7), `pnpm typecheck`, and `eslint` all pass.

Closes #13190