### PR TITLE
fix(images): send agent target header when removing swarm images

### DIFF
--- a/app/react/docker/images/ListView/ImagesDatatable/RemoveButtonMenu.tsx
+++ b/app/react/docker/images/ListView/ImagesDatatable/RemoveButtonMenu.tsx
@@ -95,7 +95,10 @@ export function RemoveButtonMenu({
     }
 
     deleteImageListMutation.mutate({
-      imageIds: selectedItems.map((image) => image.id),
+      imageIds: selectedItems.map((image) => ({
+        id: image.id,
+        nodeName: image.nodeName,
+      })),
       force,
     });
   }
@@ -110,11 +113,11 @@ function useDeleteImageListMutation() {
       imageIds,
       ...args
     }: {
-      imageIds: Array<string>;
+      imageIds: Array<{ id: string; nodeName?: string }>;
     } & Omit<Parameters<typeof deleteImage>[0], 'imageId' | 'environmentId'>) =>
-      processItemsInBatches(imageIds, (imageId) =>
-        deleteImage({ ...args, environmentId, imageId }).then(() =>
-          notifySuccess('Image successfully removed', imageId)
+      processItemsInBatches(imageIds, ({ id, nodeName }) =>
+        deleteImage({ ...args, environmentId, imageId: id, nodeName }).then(() =>
+          notifySuccess('Image successfully removed', id)
         )
       ),
     ...withInvalidate(queryClient, [queryKeys.base(environmentId)]),


### PR DESCRIPTION
closes #13113

### Problem

On a multi node Docker Swarm, removing unused images from the UI does nothing. You select the images, click Remove, and they stay in the list. This started after the images page was rebuilt in React.

To delete an image on a Swarm, Portainer has to tell the cluster which node the image lives on. That piece of information was getting dropped before the delete request was sent, so the request went to the wrong node and the image was never removed.

### Fix

Keep the node information attached to each image when it is removed, so the delete reaches the node that actually holds it.

The change is in one file: `app/react/docker/images/ListView/ImagesDatatable/RemoveButtonMenu.tsx`

### Testing

Tested on a 2 node Swarm with an image present on only one node. Before the change the image stayed after clicking Remove; after the change it is removed correctly. Typecheck and lint pass.

##### Before


https://github.com/user-attachments/assets/f85b0622-4077-488b-b022-393146f36214



##### After


https://github.com/user-attachments/assets/70c7852f-4f3b-4512-b3a5-e1c86c40e379

