### PR TITLE
Fix missing error toast on image deletion

### DIFF
--- a/app/react/docker/images/ListView/ImagesDatatable/RemoveButtonMenu.tsx
+++ b/app/react/docker/images/ListView/ImagesDatatable/RemoveButtonMenu.tsx
@@ -4,7 +4,7 @@ import { positionRight } from '@reach/popover';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { Authorized } from '@/react/hooks/useUser';
-import { withInvalidate } from '@/react-tools/react-query';
+import { withError, withInvalidate } from '@/react-tools/react-query';
 import { useEnvironmentId } from '@/react/hooks/useEnvironmentId';
 import { notifySuccess } from '@/portainer/services/notifications';
 import { processItemsInBatches } from '@/react/common/processItemsInBatches';
@@ -118,5 +118,6 @@ function useDeleteImageListMutation() {
         )
       ),
     ...withInvalidate(queryClient, [queryKeys.base(environmentId)]),
+    ...withError('Unable to delete image'),
   });
 }


### PR DESCRIPTION
closes #13199 

### Changes:
#### Before
<img width="1806" height="978" alt="2026-06-12-000326_screenshot" src="https://github.com/user-attachments/assets/9f68f15f-9fca-4644-92bf-f6b1d2b38592" />

#### After
<img width="1768" height="967" alt="2026-06-12-000041_screenshot" src="https://github.com/user-attachments/assets/ae0a52e6-186c-4398-99fc-4e405f1c8e88" />

