### PR TITLE
feat(ui): trigger stack update when code editor receives Cmd-s or Ctrl-s

### DIFF
--- a/app/react/components/CodeEditor/CodeEditor.test.tsx
+++ b/app/react/components/CodeEditor/CodeEditor.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Extension } from '@codemirror/state';
+import { keymap as codeMirrorKeymap } from '@uiw/react-codemirror';
 
 import { mockClipboard } from '@/react/test-utils/clipboard';
 
@@ -132,4 +133,27 @@ test('should render with file name header when provided', async () => {
 
   expect(await findByText(fileName)).toBeInTheDocument();
   expect(await findByText(testValue)).toBeInTheDocument();
+});
+
+test('should register save keymap and call onSave command handler', () => {
+  const onSave = vi.fn();
+  const keymapOfSpy = vi.spyOn(codeMirrorKeymap, 'of');
+  render(<CodeEditor {...defaultProps} value="some content" onSave={onSave} />);
+
+  type KeyBindingLike = {
+    key?: string;
+    run?: (...args: unknown[]) => boolean;
+  };
+
+  const saveBinding = keymapOfSpy.mock.calls
+    .flatMap(([bindings]) =>
+      Array.isArray(bindings) ? (bindings as KeyBindingLike[]) : []
+    )
+    .find((binding: KeyBindingLike) => binding.key === 'Mod-s');
+
+  expect(saveBinding).toBeDefined();
+  expect(saveBinding?.run?.()).toBe(true);
+  expect(onSave).toHaveBeenCalledTimes(1);
+
+  keymapOfSpy.mockRestore();
 });

--- a/app/react/components/CodeEditor/CodeEditor.tsx
+++ b/app/react/components/CodeEditor/CodeEditor.tsx
@@ -34,6 +34,7 @@ interface Props extends AutomationTestingProps {
   fileName?: string;
   placeholder?: string;
   showToolbar?: boolean;
+  onSave?: () => void;
 }
 
 export const theme = createTheme({
@@ -82,10 +83,11 @@ export function CodeEditor({
   placeholder,
   showToolbar = true,
   'aria-label': ariaLabel,
+  onSave,
 }: Props & Pick<AriaAttributes, 'aria-label'>) {
   const [isRollback, setIsRollback] = useState(false);
 
-  const extensions = useCodeEditorExtensions(type, schema);
+  const extensions = useCodeEditorExtensions(type, schema, onSave);
 
   const handleVersionChange = useCallback(
     (version: number) => {

--- a/app/react/components/CodeEditor/useCodeEditorExtensions.ts
+++ b/app/react/components/CodeEditor/useCodeEditorExtensions.ts
@@ -7,7 +7,7 @@ import {
 import { dockerFile } from '@codemirror/legacy-modes/mode/dockerfile';
 import { shell } from '@codemirror/legacy-modes/mode/shell';
 import { keymap, Extension } from '@uiw/react-codemirror';
-import { highlightSpecialChars, lineNumbers } from '@codemirror/view';
+import { Command, highlightSpecialChars, lineNumbers } from '@codemirror/view';
 import type { JSONSchema7 } from 'json-schema';
 import { lintKeymap, lintGutter } from '@codemirror/lint';
 import { defaultKeymap } from '@codemirror/commands';
@@ -75,10 +75,29 @@ function yamlLanguage(schema?: JSONSchema7) {
 
 export function useCodeEditorExtensions(
   type?: CodeEditorType,
-  schema?: JSONSchema7
+  schema?: JSONSchema7,
+  onSave?: () => void,
 ): Extension[] {
+  const baseExtensions: Extension[] = [extendedHighlightSpecialChars];
+
+  if (onSave) {
+    const handleSave: Command = () => {
+      onSave();
+      return true;
+    };
+
+    const saveKeymap = keymap.of([
+      {
+        key: 'Mod-s', // 'Mod' maps to 'Cmd' on Mac and 'Ctrl' on Windows/Linux
+        run: handleSave,
+        preventDefault: true, // Prevents the browser's default save dialog
+      },
+    ]);
+
+    baseExtensions.push(saveKeymap);
+  }
+
   return useMemo(() => {
-    const baseExtensions = [extendedHighlightSpecialChars];
     switch (type) {
       case 'dockerfile':
         return [...baseExtensions, dockerFileLanguage];

--- a/app/react/docker/stacks/ItemView/StackEditorTab/StackEditorTabInner.tsx
+++ b/app/react/docker/stacks/ItemView/StackEditorTab/StackEditorTabInner.tsx
@@ -47,8 +47,14 @@ export function StackEditorTabInner({
     'PortainerStackUpdate'
   );
 
-  const { values, errors, setFieldValue, isValid, initialValues } =
-    useFormikContext<StackEditorFormValues>();
+  const {
+    values,
+    errors,
+    setFieldValue,
+    isValid,
+    initialValues,
+    submitForm,
+  } = useFormikContext<StackEditorFormValues>();
 
   usePreventExit(
     initialValues.stackFileContent,
@@ -70,6 +76,13 @@ export function StackEditorTabInner({
   });
 
   const isDeployDisabled = isOrphaned;
+
+  const onSave = useCallback(() => {
+    if (!isValid || isDeployDisabled) {
+      return;
+    }
+    submitForm();
+  }, [isValid, isDeployDisabled]);
 
   return (
     <Form className="form-horizontal">
@@ -120,6 +133,7 @@ export function StackEditorTabInner({
             data-cy="stack-editor"
             onVersionChange={handleVersionChange}
             versions={versions}
+            onSave={onSave}
           />
         </div>
       </div>


### PR DESCRIPTION
This pull request adds support for a "Save" keyboard shortcut (Cmd+S/Ctrl+S) to the `CodeEditor` component, allowing users to trigger a stack update via the keyboard.
