### PR TITLE
fix(libstack/swarm): change registry match mechanism to path level

### DIFF
--- a/pkg/libstack/swarm/swarm.go
+++ b/pkg/libstack/swarm/swarm.go
@@ -384,7 +384,7 @@ func encodeRegistryAuth(image string, registries []configtypes.AuthConfig) (stri
 	}
 
 	for _, r := range registries {
-		if r.ServerAddress == domain {
+		if strings.Contains(image, r.ServerAddress) {
 			encoded, err := registrytypes.EncodeAuthConfig(registrytypes.AuthConfig{
 				Username:      r.Username,
 				Password:      r.Password,

--- a/pkg/libstack/swarm/swarm.go
+++ b/pkg/libstack/swarm/swarm.go
@@ -383,24 +383,31 @@ func encodeRegistryAuth(image string, registries []configtypes.AuthConfig) (stri
 		domain = dockerregistry.IndexServer
 	}
 
+	specificity := 0
+	encoded, err := "", nil
+
 	for _, r := range registries {
-		if strings.Contains(image, r.ServerAddress) {
-			encoded, err := registrytypes.EncodeAuthConfig(registrytypes.AuthConfig{
-				Username:      r.Username,
-				Password:      r.Password,
-				ServerAddress: r.ServerAddress,
-				Auth:          r.Auth,
-				IdentityToken: r.IdentityToken,
-				RegistryToken: r.RegistryToken,
-			})
-			if err != nil {
-				return "", fmt.Errorf("failed to encode auth for registry %s: %w", domain, err)
+		if strings.HasPrefix(image, r.ServerAddress) {
+			matchSpecificity := len(r.ServerAddress)
+			if matchSpecificity > specificity {
+				specificity = matchSpecificity
+
+				encoded, err = registrytypes.EncodeAuthConfig(registrytypes.AuthConfig{
+					Username:      r.Username,
+					Password:      r.Password,
+					ServerAddress: r.ServerAddress,
+					Auth:          r.Auth,
+					IdentityToken: r.IdentityToken,
+					RegistryToken: r.RegistryToken,
+				})
+				if err != nil {
+					return "", fmt.Errorf("failed to encode auth for registry %s: %w", domain, err)
+				}
 			}
-			return encoded, nil
 		}
 	}
 
-	return "", nil
+	return encoded, nil
 }
 
 func deployServices(


### PR DESCRIPTION
Probably related to this: https://github.com/portainer/portainer/issues/10699#issuecomment-2016710044

### Description:
When configured with multiple subpaths of the same registry but different credentials, the private images of a swarm stack are not pulled correctly since just the domain of the image is compared to the registry paths, and they would never match.

Here is an example of configured registries:
<img width="630" height="291" alt="image" src="https://github.com/user-attachments/assets/7c7b30f2-1231-4c5b-8662-d22078245b8c" />


### Changes:
- Changed the match mechanism in the libstack/swarm package to try to match if the stored credentials registry path does match the image path. So if the stored credential registry path is contained in the image, it is the correct registry.

Before:
<img width="2237" height="981" alt="image" src="https://github.com/user-attachments/assets/2bac06bc-8e41-456b-85e6-6233c31c5594" />

After:
<img width="2237" height="981" alt="image" src="https://github.com/user-attachments/assets/64ba50ad-6757-42d7-8877-8111ac3fc0d1" />

I can remember that in a previous version of Portainer (a very long time ago), the deployment of stacks has been working very well. But after an update, the mechanism is broken.

If you have any questions, do not hesitate to ask. :)