### PR TITLE
feat(unpacker): add envar to specify unpacker container network mode

### DIFF
--- a/api/stacks/deployments/deployer_remote.go
+++ b/api/stacks/deployments/deployer_remote.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	defaultUnpackerImage       = "portainer/compose-unpacker:" + portainer.APIVersion
-	composeUnpackerImageEnvVar = "COMPOSE_UNPACKER_IMAGE"
-	composePathPrefix          = "portainer-compose-unpacker"
+	defaultUnpackerImage             = "portainer/compose-unpacker:" + portainer.APIVersion
+	composeUnpackerImageEnvVar       = "COMPOSE_UNPACKER_IMAGE"
+	composeUnpackerNetworkModeEnvVar = "COMPOSE_UNPACKER_NETWORK_MODE"
+	composePathPrefix                = "portainer-compose-unpacker"
 )
 
 type RemoteStackDeployer interface {
@@ -225,6 +226,7 @@ func (d *stackDeployer) remoteStack(ctx context.Context, stack *portainer.Stack,
 			fmt.Sprintf("%s:%s", composeDestination, composeDestination),
 			fmt.Sprintf("%s:%s", targetSocketBindHost, targetSocketBindContainer),
 		},
+		NetworkMode: container.NetworkMode(os.Getenv(composeUnpackerNetworkModeEnvVar)),
 	}, nil, nil, fmt.Sprintf("portainer-unpacker-%d-%s-%d", stack.ID, stack.Name, librand.Intn(100)))
 	if err != nil {
 		return errors.Wrap(err, "unable to create unpacker container")


### PR DESCRIPTION
addresses [#10494](https://github.com/orgs/portainer/discussions/10494)
addresses [#13028](https://github.com/orgs/portainer/discussions/13028)

### Changes:
Add environment variable to set network mode for Unpacker container. 

Use case:
Portainer is connected to a Tailscale tailnet through a sidecar container, named "sidecar" for example (Portainer's NetworkMode is set to "container:sidecar", could be abstracted in Compose with "service:sidecar").

Assume a Git server exists on the tailnet. Portainer will be able to access it through the Tailscale sidecar. However, the dynamically-created Unpacker container won't. This is because the Unpacker container isn't instructed to share Portainer's network stack, or the Tailscale sidecar's stack for that matter. This creates a problem when trying to pull data to a relative path volume, the Unpacker container won't be able to resolve or connect to the Git server since it's not on the tailnet.

The new option added allows the user to insert the Unpacker container into the tailnet by manually specifying the network mode to be either "container:sidecar" (like Portainer) or even "host", if appropriate.

It might be possible to make Unpacker automatically inherit the network settings from Portainer, however my knowledge of this codebase is limited so this is the best I could do. I believe it's a good first step, until someone more experienced can come in and improve this feature.

P.S. I couldn't find anywhere the existing `COMPOSE_UNPACKER_IMAGE` envar is documented so I wasn't sure where to document my new envar.