### PR TITLE
fix(ui): truncate published ports list with show more badge

### DIFF
--- a/app/react/docker/containers/ListView/ContainersDatatable/columns/ports.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/columns/ports.tsx
@@ -4,9 +4,14 @@ import { CellContext } from '@tanstack/react-table';
 import { PublishedPortLink } from '@/react/docker/components/ImageStatus/PublishedPortLink';
 import type { ContainerListViewModel } from '@/react/docker/containers/types';
 
+import { Badge } from '@@/Badge';
+import { TooltipWithChildren } from '@@/Tip/TooltipWithChildren';
+
 import { useRowContext } from '../RowContext';
 
 import { columnHelper } from './helper';
+
+const MAX_VISIBLE_PORTS = 3;
 
 export const ports = columnHelper.accessor(
   (row) =>
@@ -21,7 +26,7 @@ export const ports = columnHelper.accessor(
 );
 
 function Cell({ row }: CellContext<ContainerListViewModel, string>) {
-  const ports = row.original.Ports;
+  const ports = _.uniqBy(row.original.Ports, 'public');
 
   const { environment } = useRowContext();
 
@@ -29,9 +34,12 @@ function Cell({ row }: CellContext<ContainerListViewModel, string>) {
     return '-';
   }
 
+  const visiblePorts = ports.slice(0, MAX_VISIBLE_PORTS);
+  const hiddenPorts = ports.slice(MAX_VISIBLE_PORTS);
+
   return (
-    <div className="flex flex-wrap gap-1">
-      {_.uniqBy(ports, 'public').map((port) => (
+    <div className="flex flex-wrap items-center gap-1">
+      {visiblePorts.map((port) => (
         <PublishedPortLink
           key={`${port.host}:${port.public}`}
           hostPort={port.public}
@@ -39,6 +47,26 @@ function Cell({ row }: CellContext<ContainerListViewModel, string>) {
           hostURL={environment.PublicURL || port.host}
         />
       ))}
+      {hiddenPorts.length > 0 && (
+        <TooltipWithChildren
+          message={
+            <div className="flex flex-wrap gap-1">
+              {hiddenPorts.map((port) => (
+                <PublishedPortLink
+                  key={`${port.host}:${port.public}`}
+                  hostPort={port.public}
+                  containerPort={port.private}
+                  hostURL={environment.PublicURL || port.host}
+                />
+              ))}
+            </div>
+          }
+        >
+          <Badge type="muted" size="sm">
+            +{hiddenPorts.length} more
+          </Badge>
+        </TooltipWithChildren>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Containers list "Published Ports" column now shows only the first 3 port mappings inline.
- Remaining ports are collapsed into a `+N more` badge.
- Hovering/clicking the badge shows the full remaining list in a tooltip, reusing the existing `Badge` and `TooltipWithChildren` components (no new styles introduced).

Fixes #13217

BEFORE
<img width="1284" height="780" alt="Screenshot 2026-06-19 at 1 51 22 PM" src="https://github.com/user-attachments/assets/a4aad91a-ae5f-43b3-a3f0-6c54ef03a940" />

AFTER
<img width="1284" height="780" alt="Screenshot 2026-06-19 at 1 55 09 PM" src="https://github.com/user-attachments/assets/50e5ddbd-479d-4fd3-a416-59011507d662" />


## Test plan
- [x] Start a container with 10+ published ports
- [x] Confirm only the first 3 ports render inline in the Containers list
- [x] Confirm a `+N more` badge appears for the rest
- [x] Hover/click the badge and confirm the remaining ports show in a tooltip, each still linking out correctly
- [x] Confirm containers with <= 3 ports render unchanged