### PR TITLE
fix(containers): prevent page reset on window focus

### DIFF
--- a/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
+++ b/app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
@@ -97,7 +97,8 @@ export function ContainersDatatable({
             withColumnFilters(
               tableState.columnFilters,
               tableState.setColumnFilters
-            )
+            ),
+            (options) => ({ ...options, autoResetPageIndex: false })
           )}
         />
       </TableSettingsProvider>


### PR DESCRIPTION
Fixes #13027

## Problem

When you switch away from the Portainer tab and then switch back, the Containers page resets to page 1, even if you were looking at page 2 or 3.

## What Caused It

The page was automatically resetting because three things were happening together:

**Automatic refresh on tab focus**: When you switch back to the Portainer tab, the app refreshes the container list automatically


**Where it happened:**
```
app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx
Lines 96-101 (the extendTableOptions section)
```

## The Fix

We added one line to tell the table: "Don't auto-reset the page when you see new data, because we're just refreshing the same list."

**File changed:**
- `app/react/docker/containers/ListView/ContainersDatatable/ContainersDatatable.tsx` — Added 1 line to disable auto-reset behavior

## Testing

**Before**

https://github.com/user-attachments/assets/5a9ab3c3-ff96-4357-b99a-6fa2fa52202d

**After**

https://github.com/user-attachments/assets/781dec1f-b5a0-4d55-8b59-0ebaadc15c5d