### PR TITLE
fix(swarm): resolve relative env_file/file paths against the compose file's directory

### DIFF
--- a/pkg/libstack/swarm/swarm.go
+++ b/pkg/libstack/swarm/swarm.go
@@ -651,6 +651,14 @@ func getConfigDetails(filePaths []string, workingDir string, env []string) (comp
 		return details, errors.New("at least one compose file must be specified")
 	}
 
+	// Relative env_file/file: paths inside a compose file are resolved against
+	// the directory containing that compose file, not the stack root. Callers
+	// (e.g. api/exec/swarm_stack.go) pass the stack root as workingDir, which is
+	// incorrect for compose files located in a subdirectory of the stack. Derive
+	// the working dir from the compose file's own directory to keep behavior
+	// symmetric with the standalone compose deployer.
+	workingDir = filepath.Dir(filePaths[0])
+
 	details.WorkingDir = workingDir
 
 	details.ConfigFiles = make([]composetypes.ConfigFile, 0, len(filePaths))

--- a/pkg/libstack/swarm/swarm_unit_test.go
+++ b/pkg/libstack/swarm/swarm_unit_test.go
@@ -466,6 +466,42 @@ services:
 	}
 }
 
+// Test_getConfig_envFileInSubdirectory is a regression test ensuring that a
+// relative env_file in a compose file located in a SUBDIRECTORY of the stack
+// resolves against the compose file's own directory, not the stack root. A
+// decoy stack.env at the stack root must be ignored in favour of the sibling
+// stack.env next to the compose file.
+func Test_getConfig_envFileInSubdirectory(t *testing.T) {
+	root := t.TempDir()
+
+	// Decoy env file at the stack root: must NOT be picked up.
+	require.NoError(t, os.WriteFile(filesystem.JoinPaths(root, "stack.env"), []byte("FOO=fromroot"), 0o644))
+
+	subDir := filesystem.JoinPaths(root, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	composePath := filesystem.JoinPaths(subDir, "docker-compose.yml")
+	require.NoError(t, os.WriteFile(composePath, []byte(`services:
+  web:
+    image: busybox
+    env_file:
+      - stack.env`), 0o644))
+
+	// Sibling env file next to the compose file: this is the one that must win.
+	require.NoError(t, os.WriteFile(filesystem.JoinPaths(subDir, "stack.env"), []byte("FOO=fromsub"), 0o644))
+
+	getStrPointer := func(s string) *string { return &s }
+
+	// workingDir is the stack ROOT, exactly as api/exec/swarm_stack.go passes it.
+	cfg, err := getConfig([]string{composePath}, root, nil)
+	require.NoError(t, err)
+	require.Len(t, cfg.Services, 1)
+
+	svc := cfg.Services[0]
+	require.Equal(t, composetypes.MappingWithEquals{"FOO": getStrPointer("fromsub")}, svc.Environment)
+	require.Equal(t, composetypes.StringList{filesystem.JoinPaths(subDir, "stack.env")}, svc.EnvFile)
+}
+
 type mockAPIClient struct {
 	client.APIClient
 	serviceListFn   func(context.Context, swarm.ServiceListOptions) ([]swarm.Service, error)


### PR DESCRIPTION
## Problem

Deploying a Swarm stack whose compose file lives in a **subdirectory** of the stack (a common layout for Git-deployed stacks, e.g. `myapp/docker-compose.yml`) fails to resolve relative `env_file:` entries. Instead of resolving them next to the compose file, Portainer resolves them against the **stack root**, so the env file is either not found or the wrong file is picked up. The same wrong anchoring also affects other compose-relative paths loaded by compose-go (`configs`/`secrets` `file:`, bind-mount sources, build context).

Fixes #13226.

## Cause

This regressed in commit `3d0d95d` ("replace docker binary with libstack"), which moved Swarm deployment from shelling out to the `docker` binary over to the in-process `libstack` deployer. It first shipped in **2.39.4 LTS** and is present on **develop** and **2.43.0 STS**.

In `pkg/libstack/swarm/swarm.go`, `getConfigDetails` set `details.WorkingDir = workingDir`, where `workingDir` is the value the caller passes in. The sole production caller, `api/exec/swarm_stack.go`, passes the **stack root** (`stack.ProjectPath`) as `WorkingDir`. compose-go resolves relative `env_file`/`file:` paths against `details.WorkingDir`, so a relative `env_file` declared in a compose file located in a subdirectory was incorrectly resolved at the stack root. (This branch also pre-absolutizes env files via `resolveEnvFilePaths(config, workingDir)`, which used the same wrong root.)

Real `docker stack deploy` (docker/cli) derives the working dir from the compose file path itself, and Portainer's own **standalone compose deployer** (`pkg/libstack/compose/composeplugin.go`, `createProject`) defaults its working dir to `filepath.Dir(configFilepaths[0])`. The Swarm path was the odd one out.

## Fix

One line in `getConfigDetails` (after the "at least one compose file" guard, before `details.WorkingDir` and `resolveEnvFilePaths` are used), so it corrects both consumers at once:

```go
workingDir = filepath.Dir(filePaths[0])
```

This anchors relative path resolution on the directory containing the compose file, matching both the standalone compose deployer and upstream `docker stack deploy`. `path/filepath` was already imported and the guard guarantees `filePaths[0]` is safe.

Because `getConfigDetails` feeds `getConfig`, which is called by both the `Validate()` and `Deploy` paths, the single change covers both validation and deployment.

### Before / After

- **Before:** relative `env_file` in `<stack>/sub/docker-compose.yml` resolved against `<stack>/` (stack root) → wrong file or "file not found".
- **After:** it resolves against `<stack>/sub/` (the compose file's directory) → correct, and consistent with standalone compose and `docker stack deploy`.

### Note on the common case

For top-level compose files (`EntryPoint` with no subdirectory), `filepath.Dir(filePaths[0])` equals the stack root, so the change is a strict no-op there; it only changes behavior for nested compose files — exactly the broken case.

## Regression test

`Test_getConfig_envFileInSubdirectory` in `pkg/libstack/swarm/swarm_unit_test.go`:

- Plants a **decoy** `stack.env` (`FOO=fromroot`) at the stack root and the real `stack.env` (`FOO=fromsub`) next to a compose file in `sub/`.
- Calls `getConfig` with the stack **root** as `workingDir`, mirroring exactly how `api/exec/swarm_stack.go` calls it in production.
- Asserts the sibling file wins (`FOO=fromsub`) and `EnvFile` resolves to `sub/stack.env`.

Without the fix the test fails (`FOO=fromroot`); with the fix it passes. `go test ./pkg/libstack/...` is green and `go vet` / `gofmt -l` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
