### PR TITLE
fix(kubernetes): re-read local service account token on each request

### DIFF
--- a/api/http/proxy/factory/kubernetes/token.go
+++ b/api/http/proxy/factory/kubernetes/token.go
@@ -3,19 +3,23 @@ package kubernetes
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/dataservices"
 	"github.com/rs/zerolog/log"
 )
 
-const defaultServiceAccountTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+var defaultServiceAccountTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 type tokenManager struct {
 	tokenCache *tokenCache
 	kubecli    portainer.KubeClient
 	dataStore  dataservices.DataStore
-	adminToken string
+
+	adminTokenMu       sync.Mutex
+	adminToken         string
+	adminTokenFromFile bool // true only for local (in-cluster) environments
 }
 
 // NewTokenManager returns a pointer to a new instance of tokenManager.
@@ -36,12 +40,33 @@ func NewTokenManager(kubecli portainer.KubeClient, dataStore dataservices.DataSt
 		}
 
 		tokenManager.adminToken = string(token)
+		tokenManager.adminTokenFromFile = true
 	}
 
 	return tokenManager, nil
 }
 
+// GetAdminServiceAccountToken re-reads the projected token file on each call so kubelet
+// rotations are picked up, keeping the last-known-good value on a read error (issue #13150).
 func (manager *tokenManager) GetAdminServiceAccountToken() string {
+	manager.adminTokenMu.Lock()
+	defer manager.adminTokenMu.Unlock()
+
+	if !manager.adminTokenFromFile {
+		return manager.adminToken
+	}
+
+	token, err := os.ReadFile(defaultServiceAccountTokenFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to re-read local admin service account token, using last known value")
+		return manager.adminToken
+	}
+
+	if len(token) == 0 {
+		return manager.adminToken
+	}
+
+	manager.adminToken = string(token)
 	return manager.adminToken
 }
 

--- a/api/http/proxy/factory/kubernetes/token_test.go
+++ b/api/http/proxy/factory/kubernetes/token_test.go
@@ -1,0 +1,132 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func useTempTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte(contents), 0o600); err != nil {
+		t.Fatalf("failed seeding token file: %v", err)
+	}
+	original := defaultServiceAccountTokenFile
+	defaultServiceAccountTokenFile = tokenFile
+	t.Cleanup(func() { defaultServiceAccountTokenFile = original })
+	return tokenFile
+}
+
+// regression test for issue #13150: a rotated on-disk token must be picked up
+func TestAdminTokenRefreshesAfterRotation(t *testing.T) {
+	const tokenV1 = "TOKEN_V1_minted_at_pod_start"
+	const tokenV2 = "TOKEN_V2_rotated_by_kubelet"
+
+	tokenFile := useTempTokenFile(t, tokenV1)
+
+	manager, err := NewTokenManager(nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("NewTokenManager failed: %v", err)
+	}
+
+	if got := manager.GetAdminServiceAccountToken(); got != tokenV1 {
+		t.Fatalf("expected freshly-read token %q, got %q", tokenV1, got)
+	}
+
+	if err := os.WriteFile(tokenFile, []byte(tokenV2), 0o600); err != nil {
+		t.Fatalf("failed rotating token file: %v", err)
+	}
+
+	if got := manager.GetAdminServiceAccountToken(); got != tokenV2 {
+		t.Fatalf("expected rotated token %q, got stale %q", tokenV2, got)
+	}
+}
+
+// a read failure must fall back to the last-known-good token, not empty
+func TestAdminTokenFallsBackWhenFileUnreadable(t *testing.T) {
+	const tokenV1 = "TOKEN_V1_last_known_good"
+
+	tokenFile := useTempTokenFile(t, tokenV1)
+
+	manager, err := NewTokenManager(nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("NewTokenManager failed: %v", err)
+	}
+	if got := manager.GetAdminServiceAccountToken(); got != tokenV1 {
+		t.Fatalf("expected %q, got %q", tokenV1, got)
+	}
+
+	if err := os.Remove(tokenFile); err != nil {
+		t.Fatalf("failed removing token file: %v", err)
+	}
+
+	if got := manager.GetAdminServiceAccountToken(); got != tokenV1 {
+		t.Fatalf("expected fallback to last-known-good %q, got %q", tokenV1, got)
+	}
+}
+
+// Agent/Edge environments stay empty and never read the file
+func TestAdminTokenEmptyForNonLocalEnv(t *testing.T) {
+	original := defaultServiceAccountTokenFile
+	defaultServiceAccountTokenFile = filepath.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { defaultServiceAccountTokenFile = original })
+
+	manager, err := NewTokenManager(nil, nil, nil, false)
+	if err != nil {
+		t.Fatalf("NewTokenManager failed: %v", err)
+	}
+
+	if got := manager.GetAdminServiceAccountToken(); got != "" {
+		t.Fatalf("expected empty token for non-local env, got %q", got)
+	}
+}
+
+// concurrent readers while the file rotates, run under -race
+func TestAdminTokenRefreshConcurrent(t *testing.T) {
+	tokenFile := useTempTokenFile(t, "TOKEN_INITIAL")
+
+	manager, err := NewTokenManager(nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("NewTokenManager failed: %v", err)
+	}
+
+	stop := make(chan struct{})
+
+	var rotator sync.WaitGroup
+	rotator.Add(1)
+	go func() {
+		defer rotator.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				tmp := tokenFile + ".tmp"
+				if err := os.WriteFile(tmp, []byte("TOKEN_"+string(rune('A'+i%26))), 0o600); err != nil {
+					continue
+				}
+				_ = os.Rename(tmp, tokenFile)
+			}
+		}
+	}()
+
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for range 500 {
+				if got := manager.GetAdminServiceAccountToken(); got == "" {
+					t.Errorf("got empty token during concurrent refresh")
+					return
+				}
+			}
+		}()
+	}
+
+	readers.Wait()
+	close(stop)
+	rotator.Wait()
+}


### PR DESCRIPTION
closes #13150

### Changes:

When Portainer runs inside a Kubernetes cluster as a local environment, it read its service account token from the projected token file only once, when the proxy was first created, and then kept that value in memory. Kubernetes rotates that token on disk over time. Once the cached copy expired, every admin request to the Kubernetes API returned 401 and the environment showed as unreachable. The only way to recover was to restart the pod.

**How I reproduced it**

I ran Portainer inside a local kind cluster as a local Kubernetes environment. To avoid waiting an hour for the normal rotation, I set the projected token to expire in 10 minutes, which is the Kubernetes minimum. About 11 minutes after opening a Kubernetes view, every proxied call started returning 401 while a fresh token for the same service account still worked against the API server. Restarting the pod fixed it, which matched the report.

**How I fixed it**

The stale value was `tokenManager.adminToken` in `api/http/proxy/factory/kubernetes/token.go`. `GetAdminServiceAccountToken` now re-reads the token file on each call for local environments instead of returning the value cached at construction. Reading a local file is cheap and this is the same approach the Kubernetes client library already uses for the in-cluster config path. If the read fails it keeps serving the last known value instead of returning an empty token. Agent and Edge environments are not affected because they never set this token.

**How I tested it**

I added unit tests for the refresh after rotation, the fallback when the file cannot be read, the non local case staying empty, and a concurrent read test run under the race detector. I ran go build, go vet, the package tests and go test with the race detector and they all pass. I also built the fixed binary into an image, loaded it into the same kind cluster, and polled a proxied Kubernetes call from inside the cluster for about 15 minutes. It stayed at 200 the whole time, well past the point where the old build broke, with no unauthorized errors in the logs and no pod restarts.
