### PR TITLE
fix(endpoints): report edge check-in interval consistently in list and inspect

### DIFF
--- a/api/http/handler/endpoints/endpoint_inspect.go
+++ b/api/http/handler/endpoints/endpoint_inspect.go
@@ -51,6 +51,7 @@ func (handler *Handler) endpointInspect(w http.ResponseWriter, r *http.Request) 
 
 	hideFields(endpoint)
 	endpointutils.UpdateEdgeEndpointHeartbeat(endpoint, settings)
+	endpointutils.UpdateEdgeEndpointCheckinInterval(endpoint, settings)
 	endpoint.ComposeSyntaxMaxVersion = handler.ComposeStackManager.ComposeSyntaxMaxVersion()
 
 	excludeSnapshot, _ := request.RetrieveBooleanQueryParameter(r, "excludeSnapshot", true)

--- a/api/http/handler/endpoints/endpoint_inspect_test.go
+++ b/api/http/handler/endpoints/endpoint_inspect_test.go
@@ -1,0 +1,135 @@
+package endpoints
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/datastore"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/internal/snapshot"
+	"github.com/portainer/portainer/api/internal/testhelpers"
+	"github.com/portainer/portainer/api/pendingactions"
+
+	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupEndpointInspectHandler(t *testing.T, endpoints []portainer.Endpoint, edgeAgentCheckinInterval int) *Handler {
+	_, store := datastore.MustNewTestStore(t, true, true)
+
+	settings, err := store.Settings().Settings()
+	require.NoError(t, err, "error retrieving settings")
+	settings.EdgeAgentCheckinInterval = edgeAgentCheckinInterval
+	require.NoError(t, store.Settings().UpdateSettings(settings), "error updating settings")
+
+	for _, endpoint := range endpoints {
+		err := store.Endpoint().Create(&endpoint)
+		require.NoError(t, err, "error creating environment")
+	}
+
+	err = store.User().Create(&portainer.User{Username: "admin", Role: portainer.AdministratorRole})
+	require.NoError(t, err, "error creating a user")
+
+	handler := NewHandler(testhelpers.NewTestRequestBouncer())
+	handler.DataStore = store
+	handler.ComposeStackManager = testhelpers.NewComposeStackManager()
+	handler.SnapshotService, _ = snapshot.NewService("1s", store, nil, nil, nil)
+	handler.PendingActionsService = pendingactions.NewService(store, nil)
+
+	return handler
+}
+
+func doEndpointInspectRequest(t *testing.T, h *Handler, id portainer.EndpointID) portainer.Endpoint {
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/endpoints/%d?excludeSnapshot=true", id), nil)
+
+	ctx := security.StoreTokenData(req, &portainer.TokenData{ID: 1, Username: "admin", Role: 1})
+	req = req.WithContext(ctx)
+
+	restrictedCtx := security.StoreRestrictedRequestContext(req, &security.RestrictedRequestContext{UserID: 1, IsAdmin: true})
+	req = req.WithContext(restrictedCtx)
+
+	testhelpers.AddTestSecurityCookie(req, "Bearer dummytoken")
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Status should be 200")
+
+	body, err := io.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var endpoint portainer.Endpoint
+	require.NoError(t, json.Unmarshal(body, &endpoint))
+
+	return endpoint
+}
+
+// Test_EndpointInspect_EdgeCheckinInterval ensures the inspect response resolves the
+// effective edge check-in interval the same way the list response does. Edge endpoints
+// without a specific interval fall back to the global default, while non-edge endpoints
+// report no interval. See https://github.com/portainer/portainer/issues/5384.
+func Test_EndpointInspect_EdgeCheckinInterval(t *testing.T) {
+	t.Parallel()
+
+	const globalCheckinInterval = 60
+
+	edgeNoInterval := portainer.Endpoint{ID: 1, GroupID: 1, Type: portainer.EdgeAgentOnDockerEnvironment, UserTrusted: true}
+	edgeWithInterval := portainer.Endpoint{ID: 2, GroupID: 1, Type: portainer.EdgeAgentOnDockerEnvironment, EdgeCheckinInterval: 7, UserTrusted: true}
+	nonEdge := portainer.Endpoint{ID: 3, GroupID: 1, Type: portainer.DockerEnvironment}
+
+	handler := setupEndpointInspectHandler(t, []portainer.Endpoint{edgeNoInterval, edgeWithInterval, nonEdge}, globalCheckinInterval)
+
+	tests := []struct {
+		name     string
+		id       portainer.EndpointID
+		expected int
+	}{
+		{"edge endpoint without a specific interval falls back to the global default", 1, globalCheckinInterval},
+		{"edge endpoint with a specific interval keeps its own value", 2, 7},
+		{"non-edge endpoint reports no check-in interval", 3, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint := doEndpointInspectRequest(t, handler, tc.id)
+			assert.Equal(t, tc.expected, endpoint.EdgeCheckinInterval)
+		})
+	}
+}
+
+// Test_EndpointCheckinInterval_ListMatchesInspect guards against the list and inspect
+// endpoints reporting different EdgeCheckinInterval values for the same environment,
+// which was the regression reported in issue 5384.
+func Test_EndpointCheckinInterval_ListMatchesInspect(t *testing.T) {
+	t.Parallel()
+
+	const globalCheckinInterval = 60
+
+	endpoints := []portainer.Endpoint{
+		{ID: 1, GroupID: 1, Type: portainer.EdgeAgentOnDockerEnvironment, UserTrusted: true},
+		{ID: 2, GroupID: 1, Type: portainer.EdgeAgentOnDockerEnvironment, EdgeCheckinInterval: 7, UserTrusted: true},
+		{ID: 3, GroupID: 1, Type: portainer.DockerEnvironment},
+	}
+
+	handler := setupEndpointInspectHandler(t, endpoints, globalCheckinInterval)
+
+	is := assert.New(t)
+	listed, err := doEndpointListRequest(buildEndpointListRequest(""), handler, is)
+	require.NoError(t, err)
+
+	listedIntervals := make(map[portainer.EndpointID]int, len(listed))
+	for _, endpoint := range listed {
+		listedIntervals[endpoint.ID] = endpoint.EdgeCheckinInterval
+	}
+
+	for _, endpoint := range endpoints {
+		inspected := doEndpointInspectRequest(t, handler, endpoint.ID)
+		is.Equal(listedIntervals[endpoint.ID], inspected.EdgeCheckinInterval,
+			"list and inspect must report the same check-in interval for endpoint %d", endpoint.ID)
+	}
+}

--- a/api/http/handler/endpoints/endpoint_list.go
+++ b/api/http/handler/endpoints/endpoint_list.go
@@ -111,9 +111,7 @@ func (handler *Handler) endpointList(w http.ResponseWriter, r *http.Request) *ht
 		hideFields(&paginatedEndpoints[idx])
 
 		paginatedEndpoints[idx].ComposeSyntaxMaxVersion = handler.ComposeStackManager.ComposeSyntaxMaxVersion()
-		if paginatedEndpoints[idx].EdgeCheckinInterval == 0 {
-			paginatedEndpoints[idx].EdgeCheckinInterval = settings.EdgeAgentCheckinInterval
-		}
+		endpointutils.UpdateEdgeEndpointCheckinInterval(&paginatedEndpoints[idx], settings)
 
 		endpointutils.UpdateEdgeEndpointHeartbeat(&paginatedEndpoints[idx], settings)
 

--- a/api/internal/endpointutils/endpointutils.go
+++ b/api/internal/endpointutils/endpointutils.go
@@ -194,6 +194,17 @@ func UpdateEdgeEndpointHeartbeat(endpoint *portainer.Endpoint, settings *portain
 	endpoint.Heartbeat = GetHeartbeatStatus(endpoint, settings)
 }
 
+// UpdateEdgeEndpointCheckinInterval resolves the effective edge check-in interval
+// reported in API responses. Edge endpoints that don't define their own interval
+// fall back to the global default from the settings, while non-edge endpoints are
+// left untouched as the check-in interval is not relevant to them. This keeps the
+// value consistent across the endpoint list and inspect responses.
+func UpdateEdgeEndpointCheckinInterval(endpoint *portainer.Endpoint, settings *portainer.Settings) {
+	if IsEdgeEndpoint(endpoint) && endpoint.EdgeCheckinInterval == 0 {
+		endpoint.EdgeCheckinInterval = settings.EdgeAgentCheckinInterval
+	}
+}
+
 func GetHeartbeatStatus(endpoint *portainer.Endpoint, settings *portainer.Settings) bool {
 	checkInInterval := getEndpointCheckinInterval(endpoint, settings)
 	return time.Now().Unix()-endpoint.LastCheckInDate <= int64(checkInInterval*2+20)


### PR DESCRIPTION
closes #5384

### Changes:

`GET /endpoints` substitutes the global `EdgeAgentCheckinInterval` when an environment has no specific `EdgeCheckinInterval`, but `GET /endpoints/{id}` returned the raw stored value (0). The two endpoints therefore reported different `EdgeCheckinInterval` values for the same environment.

- Extract the fallback into a shared `endpointutils.UpdateEdgeEndpointCheckinInterval` helper and use it in both the list and inspect handlers.
- Gate the fallback on edge endpoints, matching the behaviour described in the issue by @chiptus/@samdulam: edge environments without their own interval report the global default, non-edge environments report 0 (previously the list handler applied the default unconditionally, including to non-edge environments).
- Add handler tests covering inspect resolution and list/inspect consistency (they fail on develop and pass with this change).

> Disclosure: this change was prepared with AI assistance (Claude) and reviewed before submission.
