### PR TITLE
fix(stacks): strip surrounding quotes from stack env values

### DIFF
--- a/api/exec/swarm_stack.go
+++ b/api/exec/swarm_stack.go
@@ -49,7 +49,7 @@ func (manager *SwarmStackManager) Deploy(
 
 	env := make([]string, 0, len(stack.Env))
 	for _, ev := range stack.Env {
-		env = append(env, ev.Name+"="+ev.Value)
+		env = append(env, ev.Name+"="+stackutils.UnquoteEnvValue(ev.Value))
 	}
 
 	return manager.deployer.Deploy(context.TODO(), filePaths, swarm.DeployOptions{

--- a/api/stacks/stackutils/env.go
+++ b/api/stacks/stackutils/env.go
@@ -27,8 +27,21 @@ func BuildEnvMap(stack *portainer.Stack) map[string]string {
 	}
 
 	for _, pair := range stack.Env {
-		env[pair.Name] = pair.Value
+		env[pair.Name] = UnquoteEnvValue(pair.Value)
 	}
 
 	return env
+}
+
+// UnquoteEnvValue removes a single matched pair of surrounding quotes from an env
+// var value, matching how docker compose reads env-file values.
+func UnquoteEnvValue(value string) string {
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+
+	return value
 }

--- a/api/stacks/stackutils/env_test.go
+++ b/api/stacks/stackutils/env_test.go
@@ -1,0 +1,57 @@
+package stackutils
+
+import (
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnquoteEnvValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"double quoted", `"8005"`, "8005"},
+		{"single quoted", `'8005'`, "8005"},
+		{"unquoted", "8005", "8005"},
+		{"empty quoted", `""`, ""},
+		{"leading quote only", `"8005`, `"8005`},
+		{"trailing quote only", `8005"`, `8005"`},
+		{"quoted string", `"hello world"`, "hello world"},
+		{"inner quotes", `pa"ss"word`, `pa"ss"word`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, UnquoteEnvValue(tt.value))
+		})
+	}
+}
+
+func TestIsValidStackFile_QuotedPortEnvSubstitution(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := []byte(`
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "${API_PORT}:8005"
+`)
+
+	stack := &portainer.Stack{
+		EntryPoint: "docker-compose.yml",
+		Env:        []portainer.Pair{{Name: "API_PORT", Value: `"8005"`}},
+	}
+
+	err := IsValidStackFile(StackFileValidationConfig{
+		Content:          yamlContent,
+		SecuritySettings: &portainer.EndpointSecuritySettings{},
+		Env:              BuildEnvMap(stack),
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Problem

Fixes #13122. A quoted numeric value in a stack environment variable (for example `API_PORT="8005"`) used in a port mapping breaks redeploy.

The standalone deploy writes `stack.Env` to a `stack.env` file that `docker compose` reads with dotenv semantics, which strip the surrounding quotes. Other consumers use the `stack.Env` values verbatim, so `"${API_PORT}:8005"` interpolates to `"8005":8005` and the port parser rejects it:

- Standalone: the non-admin validation pre-check (`BuildEnvMap` -> `IsValidStackFile`) fails with `stack config file is invalid: invalid hostPort: "8005"`. Admins skip this check, so only non-admins were affected.
- Swarm: the deployer builds its env from `stack.Env` directly and parses with strict validation, so admins fail too with `services.web.ports.0 Does not match format 'ports'`.

## Fix

Add a small `UnquoteEnvValue` helper that strips a matched pair of surrounding quotes, matching how docker compose reads env-file values, and apply it where `stack.Env` is consumed:

- `BuildEnvMap` (validation path)
- the Swarm deployer's env building

so both paths use the same values the standalone deploy already does.

## Testing

- Table-driven unit tests over quoted, single-quoted, unquoted, empty, malformed and inner-quote formats.
- Verified end to end on both a standalone and a Swarm environment: admin and non-admin redeploys with `"8005"`, `'8005'` and `8005` all succeed, and unquoted values are unchanged.

## Standalone Docker

 ### Before
    

https://github.com/user-attachments/assets/c5620571-2ff6-4327-9cbc-c98e3ef35e7f

### After
      
   

https://github.com/user-attachments/assets/0d65eb02-f0ec-43e2-9173-9a32443b46c8

## Swarm

### Before
https://github.com/user-attachments/assets/6cc84973-f7eb-4394-81b0-51ec8df4f953


### After
https://github.com/user-attachments/assets/4f5626fc-0321-4b8e-bd7b-c5f97c3d84c7

