### PR TITLE
fix(swarm): detect async deploy failures instead of reporting success

### DIFF
--- a/api/exec/swarm_stack.go
+++ b/api/exec/swarm_stack.go
@@ -3,12 +3,17 @@ package exec
 import (
 	"context"
 	"fmt"
+	"time"
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/http/proxy"
 	"github.com/portainer/portainer/api/stacks/stackutils"
+	"github.com/portainer/portainer/pkg/libstack"
 	"github.com/portainer/portainer/pkg/libstack/swarm"
 )
+
+// postDeployFailureCheckTimeout bounds how long Deploy waits for tasks to start or fail after being accepted by Swarm.
+const postDeployFailureCheckTimeout = 30 * time.Second
 
 // SwarmStackManager represents a service for managing stacks.
 type SwarmStackManager struct {
@@ -52,7 +57,7 @@ func (manager *SwarmStackManager) Deploy(
 		env = append(env, ev.Name+"="+ev.Value)
 	}
 
-	return manager.deployer.Deploy(context.TODO(), filePaths, swarm.DeployOptions{
+	if err := manager.deployer.Deploy(context.TODO(), filePaths, swarm.DeployOptions{
 		Options: swarm.Options{
 			ProjectName: stack.Name,
 			Host:        url,
@@ -62,7 +67,26 @@ func (manager *SwarmStackManager) Deploy(
 		},
 		RemoveOrphans: prune,
 		PullImage:     pullImage,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Swarm schedules and pulls images asynchronously, so check for early failures before reporting success.
+	waitCtx, cancel := context.WithTimeout(ctx, postDeployFailureCheckTimeout)
+	defer cancel()
+
+	result := manager.deployer.WaitForStatus(waitCtx, stack.Name, swarm.Options{
+		ProjectName: stack.Name,
+		Host:        url,
+		Env:         env,
+		WorkingDir:  stack.ProjectPath,
+		Registries:  portainerRegistriesToAuthConfigs(registries),
+	}, libstack.StatusRunning)
+	if result.Status == libstack.StatusError {
+		return fmt.Errorf("deployment failed: %s", result.ErrorMsg)
+	}
+
+	return nil
 }
 
 // Remove deletes all resources belonging to a Swarm stack.

--- a/pkg/libstack/swarm/swarm.go
+++ b/pkg/libstack/swarm/swarm.go
@@ -769,6 +769,8 @@ func (d *SwarmDeployer) WaitForStatus(
 					}
 
 					if errorMessage != "" {
+						// An error message means a service failed, so the result must reflect that.
+						waitResult.Status = libstack.StatusError
 						waitResult.ErrorMsg = errorMessage
 						return nil
 					}
@@ -860,7 +862,8 @@ func getServiceStatus(
 			return libstack.StatusStarting, "", nil
 		case swarm.TaskStateRemove:
 			return libstack.StatusRemoving, "", nil
-		case swarm.TaskStateFailed:
+		case swarm.TaskStateFailed, swarm.TaskStateRejected:
+			// Rejected means the task could never start (e.g. missing image, no disk space).
 			return libstack.StatusError, task.Status.Err, nil
 		default:
 			return libstack.StatusUnknown, "", nil

--- a/pkg/libstack/swarm/swarm_unit_test.go
+++ b/pkg/libstack/swarm/swarm_unit_test.go
@@ -469,6 +469,7 @@ services:
 type mockAPIClient struct {
 	client.APIClient
 	serviceListFn   func(context.Context, swarm.ServiceListOptions) ([]swarm.Service, error)
+	taskListFn      func(context.Context, swarm.TaskListOptions) ([]swarm.Task, error)
 	serviceUpdateFn func(
 		context.Context,
 		string,
@@ -484,6 +485,14 @@ func (m *mockAPIClient) ServiceList(ctx context.Context, opts swarm.ServiceListO
 	}
 
 	return m.serviceListFn(ctx, opts)
+}
+
+func (m *mockAPIClient) TaskList(ctx context.Context, opts swarm.TaskListOptions) ([]swarm.Task, error) {
+	if m.taskListFn == nil {
+		return nil, nil
+	}
+
+	return m.taskListFn(ctx, opts)
 }
 
 func (m *mockAPIClient) ServiceUpdate(
@@ -559,6 +568,63 @@ func Test_deployServices_forceRecreate(t *testing.T) {
 			err := deployServices(context.Background(), mock, nil, services, namespace, false, tt.forceRecreate)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedForceUpdate, capturedForceUpdate)
+		})
+	}
+}
+
+func Test_getServiceStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		task           swarm.Task
+		expectedStatus libstack.Status
+		expectedErrMsg string
+	}{
+		{
+			name:           "running task reports running",
+			task:           swarm.Task{Status: swarm.TaskStatus{State: swarm.TaskStateRunning}},
+			expectedStatus: libstack.StatusRunning,
+		},
+		{
+			name:           "pending task reports starting",
+			task:           swarm.Task{Status: swarm.TaskStatus{State: swarm.TaskStatePending}},
+			expectedStatus: libstack.StatusStarting,
+		},
+		{
+			name:           "failed task reports error with message",
+			task:           swarm.Task{Status: swarm.TaskStatus{State: swarm.TaskStateFailed, Err: "task: non-zero exit (1)"}},
+			expectedStatus: libstack.StatusError,
+			expectedErrMsg: "task: non-zero exit (1)",
+		},
+		{
+			// Regression case for #13213: a rejected task must report an error, not "unknown".
+			name: "rejected task reports error with message",
+			task: swarm.Task{Status: swarm.TaskStatus{
+				State: swarm.TaskStateRejected,
+				Err:   "No such image: this-image-definitely-does-not-exist-xyz:latest",
+			}},
+			expectedStatus: libstack.StatusError,
+			expectedErrMsg: "No such image: this-image-definitely-does-not-exist-xyz:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockAPIClient{
+				taskListFn: func(context.Context, swarm.TaskListOptions) ([]swarm.Task, error) {
+					return []swarm.Task{tt.task}, nil
+				},
+			}
+
+			svc := swarm.Service{ID: "svc-id-1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "mystack_web"}}}
+
+			status, errMsg, err := getServiceStatus(context.Background(), mock, svc)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedStatus, status)
+			require.Equal(t, tt.expectedErrMsg, errMsg)
 		})
 	}
 }


### PR DESCRIPTION
## What

Addresses #13213. Portainer reported a Docker Swarm stack as successfully deployed even when the image could not be pulled (e.g. missing image, disk full).

## Why this happens

Docker Swarm deployment is async: Docker accepts the "create/update service" request and replies immediately, before it has actually scheduled the task or pulled the image on any node. The real outcome (running, or rejected because the image couldn't be pulled) is only known afterwards. 
## Fix

After deploying, Portainer now polls Docker for the real status, using `WaitForStatus`(with 30s timeout).

Also Fixed `getServiceStatus`, it recognized a "failed" task as an error, but not a "rejected" one — which is the actual state Docker puts a task in when it can't pull the image. 


## Open question: toast message

Not changed in this PR: the "Stack successfully created" toast shows up immediately on create, before we know if the deployment actually worked. The real outcome is already shown on the stack's own page, so this is probably just a rephrase (e.g. "Stack created" instead of implying it's fully up) — flagging for discussion rather than changing it here.

## Test plan

- Added `Test_getServiceStatus` covering Running/Pending/Failed/Rejected task states.
- `go build ./...` and the affected test suites pass.
- Manually reproduced before/after with:
  ```yaml
  services:
    bad:
      image: this-image-definitely-does-not-exist-xyz:latest
      deploy:
        replicas: 1
  ```
  Before: stack shows Active forever. After: stack flips to Error with the pull failure message within ~30s.
EOF
)"


## Before

https://github.com/user-attachments/assets/fee0855e-ee2a-4ef2-98f2-d8018a54509c


## After


https://github.com/user-attachments/assets/ee478aad-a493-4a6a-8914-e1ae53253ef7


