### PR TITLE
fix(stacks): support swarm job services in stack status and service views

### DIFF
--- a/app/docker/models/service.test.ts
+++ b/app/docker/models/service.test.ts
@@ -1,0 +1,58 @@
+import { Service } from 'docker-types';
+
+import { PortainerResponse } from '@/react/docker/types';
+
+import { ServiceViewModel } from './service';
+
+function buildService(
+  mode: Service['Spec']['Mode']
+): PortainerResponse<Service> {
+  return {
+    ID: 'service-id',
+    Spec: {
+      Name: 'my-service',
+      Mode: mode,
+    },
+  };
+}
+
+describe('ServiceViewModel scheduling mode', () => {
+  it('detects replicated mode and its replica count', () => {
+    const model = new ServiceViewModel(
+      buildService({ Replicated: { Replicas: 3 } })
+    );
+
+    expect(model.Mode).toBe('replicated');
+    expect(model.Replicas).toBe(3);
+  });
+
+  it('detects global mode', () => {
+    const model = new ServiceViewModel(buildService({ Global: {} }));
+
+    expect(model.Mode).toBe('global');
+    expect(model.Replicas).toBeUndefined();
+  });
+
+  it('detects replicated-job mode and uses total completions as replicas', () => {
+    const model = new ServiceViewModel(
+      buildService({ ReplicatedJob: { MaxConcurrent: 1, TotalCompletions: 5 } })
+    );
+
+    expect(model.Mode).toBe('replicated-job');
+    expect(model.Replicas).toBe(5);
+  });
+
+  it('detects global-job mode', () => {
+    const model = new ServiceViewModel(buildService({ GlobalJob: {} }));
+
+    expect(model.Mode).toBe('global-job');
+    expect(model.Replicas).toBeUndefined();
+  });
+
+  it('falls back to global when the mode is missing', () => {
+    const model = new ServiceViewModel(buildService(undefined));
+
+    expect(model.Mode).toBe('global');
+    expect(model.Replicas).toBeUndefined();
+  });
+});

--- a/app/docker/models/service.ts
+++ b/app/docker/models/service.ts
@@ -150,6 +150,11 @@ export class ServiceViewModel {
     if (data.Spec?.Mode?.Replicated) {
       this.Mode = 'replicated';
       this.Replicas = data.Spec.Mode.Replicated.Replicas;
+    } else if (data.Spec?.Mode?.ReplicatedJob) {
+      this.Mode = 'replicated-job';
+      this.Replicas = data.Spec.Mode.ReplicatedJob.TotalCompletions;
+    } else if (data.Spec?.Mode?.GlobalJob) {
+      this.Mode = 'global-job';
     } else {
       this.Mode = 'global';
     }

--- a/app/docker/views/services/edit/includes/tasks.html
+++ b/app/docker/views/services/edit/includes/tasks.html
@@ -1,6 +1,6 @@
 <docker-service-tasks-datatable
   ng-if="tasks.length > 0"
   dataset="tasks"
-  is-slot-column-visible="service.Mode !== 'global'"
+  is-slot-column-visible="service.Mode !== 'global' && service.Mode !== 'global-job'"
   service-name="service.Name"
 ></docker-service-tasks-datatable>

--- a/app/react/docker/services/ListView/ServicesDatatable/columns/schedulingMode/schedulingMode.tsx
+++ b/app/react/docker/services/ListView/ServicesDatatable/columns/schedulingMode/schedulingMode.tsx
@@ -29,12 +29,19 @@ function Cell({
   }
 
   const mode = getValue();
+  const isJob = mode === 'replicated-job' || mode === 'global-job';
+
   return (
     <div className="flex items-center gap-3">
       {mode}
-      <code>{totalRunningTasks(item.Tasks)}</code> /{' '}
       <code>
-        {mode === 'replicated'
+        {isJob
+          ? totalCompletedTasks(item.Tasks)
+          : totalRunningTasks(item.Tasks)}
+      </code>{' '}
+      /{' '}
+      <code>
+        {mode === 'replicated' || mode === 'replicated-job'
           ? item.Replicas
           : availableNodeCount(nodesQuery.data, item)}
       </code>
@@ -48,6 +55,10 @@ function totalRunningTasks(tasks: Array<TaskViewModel>) {
     (task) =>
       task.Status?.State === 'running' && task.DesiredState === 'running'
   ).length;
+}
+
+function totalCompletedTasks(tasks: Array<TaskViewModel>) {
+  return tasks.filter((task) => task.Status?.State === 'complete').length;
 }
 
 function availableNodeCount(nodes: Array<Node>, service: ServiceViewModel) {

--- a/pkg/libstack/swarm/swarm.go
+++ b/pkg/libstack/swarm/swarm.go
@@ -786,14 +786,24 @@ func (d *SwarmDeployer) WaitForStatus(
 					serviceStatuses = append(serviceStatuses, svcStatus)
 				}
 
-				if aggregateStatus(serviceStatuses) == status {
+				aggregate := aggregateStatus(serviceStatuses)
+
+				if aggregate == status {
+					return nil
+				}
+
+				// A stack made up entirely of job services never reaches "running":
+				// mirror the compose deployer and treat "completed" as success.
+				if status == libstack.StatusRunning && aggregate == libstack.StatusCompleted {
+					waitResult.Status = libstack.StatusCompleted
+
 					return nil
 				}
 
 				log.Debug().
 					Str("project_name", projectName).
 					Str("required_status", string(status)).
-					Str("status", string(aggregateStatus(serviceStatuses))).
+					Str("status", string(aggregate)).
 					Msg("waiting for status")
 			}
 		})
@@ -831,6 +841,12 @@ func getServiceStatus(
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("failed to list tasks for service %s: %w", svc.Spec.Name, err)
+	}
+
+	if svc.Spec.Mode.ReplicatedJob != nil || svc.Spec.Mode.GlobalJob != nil {
+		status, errorMessage := jobServiceStatus(svc, tasks)
+
+		return status, errorMessage, nil
 	}
 
 	expectedRunningTaskCount := 0
@@ -879,6 +895,74 @@ func getServiceStatus(
 	}
 
 	return libstack.StatusUnknown, "", nil
+}
+
+// jobServiceStatus derives the status of a replicated-job or global-job service
+// from its tasks. Only tasks belonging to the current job iteration are
+// considered: on re-deployment swarm increments JobStatus.JobIteration and
+// completed tasks from previous iterations linger in the task history.
+func jobServiceStatus(svc swarm.Service, tasks []swarm.Task) (libstack.Status, string) {
+	if svc.JobStatus != nil {
+		iteration := svc.JobStatus.JobIteration.Index
+
+		currentTasks := make([]swarm.Task, 0, len(tasks))
+		for _, task := range tasks {
+			if task.JobIteration != nil && task.JobIteration.Index == iteration {
+				currentTasks = append(currentTasks, task)
+			}
+		}
+
+		tasks = currentTasks
+	}
+
+	runningCount, completedCount := 0, 0
+
+	for _, task := range tasks {
+		switch task.Status.State {
+		case swarm.TaskStateFailed, swarm.TaskStateRejected:
+			// Consistent with regular services: any failed task reports an error.
+			return libstack.StatusError, task.Status.Err
+		case swarm.TaskStateRemove:
+			return libstack.StatusRemoving, ""
+		case swarm.TaskStateRunning:
+			runningCount++
+		case swarm.TaskStateComplete:
+			completedCount++
+		}
+	}
+
+	if completedCount >= expectedJobCompletions(svc, len(tasks)) {
+		return libstack.StatusCompleted, ""
+	}
+
+	if runningCount > 0 {
+		return libstack.StatusRunning, ""
+	}
+
+	return libstack.StatusStarting, ""
+}
+
+// expectedJobCompletions returns the number of completed tasks required for a
+// job service to be considered done.
+func expectedJobCompletions(svc swarm.Service, currentTaskCount int) int {
+	if replicatedJob := svc.Spec.Mode.ReplicatedJob; replicatedJob != nil {
+		if replicatedJob.TotalCompletions != nil {
+			return int(*replicatedJob.TotalCompletions)
+		}
+
+		// Per the Docker API, MaxConcurrent is used when TotalCompletions is unset.
+		if replicatedJob.MaxConcurrent != nil {
+			return int(*replicatedJob.MaxConcurrent)
+		}
+
+		return 1
+	}
+
+	// Global job: swarm creates all tasks for the current iteration up front,
+	// one per eligible node, so the current task count is the target. The
+	// eligible node count cannot be derived from NodeList because placement
+	// constraints restrict which nodes get a task.
+	return max(currentTaskCount, 1)
 }
 
 // waitOnTasks polls until all tasks belonging to the namespace reach a terminal state.

--- a/pkg/libstack/swarm/swarm_status_test.go
+++ b/pkg/libstack/swarm/swarm_status_test.go
@@ -47,6 +47,33 @@ services:
 			ExpectedStatus:        libstack.StatusError,
 			ExpectedStatusMessage: "task: non-zero exit (1)",
 		},
+		{
+			TestName: "replicated-job",
+			FileContent: `version: '3'
+services:
+  job:
+    image: alpine:latest
+    command: ["sh", "-c", "echo done"]
+    deploy:
+      mode: replicated-job
+      replicas: 1
+      restart_policy:
+        condition: none`,
+			ExpectedStatus: libstack.StatusCompleted,
+		},
+		{
+			TestName: "global-job",
+			FileContent: `version: '3'
+services:
+  job:
+    image: alpine:latest
+    command: ["sh", "-c", "echo done"]
+    deploy:
+      mode: global-job
+      restart_policy:
+        condition: none`,
+			ExpectedStatus: libstack.StatusCompleted,
+		},
 	}
 
 	ensureSwarmMode(t)

--- a/pkg/libstack/swarm/swarm_unit_test.go
+++ b/pkg/libstack/swarm/swarm_unit_test.go
@@ -628,3 +628,189 @@ func Test_getServiceStatus(t *testing.T) {
 		})
 	}
 }
+
+func Test_getServiceStatus_jobService(t *testing.T) {
+	t.Parallel()
+
+	// A completed job task must report "completed", proving the job branch is
+	// taken instead of the regular service logic (which would report "unknown").
+	mock := &mockAPIClient{
+		taskListFn: func(context.Context, swarm.TaskListOptions) ([]swarm.Task, error) {
+			return []swarm.Task{
+				{Status: swarm.TaskStatus{State: swarm.TaskStateComplete}},
+			}, nil
+		},
+	}
+
+	svc := swarm.Service{
+		ID: "svc-id-1",
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{Name: "mystack_job"},
+			Mode:        swarm.ServiceMode{ReplicatedJob: &swarm.ReplicatedJob{}},
+		},
+	}
+
+	status, errMsg, err := getServiceStatus(context.Background(), mock, svc)
+	require.NoError(t, err)
+	require.Equal(t, libstack.StatusCompleted, status)
+	require.Empty(t, errMsg)
+}
+
+func Test_jobServiceStatus(t *testing.T) {
+	t.Parallel()
+
+	uint64Ptr := func(v uint64) *uint64 { return &v }
+	iteration := func(index uint64) *swarm.Version { return &swarm.Version{Index: index} }
+
+	replicatedJobSvc := func(totalCompletions, maxConcurrent *uint64, jobIteration uint64) swarm.Service {
+		return swarm.Service{
+			Spec: swarm.ServiceSpec{
+				Mode: swarm.ServiceMode{
+					ReplicatedJob: &swarm.ReplicatedJob{
+						MaxConcurrent:    maxConcurrent,
+						TotalCompletions: totalCompletions,
+					},
+				},
+			},
+			JobStatus: &swarm.JobStatus{JobIteration: swarm.Version{Index: jobIteration}},
+		}
+	}
+
+	globalJobSvc := func(jobIteration uint64) swarm.Service {
+		return swarm.Service{
+			Spec:      swarm.ServiceSpec{Mode: swarm.ServiceMode{GlobalJob: &swarm.GlobalJob{}}},
+			JobStatus: &swarm.JobStatus{JobIteration: swarm.Version{Index: jobIteration}},
+		}
+	}
+
+	task := func(state swarm.TaskState, jobIteration uint64, errMsg string) swarm.Task {
+		return swarm.Task{
+			Status:       swarm.TaskStatus{State: state, Err: errMsg},
+			JobIteration: iteration(jobIteration),
+		}
+	}
+
+	tests := []struct {
+		name           string
+		service        swarm.Service
+		tasks          []swarm.Task
+		expectedStatus libstack.Status
+		expectedErrMsg string
+	}{
+		{
+			name:    "replicated-job with all completions reports completed",
+			service: replicatedJobSvc(uint64Ptr(2), uint64Ptr(1), 0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+			},
+			expectedStatus: libstack.StatusCompleted,
+		},
+		{
+			name:    "replicated-job with a running task reports running",
+			service: replicatedJobSvc(uint64Ptr(2), uint64Ptr(1), 0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateRunning, 0, ""),
+			},
+			expectedStatus: libstack.StatusRunning,
+		},
+		{
+			name:    "replicated-job between task launches reports starting",
+			service: replicatedJobSvc(uint64Ptr(2), uint64Ptr(1), 0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+			},
+			expectedStatus: libstack.StatusStarting,
+		},
+		{
+			name:           "replicated-job without tasks reports starting",
+			service:        replicatedJobSvc(uint64Ptr(1), uint64Ptr(1), 0),
+			tasks:          []swarm.Task{},
+			expectedStatus: libstack.StatusStarting,
+		},
+		{
+			name:    "replicated-job with a failed task reports error with message",
+			service: replicatedJobSvc(uint64Ptr(1), uint64Ptr(1), 0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateFailed, 0, "task: non-zero exit (1)"),
+			},
+			expectedStatus: libstack.StatusError,
+			expectedErrMsg: "task: non-zero exit (1)",
+		},
+		{
+			name:    "replicated-job ignores completed tasks from previous iterations",
+			service: replicatedJobSvc(uint64Ptr(2), uint64Ptr(1), 10),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 5, ""),
+				task(swarm.TaskStateComplete, 5, ""),
+				task(swarm.TaskStatePending, 10, ""),
+			},
+			expectedStatus: libstack.StatusStarting,
+		},
+		{
+			name:    "replicated-job falls back to max concurrent when total completions is unset",
+			service: replicatedJobSvc(nil, uint64Ptr(3), 0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+			},
+			expectedStatus: libstack.StatusCompleted,
+		},
+		{
+			name:    "global-job with all tasks complete reports completed",
+			service: globalJobSvc(0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+			},
+			expectedStatus: libstack.StatusCompleted,
+		},
+		{
+			name:    "global-job with a running task reports running",
+			service: globalJobSvc(0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateComplete, 0, ""),
+				task(swarm.TaskStateRunning, 0, ""),
+			},
+			expectedStatus: libstack.StatusRunning,
+		},
+		{
+			name:           "global-job without tasks reports starting",
+			service:        globalJobSvc(0),
+			tasks:          []swarm.Task{},
+			expectedStatus: libstack.StatusStarting,
+		},
+		{
+			name:    "global-job with a rejected task reports error with message",
+			service: globalJobSvc(0),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateRejected, 0, "No such image: missing:latest"),
+			},
+			expectedStatus: libstack.StatusError,
+			expectedErrMsg: "No such image: missing:latest",
+		},
+		{
+			name:    "failed task from a previous iteration is ignored",
+			service: replicatedJobSvc(uint64Ptr(1), uint64Ptr(1), 10),
+			tasks: []swarm.Task{
+				task(swarm.TaskStateFailed, 5, "task: non-zero exit (1)"),
+				task(swarm.TaskStateComplete, 10, ""),
+			},
+			expectedStatus: libstack.StatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, errMsg := jobServiceStatus(tt.service, tt.tasks)
+			require.Equal(t, tt.expectedStatus, status)
+			require.Equal(t, tt.expectedErrMsg, errMsg)
+		})
+	}
+}


### PR DESCRIPTION
This addresses the remaining gaps from #5383 (*Swarm Job Support*, labeled `contributions-welcome`) and fixes the symptom reported in https://github.com/orgs/portainer/discussions/12474, where a service created with `Mode.ReplicatedJob` is displayed as **"global"** in the UI.

## Background

Docker Swarm supports four mutually exclusive service modes: `Replicated`, `Global`, `ReplicatedJob`, and `GlobalJob` (jobs were introduced in Docker 20.10 via docker/cli#2262 and gained `docker stack deploy` support via docker/cli#2907).

Since the swarm stack deployment was ported to run in-process on top of docker/cli's `cli/compose/convert` package, the compose-to-ServiceSpec conversion itself is already correct on `develop`: `deploy.mode: replicated-job` produces `ReplicatedJob{MaxConcurrent, TotalCompletions}` (with `deploy.replicas` feeding both, defaulting to 1), and `deploy.mode: global-job` produces `GlobalJob{}` — see `convertDeployMode` in docker/cli.

However, two parts of Portainer still have no notion of job modes:

1. **Stack status polling** (`pkg/libstack/swarm/swarm.go`): `getServiceStatus` only handles `Mode.Replicated` and `Mode.Global`. Job tasks that finish in state `complete` fall through to `StatusUnknown`. As a result, the post-deploy failure check in `SwarmStackManager.Deploy` polls until its timeout for every stack that contains a job, and a stack consisting only of job services can never reach `running`.
2. **UI** (`app/docker/models/service.ts`): the service view model maps anything that is not `Replicated` to `global`. Job services are therefore shown as "global", with the available node count as the denominator and no completion information (this is exactly what discussion 12474 reports).

## What this PR changes

### Commit 1 — `fix(stacks): report correct status for swarm job services` (backend, independently mergeable)

- `getServiceStatus` branches to a new `jobServiceStatus` helper for `ReplicatedJob`/`GlobalJob` services:
  - Only tasks belonging to the current `JobStatus.JobIteration` are considered. Completed tasks from previous iterations linger in the task history, and without this filter a re-deploy would immediately (and wrongly) be reported as completed.
  - `failed`/`rejected` tasks report `StatusError` with the task error (consistent with the existing behavior for regular services), `remove` reports `StatusRemoving`.
  - Completion target: `TotalCompletions`, falling back to `MaxConcurrent` per the Docker API contract, then 1, for replicated jobs. For global jobs the current-iteration task count is used — swarm creates all tasks of an iteration up front, and `NodeList` cannot be used because placement constraints restrict which nodes are eligible (same heuristic as docker/cli's job progress reporter).
  - When the target is reached the service reports `StatusCompleted`; otherwise a running task means `StatusRunning`, else `StatusStarting`.
- `WaitForStatus` now mirrors the compose deployer (`pkg/libstack/compose/status.go`): waiting for `running` succeeds with `StatusCompleted` when the whole stack has completed. Mixed stacks (long-running service + finished job) already aggregate to `running` via `AggregateStatusCounts`, so only the all-jobs case needed this.

### Commit 2 — `fix(services): display swarm job services with their real scheduling mode` (frontend)

- `ServiceViewModel` now detects all four modes; for `replicated-job`, `Replicas` carries `TotalCompletions`.
- The services list shows `replicated-job` / `global-job` with **completed/total** counts instead of "global" with running/node counts. The scale button remains replicated-only.
- The task slot column stays hidden for `global-job` services (their tasks have no slot, like `global`).

Creating or scaling job services from the service creation UI is intentionally out of scope to keep this reviewable.

## Verification

**Unit tests**

- `go test ./pkg/libstack/swarm/` — 12 new table-driven cases for `jobServiceStatus` (completion counting, `MaxConcurrent` fallback, iteration filtering, failure propagation for both job modes) plus a case proving `getServiceStatus` takes the job branch.
- `vitest app/docker/models/service.test.ts` — view model mapping for all four modes.

**Integration tests** (single-node swarm, `INTEGRATION_TEST=1 go test ./pkg/libstack/swarm/ -run TestSwarmProjectStatus`): new `replicated-job` and `global-job` stack cases reach `StatusCompleted`. All pre-existing cases still pass.

**Manual end-to-end** through the Portainer API on a single-node swarm, deploying a stack containing a `replicated-job` and a regular replicated service:

```
$ docker service ls
ID             NAME           MODE             REPLICAS              IMAGE
0edy6o8aenpa   jobstack_job   replicated job   0/1 (1/1 completed)   alpine:latest
wap884zxcmda   jobstack_web   replicated       1/1                   nginx:alpine

$ docker service inspect jobstack_job --format '{{json .Spec.Mode}}'
{"ReplicatedJob":{"MaxConcurrent":1,"TotalCompletions":1}}
```

The job task runs exactly once to `Complete` and is not rescheduled, the stack create request returns promptly instead of polling into the post-deploy timeout, and the services list displays `replicated-job 1 / 1`.

`pnpm typecheck`, ESLint and Prettier pass on the touched files; `go vet`/`gofmt` are clean.

## Notes / accepted trade-offs

- A `replicated-job` with `restart_policy.condition: on-failure` that fails transiently reports `error` during the post-deploy check even if a retry later succeeds — identical to the existing behavior for regular services.
- The list-view completed-task counter does not filter by `JobIteration` (the task view model does not carry that field); right after a re-deploy the numerator can briefly over-count. This is display-only and seemed not worth growing the task model for.

Closes #5383
Related: https://github.com/orgs/portainer/discussions/12474
