### PR TITLE
Add native alerts, and monitoring using LogForge

### DIFF
--- a/api/dataservices/interface.go
+++ b/api/dataservices/interface.go
@@ -22,6 +22,7 @@ type (
 		ResourceControl() ResourceControlService
 		Role() RoleService
 		APIKeyRepository() APIKeyRepository
+		LogForge() LogForgeService
 		Settings() SettingsService
 		Snapshot() SnapshotService
 		SSLSettings() SSLSettingsService
@@ -180,6 +181,14 @@ type (
 	SettingsService interface {
 		Settings() (*portainer.Settings, error)
 		UpdateSettings(settings *portainer.Settings) error
+		BucketName() string
+	}
+
+	// LogForgeService represents a service for managing LogForge integration settings
+	LogForgeService interface {
+		Settings() (*portainer.LogForgeSettings, error)
+		UpdateSettings(settings *portainer.LogForgeSettings) error
+		DeleteSettings() error
 		BucketName() string
 	}
 

--- a/api/dataservices/logforge/logforge.go
+++ b/api/dataservices/logforge/logforge.go
@@ -1,0 +1,68 @@
+package logforge
+
+import (
+	portainer "github.com/portainer/portainer/api"
+)
+
+const (
+	// BucketName represents the name of the bucket where this service stores data.
+	BucketName  = "logforge"
+	settingsKey = "LOGFORGE"
+)
+
+// Service represents a service for managing LogForge integration settings.
+type Service struct {
+	connection portainer.Connection
+}
+
+func (service *Service) BucketName() string {
+	return BucketName
+}
+
+// NewService creates a new instance of a service.
+func NewService(connection portainer.Connection) (*Service, error) {
+	return &Service{
+		connection: connection,
+	}, nil
+}
+
+func (service *Service) Tx(tx portainer.Transaction) ServiceTx {
+	return ServiceTx{
+		service: service,
+		tx:      tx,
+	}
+}
+
+// Settings retrieves the LogForge settings object.
+func (service *Service) Settings() (*portainer.LogForgeSettings, error) {
+	if err := service.connection.SetServiceName(BucketName); err != nil {
+		return nil, err
+	}
+
+	var settings portainer.LogForgeSettings
+
+	err := service.connection.GetObject(BucketName, []byte(settingsKey), &settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &settings, nil
+}
+
+// UpdateSettings persists a LogForge settings object.
+func (service *Service) UpdateSettings(settings *portainer.LogForgeSettings) error {
+	if err := service.connection.SetServiceName(BucketName); err != nil {
+		return err
+	}
+
+	return service.connection.UpdateObject(BucketName, []byte(settingsKey), settings)
+}
+
+// DeleteSettings removes the LogForge settings object.
+func (service *Service) DeleteSettings() error {
+	if err := service.connection.SetServiceName(BucketName); err != nil {
+		return err
+	}
+
+	return service.connection.DeleteObject(BucketName, []byte(settingsKey))
+}

--- a/api/dataservices/logforge/tx.go
+++ b/api/dataservices/logforge/tx.go
@@ -1,0 +1,48 @@
+package logforge
+
+import (
+	portainer "github.com/portainer/portainer/api"
+)
+
+type ServiceTx struct {
+	service *Service
+	tx      portainer.Transaction
+}
+
+func (service ServiceTx) BucketName() string {
+	return BucketName
+}
+
+// Settings retrieves the LogForge settings object.
+func (service ServiceTx) Settings() (*portainer.LogForgeSettings, error) {
+	if err := service.tx.SetServiceName(BucketName); err != nil {
+		return nil, err
+	}
+
+	var settings portainer.LogForgeSettings
+
+	err := service.tx.GetObject(BucketName, []byte(settingsKey), &settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &settings, nil
+}
+
+// UpdateSettings persists a LogForge settings object.
+func (service ServiceTx) UpdateSettings(settings *portainer.LogForgeSettings) error {
+	if err := service.tx.SetServiceName(BucketName); err != nil {
+		return err
+	}
+
+	return service.tx.UpdateObject(BucketName, []byte(settingsKey), settings)
+}
+
+// DeleteSettings removes the LogForge settings object.
+func (service ServiceTx) DeleteSettings() error {
+	if err := service.tx.SetServiceName(BucketName); err != nil {
+		return err
+	}
+
+	return service.tx.DeleteObject(BucketName, []byte(settingsKey))
+}

--- a/api/datastore/services.go
+++ b/api/datastore/services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/portainer/portainer/api/dataservices/endpointrelation"
 	"github.com/portainer/portainer/api/dataservices/extension"
 	"github.com/portainer/portainer/api/dataservices/helmuserrepository"
+	"github.com/portainer/portainer/api/dataservices/logforge"
 	"github.com/portainer/portainer/api/dataservices/pendingactions"
 	"github.com/portainer/portainer/api/dataservices/registry"
 	"github.com/portainer/portainer/api/dataservices/resourcecontrol"
@@ -68,6 +69,7 @@ type Store struct {
 	ResourceControlService    *resourcecontrol.Service
 	RoleService               *role.Service
 	APIKeyRepositoryService   *apikeyrepository.Service
+	LogForgeService           *logforge.Service
 	ScheduleService           *schedule.Service
 	SettingsService           *settings.Service
 	SnapshotService           *snapshot.Service
@@ -245,6 +247,12 @@ func (store *Store) initServices() error {
 	}
 	store.APIKeyRepositoryService = apiKeyService
 
+	logForgeService, err := logforge.NewService(store.connection)
+	if err != nil {
+		return err
+	}
+	store.LogForgeService = logForgeService
+
 	versionService, err := version.NewService(store.connection)
 	if err != nil {
 		return err
@@ -352,6 +360,11 @@ func (store *Store) APIKeyRepository() dataservices.APIKeyRepository {
 	return store.APIKeyRepositoryService
 }
 
+// LogForge gives access to the LogForge data management layer
+func (store *Store) LogForge() dataservices.LogForgeService {
+	return store.LogForgeService
+}
+
 // Settings gives access to the Settings data management layer
 func (store *Store) Settings() dataservices.SettingsService {
 	return store.SettingsService
@@ -426,6 +439,7 @@ type storeExport struct {
 	EndpointRelation   []portainer.EndpointRelation   `json:"endpoint_relations,omitempty"`
 	Extensions         []portainer.Extension          `json:"extension,omitempty"`
 	HelmUserRepository []portainer.HelmUserRepository `json:"helm_user_repository,omitempty"`
+	LogForge           *portainer.LogForgeSettings    `json:"logforge,omitempty"`
 	Registry           []portainer.Registry           `json:"registries,omitempty"`
 	ResourceControl    []portainer.ResourceControl    `json:"resource_control,omitempty"`
 	Role               []portainer.Role               `json:"roles,omitempty"`
@@ -519,6 +533,14 @@ func (store *Store) Export(filename string) (err error) {
 		}
 	} else {
 		backup.HelmUserRepository = r
+	}
+
+	if settings, err := store.LogForge().Settings(); err != nil {
+		if !store.IsErrObjectNotFound(err) {
+			log.Error().Err(err).Msg("exporting LogForge settings")
+		}
+	} else {
+		backup.LogForge = settings
 	}
 
 	if r, err := store.Registry().ReadAll(); err != nil {
@@ -732,6 +754,12 @@ func (store *Store) Import(filename string) (err error) {
 	for _, v := range backup.HelmUserRepository {
 		if err := store.HelmUserRepository().Update(v.ID, &v); err != nil {
 			log.Warn().Err(err).Msg("failed to update the helm user repository in the database")
+		}
+	}
+
+	if backup.LogForge != nil && (backup.LogForge.Enabled || backup.LogForge.ApplianceURL != "" || backup.LogForge.ApplianceStackID != 0) {
+		if err := store.LogForge().UpdateSettings(backup.LogForge); err != nil {
+			log.Warn().Err(err).Msg("failed to update the LogForge settings in the database")
 		}
 	}
 

--- a/api/datastore/services.go
+++ b/api/datastore/services.go
@@ -540,6 +540,8 @@ func (store *Store) Export(filename string) (err error) {
 			log.Error().Err(err).Msg("exporting LogForge settings")
 		}
 	} else {
+		// Keep the service key so a restored Portainer remains in sync with the
+		// appliance's stored key hash. Backup archives can be password-encrypted.
 		backup.LogForge = settings
 	}
 

--- a/api/datastore/services_tx.go
+++ b/api/datastore/services_tx.go
@@ -70,6 +70,10 @@ func (tx *StoreTx) Role() dataservices.RoleService {
 
 func (tx *StoreTx) APIKeyRepository() dataservices.APIKeyRepository { return nil }
 
+func (tx *StoreTx) LogForge() dataservices.LogForgeService {
+	return tx.store.LogForgeService.Tx(tx.tx)
+}
+
 func (tx *StoreTx) Settings() dataservices.SettingsService {
 	return tx.store.SettingsService.Tx(tx.tx)
 }

--- a/api/http/handler/handler.go
+++ b/api/http/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/helm"
 	"github.com/portainer/portainer/api/http/handler/kubernetes"
 	"github.com/portainer/portainer/api/http/handler/ldap"
+	"github.com/portainer/portainer/api/http/handler/logforge"
 	"github.com/portainer/portainer/api/http/handler/motd"
 	"github.com/portainer/portainer/api/http/handler/registries"
 	"github.com/portainer/portainer/api/http/handler/resourcecontrols"
@@ -58,6 +59,7 @@ type Handler struct {
 	KubernetesHandler      *kubernetes.Handler
 	FileHandler            *file.Handler
 	LDAPHandler            *ldap.Handler
+	LogForgeHandler        *logforge.Handler
 	MOTDHandler            *motd.Handler
 	RegistryHandler        *registries.Handler
 	ResourceControlHandler *resourcecontrols.Handler
@@ -248,6 +250,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.StripPrefix("/api", h.GitOperationHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/ldap"):
 		http.StripPrefix("/api", h.LDAPHandler).ServeHTTP(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/logforge"):
+		http.StripPrefix("/api", h.LogForgeHandler).ServeHTTP(w, r)
+	case strings.HasPrefix(r.URL.Path, "/logforge/ui"):
+		h.LogForgeHandler.ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/motd"):
 		http.StripPrefix("/api", h.MOTDHandler).ServeHTTP(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/registries"):

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -857,6 +857,7 @@ func renderManagedCompose(payload *installPayload, stackName string, instanceID 
 	return fmt.Sprintf(`services:
   unicron:
     image: %s
+    pull_policy: always
     container_name: %s
     restart: unless-stopped
     read_only: true

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -521,9 +521,9 @@ func (handler *Handler) newUIProxy(target *url.URL, serviceKey string, hostHeade
 		req.Header.Del("Authorization")
 		req.Header.Del("X-API-KEY")
 		req.Header.Del("Cookie")
-		// The proxy rewrites LogForge's /unicron base path in HTML, CSS, and
-		// JavaScript responses. Request identity encoding so those response
-		// bodies are always available to ModifyResponse as plain bytes.
+		// The proxy rewrites LogForge's /unicron base path in browser assets and
+		// route manifests. Request identity encoding so those response bodies are
+		// always available to ModifyResponse as plain bytes.
 		req.Header.Set("Accept-Encoding", "identity")
 		req.Header.Del(serviceKeyHeader)
 		req.Header.Del(managedByHeader)
@@ -552,8 +552,7 @@ func rewriteProxyResponse(resp *http.Response) error {
 		resp.Header.Set("Location", strings.ReplaceAll(location, "/unicron", browserProxyPath[:len(browserProxyPath)-1]))
 	}
 
-	contentType := resp.Header.Get("Content-Type")
-	if !shouldRewriteContent(contentType) || resp.Body == nil {
+	if !shouldRewriteResponseBody(resp) {
 		return nil
 	}
 
@@ -573,12 +572,26 @@ func rewriteProxyResponse(resp *http.Response) error {
 	return nil
 }
 
+func shouldRewriteResponseBody(resp *http.Response) bool {
+	if resp.Body == nil {
+		return false
+	}
+
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "application/json") {
+		return resp.Request != nil &&
+			resp.Request.URL != nil &&
+			strings.HasSuffix(resp.Request.URL.Path, "/__manifest")
+	}
+
+	return shouldRewriteContent(contentType)
+}
+
 func shouldRewriteContent(contentType string) bool {
 	contentType = strings.ToLower(contentType)
 	return strings.Contains(contentType, "text/html") ||
 		strings.Contains(contentType, "text/css") ||
 		strings.Contains(contentType, "javascript") ||
-		strings.Contains(contentType, "application/json") ||
 		strings.Contains(contentType, "application/manifest+json") ||
 		strings.Contains(contentType, "text/plain")
 }

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -6,7 +6,6 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -18,9 +17,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	portainer "github.com/portainer/portainer/api"
+	portainercrypto "github.com/portainer/portainer/api/crypto"
 	"github.com/portainer/portainer/api/dataservices"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/authorization"
@@ -52,6 +53,7 @@ const (
 	managedIdentityHeader   = "X-LogForge-Managed-Identity"
 	managedSignatureHeader  = "X-LogForge-Managed-Identity-Signature"
 	managedIdentityTTL      = 5 * time.Minute
+	logForgeAccessCacheTTL  = 30 * time.Second
 	endpointAdminRoleID     = portainer.RoleID(1)
 	helpdeskRoleID          = portainer.RoleID(2)
 	standardRoleID          = portainer.RoleID(3)
@@ -68,6 +70,8 @@ type Handler struct {
 	ComposeStackManager portainer.ComposeStackManager
 	StackDeployer       deployments.StackDeployer
 	httpClient          *http.Client
+	accessCacheMu       sync.Mutex
+	accessCache         map[logForgeAccessCacheKey]logForgeAccessCacheEntry
 }
 
 // NewHandler creates a handler to manage LogForge integration operations.
@@ -75,12 +79,8 @@ func NewHandler(bouncer security.BouncerService) *Handler {
 	h := &Handler{
 		Router:         mux.NewRouter(),
 		requestBouncer: bouncer,
-		httpClient: &http.Client{
-			Timeout: 5 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // LogForge appliance uses a local self-signed certificate by default.
-			},
-		},
+		httpClient:     &http.Client{Timeout: 5 * time.Second},
+		accessCache:    map[logForgeAccessCacheKey]logForgeAccessCacheEntry{},
 	}
 
 	h.Handle("/logforge/status",
@@ -106,6 +106,7 @@ type statusResponse struct {
 	ApplianceEndpointID  portainer.EndpointID `json:"ApplianceEndpointId,omitempty"`
 	ApplianceURL         string               `json:"ApplianceUrl,omitempty"`
 	ApplianceHostHeader  string               `json:"ApplianceHostHeader,omitempty"`
+	TLSSkipVerify        bool                 `json:"TLSSkipVerify"`
 	BrowserProxyPath     string               `json:"BrowserProxyPath"`
 	ApplianceImage       string               `json:"ApplianceImage,omitempty"`
 	StackName            string               `json:"StackName,omitempty"`
@@ -151,10 +152,22 @@ type logForgeEndpointScope struct {
 	RoleID portainer.RoleID     `json:"RoleId,omitempty"`
 }
 
+type logForgeAccessCacheKey struct {
+	userID    portainer.UserID
+	role      portainer.UserRole
+	tokenHash [sha256.Size]byte
+}
+
+type logForgeAccessCacheEntry struct {
+	access    logForgeAccess
+	expiresAt time.Time
+}
+
 type installPayload struct {
 	EndpointID          portainer.EndpointID `json:"EndpointId,omitempty"`
 	ApplianceURL        string               `json:"ApplianceUrl,omitempty"`
 	ApplianceHostHeader string               `json:"ApplianceHostHeader,omitempty"`
+	TLSSkipVerify       bool                 `json:"TLSSkipVerify"`
 	Image               string               `json:"Image,omitempty"`
 	StackName           string               `json:"StackName,omitempty"`
 	CentralFQDN         string               `json:"CentralFQDN,omitempty"`
@@ -210,6 +223,10 @@ func (payload *installPayload) Validate(r *http.Request) error {
 	return nil
 }
 
+func tlsSkipVerifyForPayload(payload *installPayload) bool {
+	return payload.EndpointID != 0 || payload.TLSSkipVerify
+}
+
 type uninstallPayload struct {
 	RemoveManagedStack bool `json:"RemoveManagedStack"`
 }
@@ -258,6 +275,7 @@ func (handler *Handler) installOrRegister(w http.ResponseWriter, r *http.Request
 	settings.BrowserProxyPath = browserProxyPath
 	settings.ApplianceImage = valueOrDefault(payload.Image, defaultImage)
 	settings.ApplianceHostHeader = applianceHostHeader(payload)
+	settings.TLSSkipVerify = tlsSkipVerifyForPayload(payload)
 
 	if payload.EndpointID != 0 {
 		stack, endpoint, httpErr := handler.installManagedStack(r, payload, instanceID, settings.ServiceKey)
@@ -456,16 +474,18 @@ func (handler *Handler) proxyUI(w http.ResponseWriter, r *http.Request) *httperr
 		return httperror.Forbidden("Permission denied to access LogForge", errors.New("no Docker environment access"))
 	}
 
-	proxy := handler.newUIProxy(target, settings.ServiceKey, settings.ApplianceHostHeader, access)
+	proxy := handler.newUIProxy(target, settings.ServiceKey, settings.ApplianceHostHeader, settings.TLSSkipVerify, access)
 	proxy.ServeHTTP(w, r)
 	return nil
 }
 
-func (handler *Handler) newUIProxy(target *url.URL, serviceKey string, hostHeader string, access logForgeAccess) *httputil.ReverseProxy {
+func (handler *Handler) newUIProxy(target *url.URL, serviceKey string, hostHeader string, tlsSkipVerify bool, access logForgeAccess) *httputil.ReverseProxy {
 	targetQuery := target.RawQuery
 	proxy := httputil.NewSingleHostReverseProxy(target)
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	if tlsSkipVerify {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = portainercrypto.CreateTLSConfiguration(true)
+		proxy.Transport = transport
 	}
 	proxy.Director = func(req *http.Request) {
 		req.URL.Scheme = target.Scheme
@@ -569,6 +589,39 @@ func (handler *Handler) logForgeAccessForRequest(r *http.Request) (logForgeAcces
 		return logForgeAccess{}, nil
 	}
 
+	cacheKey := logForgeAccessCacheKey{
+		userID:    tokenData.ID,
+		role:      tokenData.Role,
+		tokenHash: sha256.Sum256([]byte(tokenData.Token)),
+	}
+	now := time.Now()
+
+	handler.accessCacheMu.Lock()
+	defer handler.accessCacheMu.Unlock()
+
+	if cached, ok := handler.accessCache[cacheKey]; ok && now.Before(cached.expiresAt) {
+		return cached.access, nil
+	}
+
+	access, err := handler.resolveLogForgeAccessForRequest(r, tokenData)
+	if err != nil {
+		return logForgeAccess{}, err
+	}
+
+	for key, cached := range handler.accessCache {
+		if !now.Before(cached.expiresAt) {
+			delete(handler.accessCache, key)
+		}
+	}
+	handler.accessCache[cacheKey] = logForgeAccessCacheEntry{
+		access:    access,
+		expiresAt: now.Add(logForgeAccessCacheTTL),
+	}
+
+	return access, nil
+}
+
+func (handler *Handler) resolveLogForgeAccessForRequest(r *http.Request, tokenData *portainer.TokenData) (logForgeAccess, error) {
 	securityContext, err := security.RetrieveRestrictedRequestContext(r)
 	if err != nil {
 		securityContext = &security.RestrictedRequestContext{
@@ -753,6 +806,7 @@ func (handler *Handler) buildStatus(r *http.Request, settings *portainer.LogForg
 		ApplianceEndpointID:  settings.ApplianceEndpointID,
 		ApplianceURL:         settings.ApplianceURL,
 		ApplianceHostHeader:  settings.ApplianceHostHeader,
+		TLSSkipVerify:        settings.TLSSkipVerify,
 		BrowserProxyPath:     valueOrDefault(settings.BrowserProxyPath, browserProxyPath),
 		ApplianceImage:       settings.ApplianceImage,
 		StackName:            settings.StackName,
@@ -802,7 +856,7 @@ func (handler *Handler) checkHealth(ctx context.Context, settings *portainer.Log
 		req.Host = settings.ApplianceHostHeader
 	}
 
-	resp, err := handler.httpClient.Do(req)
+	resp, err := handler.httpClientForSettings(settings).Do(req)
 	if err != nil {
 		return healthStatus{Status: "unhealthy", Message: err.Error(), CheckedAt: checkedAt}
 	}
@@ -829,6 +883,22 @@ func (handler *Handler) checkHealth(ctx context.Context, settings *portainer.Log
 		health.Version = extractJSONValue(message, "version")
 	}
 	return health
+}
+
+func (handler *Handler) httpClientForSettings(settings *portainer.LogForgeSettings) *http.Client {
+	if !settings.TLSSkipVerify {
+		return handler.httpClient
+	}
+
+	client := *handler.httpClient
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if baseTransport, ok := handler.httpClient.Transport.(*http.Transport); ok {
+		transport = baseTransport.Clone()
+	}
+	transport.TLSClientConfig = portainercrypto.CreateTLSConfiguration(true)
+	client.Transport = transport
+
+	return &client
 }
 
 func (handler *Handler) stackNameExists(endpointID portainer.EndpointID, stackName string) (bool, error) {

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	defaultImage            = "logforge/unicron:latest"
-	defaultRemoteAgentImage = "logforge/unicron-agent:latest"
+	defaultImage            = "logforge/unicron:portainer-integration"
+	defaultRemoteAgentImage = "logforge/unicron-agent:portainer-integration"
 	defaultStackName        = "logforge-unicron"
 	defaultContainerName    = "logforge-unicron-appliance"
 	defaultVolumeName       = "logforge-unicron-data"
@@ -354,7 +354,7 @@ func (handler *Handler) installManagedStack(r *http.Request, payload *installPay
 
 	stackPayload := stackbuilders.StackPayload{
 		Name:             stackName,
-		StackFileContent: []byte(renderManagedCompose(payload, instanceID, serviceKeySHA256(serviceKey))),
+		StackFileContent: []byte(renderManagedCompose(payload, stackName, instanceID, serviceKeySHA256(serviceKey))),
 		FromAppTemplate:  false,
 	}
 
@@ -365,7 +365,7 @@ func (handler *Handler) installManagedStack(r *http.Request, payload *installPay
 		handler.StackDeployer,
 	)
 
-	stack, httpErr := stackbuilders.Build(r.Context(), handler.DataStore, builder, &stackPayload, endpoint, tokenData.ID)
+	stack, httpErr := stackbuilders.BuildAndAsyncDeploy(r.Context(), handler.DataStore, builder, &stackPayload, endpoint, tokenData.ID)
 	if httpErr != nil {
 		return nil, nil, httpErr
 	}
@@ -476,11 +476,35 @@ func (handler *Handler) newUIProxy(target *url.URL, serviceKey string, hostHeade
 		} else {
 			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
 		}
+		if strings.HasSuffix(req.URL.Path, "/__manifest") {
+			query := req.URL.Query()
+			if paths := query.Get("paths"); paths != "" {
+				query.Set("paths", buildUpstreamManifestPaths(target.Path, paths))
+				req.URL.RawQuery = query.Encode()
+			}
+		}
 		req.Host = valueOrDefault(hostHeader, target.Host)
+		// The browser is talking to Portainer, but the upstream enforces a
+		// same-origin policy against its own public origin. Present the request as
+		// originating from the appliance so HTTP mutations and Socket.IO
+		// handshakes are checked against the same authority as req.Host.
+		upstreamOrigin := target.Scheme + "://" + req.Host
+		if req.Header.Get("Origin") != "" {
+			req.Header.Set("Origin", upstreamOrigin)
+		}
+		if req.Header.Get("Referer") != "" {
+			req.Header.Set("Referer", upstreamOrigin+"/")
+		}
+		req.Header.Set("X-Forwarded-Proto", target.Scheme)
+		req.Header.Set("X-Forwarded-Host", req.Host)
 
 		req.Header.Del("Authorization")
 		req.Header.Del("X-API-KEY")
 		req.Header.Del("Cookie")
+		// The proxy rewrites LogForge's /unicron base path in HTML, CSS, and
+		// JavaScript responses. Request identity encoding so those response
+		// bodies are always available to ModifyResponse as plain bytes.
+		req.Header.Set("Accept-Encoding", "identity")
 		req.Header.Del(serviceKeyHeader)
 		req.Header.Del(managedByHeader)
 		req.Header.Del(managedIdentityHeader)
@@ -635,15 +659,22 @@ func teamIDs(memberships []portainer.TeamMembership) []portainer.TeamID {
 }
 
 type managedIdentityClaims struct {
-	Issuer    string                  `json:"iss"`
-	Subject   string                  `json:"sub"`
-	UserID    portainer.UserID        `json:"user_id"`
-	Username  string                  `json:"username,omitempty"`
-	IsAdmin   bool                    `json:"is_admin"`
-	TeamIDs   []portainer.TeamID      `json:"team_ids,omitempty"`
-	Endpoints []logForgeEndpointScope `json:"endpoints"`
-	IssuedAt  int64                   `json:"iat"`
-	ExpiresAt int64                   `json:"exp"`
+	Issuer    string                         `json:"iss"`
+	Subject   string                         `json:"sub"`
+	UserID    portainer.UserID               `json:"user_id"`
+	Username  string                         `json:"username,omitempty"`
+	IsAdmin   bool                           `json:"is_admin"`
+	TeamIDs   []portainer.TeamID             `json:"team_ids,omitempty"`
+	Endpoints []managedIdentityEndpointScope `json:"endpoints"`
+	IssuedAt  int64                          `json:"iat"`
+	ExpiresAt int64                          `json:"exp"`
+}
+
+type managedIdentityEndpointScope struct {
+	ID     portainer.EndpointID `json:"id"`
+	Name   string               `json:"name"`
+	Role   string               `json:"role"`
+	RoleID portainer.RoleID     `json:"role_id,omitempty"`
 }
 
 func signedManagedIdentity(access logForgeAccess, serviceKey string) (string, string) {
@@ -659,7 +690,7 @@ func signedManagedIdentity(access logForgeAccess, serviceKey string) (string, st
 		Username:  access.Username,
 		IsAdmin:   access.IsAdmin,
 		TeamIDs:   access.TeamIDs,
-		Endpoints: access.Endpoints,
+		Endpoints: managedIdentityEndpoints(access.Endpoints),
 		IssuedAt:  now.Unix(),
 		ExpiresAt: now.Add(managedIdentityTTL).Unix(),
 	}
@@ -675,6 +706,20 @@ func signedManagedIdentity(access logForgeAccess, serviceKey string) (string, st
 	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 
 	return identity, signature
+}
+
+func managedIdentityEndpoints(endpoints []logForgeEndpointScope) []managedIdentityEndpointScope {
+	claims := make([]managedIdentityEndpointScope, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		claims = append(claims, managedIdentityEndpointScope{
+			ID:     endpoint.ID,
+			Name:   endpoint.Name,
+			Role:   endpoint.Role,
+			RoleID: endpoint.RoleID,
+		})
+	}
+
+	return claims
 }
 
 func (handler *Handler) currentSettings() (*portainer.LogForgeSettings, error) {
@@ -801,7 +846,7 @@ func (handler *Handler) stackNameExists(endpointID portainer.EndpointID, stackNa
 	return false, nil
 }
 
-func renderManagedCompose(payload *installPayload, instanceID string, serviceKeyVerifier string) string {
+func renderManagedCompose(payload *installPayload, stackName string, instanceID string, serviceKeyVerifier string) string {
 	image := valueOrDefault(payload.Image, defaultImage)
 	httpsPort := valueOrDefaultInt(payload.HTTPSPort, defaultHTTPSPort)
 	mtlsPort := valueOrDefaultInt(payload.MTLSPort, defaultMTLSPort)
@@ -851,11 +896,16 @@ func renderManagedCompose(payload *installPayload, instanceID string, serviceKey
       UNICRON_CENTRAL_FQDN: %s
       UNICRON_PUBLIC_CENTRAL_PORT: "%d"
       UNICRON_PUBLIC_CENTRAL_MTLS_PORT: "%d"
+      LOCAL_AGENT_DOCKER_NETWORK: %s_default
       UNICRON_APPLIANCE_CONTAINER_NAME: %s
       PORTAINER_INSTANCE_ID: %s
       TMPDIR: /run/pyinstaller
       CENTRAL_ADMIN_RECOVERY_OVERRIDE: "false"
       REMOTE_AGENT_IMAGE: %s
+    networks:
+      default:
+        aliases:
+          - unicron.central
     volumes:
       - %s:/var/lib/unicron
     healthcheck:
@@ -868,7 +918,7 @@ func renderManagedCompose(payload *installPayload, instanceID string, serviceKey
 volumes:
   %s:
     name: %s
-`, image, defaultContainerName, centralFQDN, httpsPort, mtlsPort, managedIdentityHeader, managedSignatureHeader, serviceKeyHeader, serviceKeyVerifier, centralFQDN, httpsPort, mtlsPort, defaultContainerName, portainerInstanceID, remoteAgentImage, defaultVolumeName, defaultVolumeName, defaultVolumeName)
+`, image, defaultContainerName, centralFQDN, httpsPort, mtlsPort, managedIdentityHeader, managedSignatureHeader, serviceKeyHeader, serviceKeyVerifier, centralFQDN, httpsPort, mtlsPort, stackName, defaultContainerName, portainerInstanceID, remoteAgentImage, defaultVolumeName, defaultVolumeName, defaultVolumeName)
 }
 
 func serviceKeySHA256(serviceKey string) string {
@@ -968,10 +1018,7 @@ func appendUnicronPath(raw string, suffix string) (string, error) {
 }
 
 func buildUpstreamPath(targetPath string, requestPath string) string {
-	basePath := strings.TrimRight(targetPath, "/")
-	if !strings.HasSuffix(basePath, "/unicron") {
-		basePath += "/unicron"
-	}
+	basePath := upstreamBasePath(targetPath)
 
 	rest := strings.TrimPrefix(requestPath, "/logforge/ui")
 	if rest == "" {
@@ -979,6 +1026,37 @@ func buildUpstreamPath(targetPath string, requestPath string) string {
 	}
 
 	return singleJoiningSlash(basePath, rest)
+}
+
+func buildUpstreamManifestPaths(targetPath string, rawPaths string) string {
+	basePath := upstreamBasePath(targetPath)
+	proxyBasePath := strings.TrimRight(browserProxyPath, "/")
+	paths := strings.Split(rawPaths, ",")
+	for index, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == basePath || strings.HasPrefix(path, basePath+"/") {
+			paths[index] = path
+			continue
+		}
+		if path == proxyBasePath {
+			paths[index] = basePath
+			continue
+		}
+		if strings.HasPrefix(path, proxyBasePath+"/") {
+			paths[index] = basePath + strings.TrimPrefix(path, proxyBasePath)
+			continue
+		}
+		paths[index] = singleJoiningSlash(basePath, path)
+	}
+	return strings.Join(paths, ",")
+}
+
+func upstreamBasePath(targetPath string) string {
+	basePath := strings.TrimRight(targetPath, "/")
+	if !strings.HasSuffix(basePath, "/unicron") {
+		basePath += "/unicron"
+	}
+	return basePath
 }
 
 func singleJoiningSlash(a, b string) string {

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -1,0 +1,1092 @@
+package logforge
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/dataservices"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/internal/authorization"
+	"github.com/portainer/portainer/api/internal/endpointutils"
+	"github.com/portainer/portainer/api/logs"
+	"github.com/portainer/portainer/api/stacks/deployments"
+	"github.com/portainer/portainer/api/stacks/stackbuilders"
+	"github.com/portainer/portainer/api/stacks/stackutils"
+	httperror "github.com/portainer/portainer/pkg/libhttp/error"
+	"github.com/portainer/portainer/pkg/libhttp/request"
+	"github.com/portainer/portainer/pkg/libhttp/response"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultImage            = "logforge/unicron:latest"
+	defaultRemoteAgentImage = "logforge/unicron-agent:latest"
+	defaultStackName        = "logforge-unicron"
+	defaultContainerName    = "logforge-unicron-appliance"
+	defaultVolumeName       = "logforge-unicron-data"
+	defaultHTTPSPort        = 9444
+	defaultMTLSPort         = 8443
+	defaultCentralFQDN      = "logforge.local"
+	browserProxyPath        = "/logforge/ui/"
+	serviceKeyHeader        = "X-LogForge-Service-Key"
+	managedByHeader         = "X-LogForge-Managed-By"
+	managedIdentityHeader   = "X-LogForge-Managed-Identity"
+	managedSignatureHeader  = "X-LogForge-Managed-Identity-Signature"
+	managedIdentityTTL      = 5 * time.Minute
+	endpointAdminRoleID     = portainer.RoleID(1)
+	helpdeskRoleID          = portainer.RoleID(2)
+	standardRoleID          = portainer.RoleID(3)
+	readOnlyRoleID          = portainer.RoleID(4)
+	operatorRoleID          = portainer.RoleID(5)
+)
+
+// Handler is the HTTP handler used to handle LogForge integration operations.
+type Handler struct {
+	*mux.Router
+	requestBouncer      security.BouncerService
+	DataStore           dataservices.DataStore
+	FileService         portainer.FileService
+	ComposeStackManager portainer.ComposeStackManager
+	StackDeployer       deployments.StackDeployer
+	httpClient          *http.Client
+}
+
+// NewHandler creates a handler to manage LogForge integration operations.
+func NewHandler(bouncer security.BouncerService) *Handler {
+	h := &Handler{
+		Router:         mux.NewRouter(),
+		requestBouncer: bouncer,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // LogForge appliance uses a local self-signed certificate by default.
+			},
+		},
+	}
+
+	h.Handle("/logforge/status",
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.status))).Methods(http.MethodGet)
+	h.Handle("/logforge/install",
+		bouncer.AdminAccess(httperror.LoggerHandler(h.installOrRegister))).Methods(http.MethodPost)
+	h.Handle("/logforge/uninstall",
+		bouncer.AdminAccess(httperror.LoggerHandler(h.uninstallOrClear))).Methods(http.MethodPost)
+
+	h.Handle("/logforge/ui",
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.proxyUI)))
+	h.PathPrefix("/logforge/ui/").Handler(
+		bouncer.AuthenticatedAccess(httperror.LoggerHandler(h.proxyUI)),
+	)
+
+	return h
+}
+
+type statusResponse struct {
+	Enabled              bool                 `json:"Enabled"`
+	Managed              bool                 `json:"Managed"`
+	ApplianceStackID     portainer.StackID    `json:"ApplianceStackId,omitempty"`
+	ApplianceEndpointID  portainer.EndpointID `json:"ApplianceEndpointId,omitempty"`
+	ApplianceURL         string               `json:"ApplianceUrl,omitempty"`
+	ApplianceHostHeader  string               `json:"ApplianceHostHeader,omitempty"`
+	BrowserProxyPath     string               `json:"BrowserProxyPath"`
+	ApplianceImage       string               `json:"ApplianceImage,omitempty"`
+	StackName            string               `json:"StackName,omitempty"`
+	PortainerInstanceID  string               `json:"PortainerInstanceId,omitempty"`
+	ServiceKeyPrefix     string               `json:"ServiceKeyPrefix,omitempty"`
+	ServiceKeyCreatedAt  int64                `json:"ServiceKeyCreatedAt,omitempty"`
+	ServiceKeyLastUsedAt int64                `json:"ServiceKeyLastUsedAt,omitempty"`
+	ServiceKeyRotatedAt  int64                `json:"ServiceKeyRotatedAt,omitempty"`
+	ManagedAuthReady     bool                 `json:"ManagedAuthReady"`
+	Stack                *stackSummary        `json:"Stack,omitempty"`
+	Health               healthStatus         `json:"Health"`
+	Access               logForgeAccess       `json:"Access"`
+}
+
+type stackSummary struct {
+	ID         portainer.StackID     `json:"Id"`
+	Name       string                `json:"Name"`
+	EndpointID portainer.EndpointID  `json:"EndpointId"`
+	Status     portainer.StackStatus `json:"Status"`
+}
+
+type healthStatus struct {
+	Status     string `json:"Status"`
+	Message    string `json:"Message,omitempty"`
+	StatusCode int    `json:"StatusCode,omitempty"`
+	Version    string `json:"Version,omitempty"`
+	CheckedAt  int64  `json:"CheckedAt,omitempty"`
+}
+
+type logForgeAccess struct {
+	Allowed   bool                    `json:"Allowed"`
+	IsAdmin   bool                    `json:"IsAdmin"`
+	UserID    portainer.UserID        `json:"UserId,omitempty"`
+	Username  string                  `json:"Username,omitempty"`
+	TeamIDs   []portainer.TeamID      `json:"TeamIds,omitempty"`
+	Endpoints []logForgeEndpointScope `json:"Endpoints,omitempty"`
+}
+
+type logForgeEndpointScope struct {
+	ID     portainer.EndpointID `json:"Id"`
+	Name   string               `json:"Name"`
+	Role   string               `json:"Role"`
+	RoleID portainer.RoleID     `json:"RoleId,omitempty"`
+}
+
+type installPayload struct {
+	EndpointID          portainer.EndpointID `json:"EndpointId,omitempty"`
+	ApplianceURL        string               `json:"ApplianceUrl,omitempty"`
+	ApplianceHostHeader string               `json:"ApplianceHostHeader,omitempty"`
+	Image               string               `json:"Image,omitempty"`
+	StackName           string               `json:"StackName,omitempty"`
+	CentralFQDN         string               `json:"CentralFQDN,omitempty"`
+	HTTPSPort           int                  `json:"HTTPSPort,omitempty"`
+	MTLSPort            int                  `json:"MTLSPort,omitempty"`
+	RemoteAgentImage    string               `json:"RemoteAgentImage,omitempty"`
+}
+
+func (payload *installPayload) Validate(r *http.Request) error {
+	if payload.EndpointID == 0 && strings.TrimSpace(payload.ApplianceURL) == "" {
+		return errors.New("EndpointId or ApplianceUrl is required")
+	}
+
+	if err := validateNoControlChars(payload.ApplianceURL); err != nil {
+		return fmt.Errorf("invalid ApplianceUrl: %w", err)
+	}
+	if err := validateNoControlChars(payload.ApplianceHostHeader); err != nil {
+		return fmt.Errorf("invalid ApplianceHostHeader: %w", err)
+	}
+	if err := validateHostHeader(payload.ApplianceHostHeader); err != nil {
+		return fmt.Errorf("invalid ApplianceHostHeader: %w", err)
+	}
+	if err := validateNoControlChars(payload.Image); err != nil {
+		return fmt.Errorf("invalid Image: %w", err)
+	}
+	if err := validateNoControlChars(payload.StackName); err != nil {
+		return fmt.Errorf("invalid StackName: %w", err)
+	}
+	if err := validateNoControlChars(payload.CentralFQDN); err != nil {
+		return fmt.Errorf("invalid CentralFQDN: %w", err)
+	}
+	if err := validateNoControlChars(payload.RemoteAgentImage); err != nil {
+		return fmt.Errorf("invalid RemoteAgentImage: %w", err)
+	}
+
+	if strings.TrimSpace(payload.ApplianceURL) != "" {
+		u, err := url.Parse(strings.TrimSpace(payload.ApplianceURL))
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return errors.New("ApplianceUrl must be an absolute URL")
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return errors.New("ApplianceUrl must use http or https")
+		}
+	}
+
+	if !isValidPort(payload.HTTPSPort) {
+		return errors.New("HTTPSPort must be between 1 and 65535")
+	}
+	if !isValidPort(payload.MTLSPort) {
+		return errors.New("MTLSPort must be between 1 and 65535")
+	}
+
+	return nil
+}
+
+type uninstallPayload struct {
+	RemoveManagedStack bool `json:"RemoveManagedStack"`
+}
+
+func (payload *uninstallPayload) Validate(r *http.Request) error {
+	return nil
+}
+
+func (handler *Handler) status(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	settings, err := handler.currentSettings()
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve LogForge settings", err)
+	}
+
+	return response.JSON(w, handler.buildStatus(r, settings))
+}
+
+func (handler *Handler) installOrRegister(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	payload, err := request.GetPayload[installPayload](r)
+	if err != nil {
+		return httperror.BadRequest("Invalid request payload", err)
+	}
+
+	settings, err := handler.currentSettings()
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve LogForge settings", err)
+	}
+
+	instanceID, err := handler.DataStore.Version().InstanceID()
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve Portainer instance identifier", err)
+	}
+
+	if settings.ServiceKey == "" {
+		serviceKey, prefix, err := generateServiceKey()
+		if err != nil {
+			return httperror.InternalServerError("Unable to generate LogForge service key", err)
+		}
+		settings.ServiceKey = serviceKey
+		settings.ServiceKeyPrefix = prefix
+		settings.ServiceKeyCreatedAt = time.Now().Unix()
+	}
+
+	settings.Enabled = true
+	settings.PortainerInstanceID = instanceID
+	settings.BrowserProxyPath = browserProxyPath
+	settings.ApplianceImage = valueOrDefault(payload.Image, defaultImage)
+	settings.ApplianceHostHeader = applianceHostHeader(payload)
+
+	if payload.EndpointID != 0 {
+		stack, endpoint, httpErr := handler.installManagedStack(r, payload, instanceID, settings.ServiceKey)
+		if httpErr != nil {
+			return httpErr
+		}
+
+		settings.Managed = true
+		settings.ApplianceStackID = stack.ID
+		settings.ApplianceEndpointID = endpoint.ID
+		settings.StackName = stack.Name
+		settings.ApplianceURL = normalizedApplianceURL(payload.ApplianceURL, payload.HTTPSPort)
+	} else {
+		settings.Managed = false
+		settings.ApplianceStackID = 0
+		settings.ApplianceEndpointID = 0
+		settings.StackName = ""
+		settings.ApplianceURL = normalizeURL(payload.ApplianceURL)
+	}
+
+	if settings.ApplianceURL == "" {
+		settings.ApplianceURL = normalizedApplianceURL(payload.ApplianceURL, payload.HTTPSPort)
+	}
+
+	if err := handler.DataStore.LogForge().UpdateSettings(settings); err != nil {
+		return httperror.InternalServerError("Unable to persist LogForge settings", err)
+	}
+
+	return response.JSONWithStatus(w, handler.buildStatus(r, settings), http.StatusCreated)
+}
+
+func (handler *Handler) uninstallOrClear(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	payload := uninstallPayload{}
+	if r.Body != nil && r.ContentLength > 0 {
+		if err := request.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+			return httperror.BadRequest("Invalid request payload", err)
+		}
+	}
+
+	settings, err := handler.currentSettings()
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve LogForge settings", err)
+	}
+
+	if payload.RemoveManagedStack && settings.Managed && settings.ApplianceStackID != 0 {
+		if httpErr := handler.removeManagedStack(r.Context(), settings); httpErr != nil {
+			return httpErr
+		}
+	}
+
+	if err := handler.DataStore.LogForge().DeleteSettings(); err != nil && !handler.DataStore.IsErrObjectNotFound(err) {
+		return httperror.InternalServerError("Unable to clear LogForge settings", err)
+	}
+
+	return response.JSON(w, handler.buildStatus(r, &portainer.LogForgeSettings{}))
+}
+
+func (handler *Handler) installManagedStack(r *http.Request, payload *installPayload, instanceID string, serviceKey string) (*portainer.Stack, *portainer.Endpoint, *httperror.HandlerError) {
+	if handler.FileService == nil || handler.StackDeployer == nil || handler.ComposeStackManager == nil {
+		return nil, nil, httperror.InternalServerError("LogForge managed install is not available", errors.New("stack services are not initialized"))
+	}
+
+	endpoint, err := handler.DataStore.Endpoint().Endpoint(payload.EndpointID)
+	if handler.DataStore.IsErrObjectNotFound(err) {
+		return nil, nil, httperror.NotFound("Unable to find the target environment", err)
+	} else if err != nil {
+		return nil, nil, httperror.InternalServerError("Unable to find the target environment", err)
+	}
+
+	if !endpointutils.IsDockerEndpoint(endpoint) {
+		return nil, nil, httperror.BadRequest("LogForge managed install supports Docker environments only", errors.New("unsupported environment type"))
+	}
+
+	if err := handler.requestBouncer.AuthorizedEndpointOperation(r, endpoint); err != nil {
+		return nil, nil, httperror.Forbidden("Permission denied to access environment", err)
+	}
+
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return nil, nil, httperror.InternalServerError("Unable to retrieve user details from authentication token", err)
+	}
+
+	securityContext, err := security.RetrieveRestrictedRequestContext(r)
+	if err != nil {
+		return nil, nil, httperror.InternalServerError("Unable to retrieve user info from request context", err)
+	}
+
+	stackName := handler.ComposeStackManager.NormalizeStackName(valueOrDefault(payload.StackName, defaultStackName))
+	if exists, err := handler.stackNameExists(endpoint.ID, stackName); err != nil {
+		return nil, nil, httperror.InternalServerError("Unable to check LogForge stack name", err)
+	} else if exists {
+		return nil, nil, httperror.Conflict("A stack with the LogForge stack name already exists on the target environment", errors.New("stack already exists"))
+	}
+
+	stackPayload := stackbuilders.StackPayload{
+		Name:             stackName,
+		StackFileContent: []byte(renderManagedCompose(payload, instanceID, serviceKeySHA256(serviceKey))),
+		FromAppTemplate:  false,
+	}
+
+	builder := stackbuilders.CreateComposeStackFileBuilder(
+		securityContext,
+		handler.DataStore,
+		handler.FileService,
+		handler.StackDeployer,
+	)
+
+	stack, httpErr := stackbuilders.Build(r.Context(), handler.DataStore, builder, &stackPayload, endpoint, tokenData.ID)
+	if httpErr != nil {
+		return nil, nil, httpErr
+	}
+
+	resourceControl := authorization.NewAdministratorsOnlyResourceControl(
+		stackutils.ResourceControlID(stack.EndpointID, stack.Name),
+		portainer.StackResourceControl,
+	)
+	if err := handler.DataStore.ResourceControl().Create(resourceControl); err != nil {
+		log.Warn().Err(err).Int("stack_id", int(stack.ID)).Msg("unable to persist LogForge stack resource control")
+	}
+
+	return stack, endpoint, nil
+}
+
+func (handler *Handler) removeManagedStack(ctx context.Context, settings *portainer.LogForgeSettings) *httperror.HandlerError {
+	if handler.StackDeployer == nil || handler.FileService == nil {
+		return nil
+	}
+
+	stack, err := handler.DataStore.Stack().Read(settings.ApplianceStackID)
+	if handler.DataStore.IsErrObjectNotFound(err) {
+		return nil
+	} else if err != nil {
+		return httperror.InternalServerError("Unable to find the managed LogForge stack", err)
+	}
+
+	endpoint, err := handler.DataStore.Endpoint().Endpoint(stack.EndpointID)
+	if handler.DataStore.IsErrObjectNotFound(err) {
+		return nil
+	} else if err != nil {
+		return httperror.InternalServerError("Unable to find the managed LogForge environment", err)
+	}
+
+	if err := handler.StackDeployer.UndeployComposeStack(ctx, stack, endpoint); err != nil {
+		return httperror.InternalServerError("Unable to remove the managed LogForge stack from Docker", err)
+	}
+
+	if err := handler.DataStore.UpdateTx(func(tx dataservices.DataStoreTx) error {
+		resourceControl, err := tx.ResourceControl().ResourceControlByResourceIDAndType(
+			stackutils.ResourceControlID(stack.EndpointID, stack.Name),
+			portainer.StackResourceControl,
+		)
+		if err != nil {
+			return err
+		}
+
+		if resourceControl != nil {
+			if err := tx.ResourceControl().Delete(resourceControl.ID); err != nil {
+				return err
+			}
+		}
+
+		return tx.Stack().Delete(stack.ID)
+	}); err != nil {
+		return httperror.InternalServerError("Unable to remove the managed LogForge stack from Portainer", err)
+	}
+
+	if stack.ProjectPath != "" {
+		if err := handler.FileService.RemoveDirectory(stack.ProjectPath); err != nil {
+			log.Warn().Err(err).Str("project_path", stack.ProjectPath).Msg("unable to remove LogForge stack files")
+		}
+	}
+
+	return nil
+}
+
+func (handler *Handler) proxyUI(w http.ResponseWriter, r *http.Request) *httperror.HandlerError {
+	settings, err := handler.currentSettings()
+	if err != nil {
+		return httperror.InternalServerError("Unable to retrieve LogForge settings", err)
+	}
+
+	if !settings.Enabled || strings.TrimSpace(settings.ApplianceURL) == "" {
+		return httperror.NotFound("LogForge is not configured", errors.New("LogForge is not configured"))
+	}
+
+	target, err := url.Parse(settings.ApplianceURL)
+	if err != nil || target.Scheme == "" || target.Host == "" {
+		return httperror.InternalServerError("LogForge appliance URL is invalid", err)
+	}
+
+	access, err := handler.logForgeAccessForRequest(r)
+	if err != nil {
+		return httperror.InternalServerError("Unable to resolve LogForge access", err)
+	}
+	if !access.Allowed {
+		return httperror.Forbidden("Permission denied to access LogForge", errors.New("no Docker environment access"))
+	}
+
+	proxy := handler.newUIProxy(target, settings.ServiceKey, settings.ApplianceHostHeader, access)
+	proxy.ServeHTTP(w, r)
+	return nil
+}
+
+func (handler *Handler) newUIProxy(target *url.URL, serviceKey string, hostHeader string, access logForgeAccess) *httputil.ReverseProxy {
+	targetQuery := target.RawQuery
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = buildUpstreamPath(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		req.Host = valueOrDefault(hostHeader, target.Host)
+
+		req.Header.Del("Authorization")
+		req.Header.Del("X-API-KEY")
+		req.Header.Del("Cookie")
+		req.Header.Del(serviceKeyHeader)
+		req.Header.Del(managedByHeader)
+		req.Header.Del(managedIdentityHeader)
+		req.Header.Del(managedSignatureHeader)
+		if serviceKey != "" {
+			req.Header.Set(serviceKeyHeader, serviceKey)
+		}
+		identity, signature := signedManagedIdentity(access, serviceKey)
+		if identity != "" && signature != "" {
+			req.Header.Set(managedByHeader, "portainer")
+			req.Header.Set(managedIdentityHeader, identity)
+			req.Header.Set(managedSignatureHeader, signature)
+		}
+	}
+	proxy.ModifyResponse = rewriteProxyResponse
+	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		httperror.WriteError(rw, http.StatusBadGateway, "Unable to reach LogForge appliance", err)
+	}
+	return proxy
+}
+
+func rewriteProxyResponse(resp *http.Response) error {
+	location := resp.Header.Get("Location")
+	if location != "" {
+		resp.Header.Set("Location", strings.ReplaceAll(location, "/unicron", browserProxyPath[:len(browserProxyPath)-1]))
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if !shouldRewriteContent(contentType) || resp.Body == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	logs.CloseAndLogErr(resp.Body)
+
+	body = bytes.ReplaceAll(body, []byte("/unicron/"), []byte(browserProxyPath))
+	body = bytes.ReplaceAll(body, []byte("\"/unicron\""), []byte("\"/logforge/ui\""))
+	body = bytes.ReplaceAll(body, []byte("'/unicron'"), []byte("'/logforge/ui'"))
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	return nil
+}
+
+func shouldRewriteContent(contentType string) bool {
+	contentType = strings.ToLower(contentType)
+	return strings.Contains(contentType, "text/html") ||
+		strings.Contains(contentType, "text/css") ||
+		strings.Contains(contentType, "javascript") ||
+		strings.Contains(contentType, "application/json") ||
+		strings.Contains(contentType, "application/manifest+json") ||
+		strings.Contains(contentType, "text/plain")
+}
+
+func (handler *Handler) logForgeAccessForRequest(r *http.Request) (logForgeAccess, error) {
+	tokenData, err := security.RetrieveTokenData(r)
+	if err != nil {
+		return logForgeAccess{}, nil
+	}
+
+	securityContext, err := security.RetrieveRestrictedRequestContext(r)
+	if err != nil {
+		securityContext = &security.RestrictedRequestContext{
+			IsAdmin: tokenData.Role == portainer.AdministratorRole,
+			UserID:  tokenData.ID,
+		}
+		if !securityContext.IsAdmin {
+			memberships, err := handler.DataStore.TeamMembership().TeamMembershipsByUserID(tokenData.ID)
+			if err != nil {
+				return logForgeAccess{}, err
+			}
+			securityContext.UserMemberships = memberships
+		}
+	}
+
+	access := logForgeAccess{
+		IsAdmin:  securityContext.IsAdmin,
+		UserID:   tokenData.ID,
+		Username: tokenData.Username,
+		TeamIDs:  teamIDs(securityContext.UserMemberships),
+	}
+
+	endpoints, err := handler.DataStore.Endpoint().Endpoints()
+	if err != nil {
+		return logForgeAccess{}, err
+	}
+
+	groups, err := handler.DataStore.EndpointGroup().ReadAll()
+	if err != nil {
+		return logForgeAccess{}, err
+	}
+	groupByID := map[portainer.EndpointGroupID]portainer.EndpointGroup{}
+	for _, group := range groups {
+		groupByID[group.ID] = group
+	}
+
+	for _, endpoint := range endpoints {
+		if !endpointutils.IsDockerEndpoint(&endpoint) {
+			continue
+		}
+
+		endpointGroup, ok := groupByID[endpoint.GroupID]
+		if !ok {
+			endpointGroup = portainer.EndpointGroup{ID: endpoint.GroupID}
+		}
+
+		if !securityContext.IsAdmin && !security.AuthorizedEndpointAccess(&endpoint, &endpointGroup, tokenData.ID, securityContext.UserMemberships) {
+			continue
+		}
+
+		roleID := endpointAccessRoleID(tokenData.ID, securityContext.UserMemberships, &endpoint, &endpointGroup)
+		if securityContext.IsAdmin {
+			roleID = endpointAdminRoleID
+		}
+		access.Endpoints = append(access.Endpoints, logForgeEndpointScope{
+			ID:     endpoint.ID,
+			Name:   endpoint.Name,
+			Role:   logForgeRole(roleID),
+			RoleID: roleID,
+		})
+	}
+
+	sort.Slice(access.Endpoints, func(i, j int) bool {
+		return access.Endpoints[i].ID < access.Endpoints[j].ID
+	})
+	access.Allowed = len(access.Endpoints) > 0
+
+	return access, nil
+}
+
+func teamIDs(memberships []portainer.TeamMembership) []portainer.TeamID {
+	teamSet := map[portainer.TeamID]bool{}
+	for _, membership := range memberships {
+		teamSet[membership.TeamID] = true
+	}
+
+	ids := make([]portainer.TeamID, 0, len(teamSet))
+	for teamID := range teamSet {
+		ids = append(ids, teamID)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+
+	return ids
+}
+
+func endpointAccessRoleID(userID portainer.UserID, memberships []portainer.TeamMembership, endpoint *portainer.Endpoint, group *portainer.EndpointGroup) portainer.RoleID {
+	roleID := portainer.RoleID(0)
+	apply := func(candidate portainer.RoleID) {
+		if rankRoleID(candidate) > rankRoleID(roleID) {
+			roleID = candidate
+		}
+	}
+
+	if policy, ok := endpoint.UserAccessPolicies[userID]; ok {
+		apply(policy.RoleID)
+	}
+	for _, membership := range memberships {
+		if policy, ok := endpoint.TeamAccessPolicies[membership.TeamID]; ok {
+			apply(policy.RoleID)
+		}
+	}
+	if policy, ok := group.UserAccessPolicies[userID]; ok {
+		apply(policy.RoleID)
+	}
+	for _, membership := range memberships {
+		if policy, ok := group.TeamAccessPolicies[membership.TeamID]; ok {
+			apply(policy.RoleID)
+		}
+	}
+
+	return roleID
+}
+
+func rankRoleID(roleID portainer.RoleID) int {
+	switch roleID {
+	case endpointAdminRoleID:
+		return 4
+	case standardRoleID, operatorRoleID:
+		return 3
+	case helpdeskRoleID, readOnlyRoleID:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func logForgeRole(roleID portainer.RoleID) string {
+	switch roleID {
+	case endpointAdminRoleID:
+		return "admin"
+	case standardRoleID, operatorRoleID:
+		return "write"
+	case helpdeskRoleID, readOnlyRoleID:
+		return "read_only"
+	default:
+		return "read_only"
+	}
+}
+
+type managedIdentityClaims struct {
+	Issuer    string                  `json:"iss"`
+	Subject   string                  `json:"sub"`
+	UserID    portainer.UserID        `json:"user_id"`
+	Username  string                  `json:"username,omitempty"`
+	IsAdmin   bool                    `json:"is_admin"`
+	TeamIDs   []portainer.TeamID      `json:"team_ids,omitempty"`
+	Endpoints []logForgeEndpointScope `json:"endpoints"`
+	IssuedAt  int64                   `json:"iat"`
+	ExpiresAt int64                   `json:"exp"`
+}
+
+func signedManagedIdentity(access logForgeAccess, serviceKey string) (string, string) {
+	if serviceKey == "" || !access.Allowed {
+		return "", ""
+	}
+
+	now := time.Now()
+	claims := managedIdentityClaims{
+		Issuer:    "portainer",
+		Subject:   fmt.Sprintf("portainer:user:%d", access.UserID),
+		UserID:    access.UserID,
+		Username:  access.Username,
+		IsAdmin:   access.IsAdmin,
+		TeamIDs:   access.TeamIDs,
+		Endpoints: access.Endpoints,
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(managedIdentityTTL).Unix(),
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", ""
+	}
+
+	identity := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(serviceKey))
+	_, _ = mac.Write([]byte(identity))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return identity, signature
+}
+
+func (handler *Handler) currentSettings() (*portainer.LogForgeSettings, error) {
+	settings, err := handler.DataStore.LogForge().Settings()
+	if err != nil {
+		if handler.DataStore.IsErrObjectNotFound(err) {
+			return &portainer.LogForgeSettings{
+				BrowserProxyPath: browserProxyPath,
+			}, nil
+		}
+		return nil, err
+	}
+
+	if settings.BrowserProxyPath == "" {
+		settings.BrowserProxyPath = browserProxyPath
+	}
+
+	return settings, nil
+}
+
+func (handler *Handler) buildStatus(r *http.Request, settings *portainer.LogForgeSettings) statusResponse {
+	access, err := handler.logForgeAccessForRequest(r)
+	if err != nil {
+		log.Warn().Err(err).Msg("unable to resolve LogForge access")
+	}
+
+	status := statusResponse{
+		Enabled:              settings.Enabled,
+		Managed:              settings.Managed,
+		ApplianceStackID:     settings.ApplianceStackID,
+		ApplianceEndpointID:  settings.ApplianceEndpointID,
+		ApplianceURL:         settings.ApplianceURL,
+		ApplianceHostHeader:  settings.ApplianceHostHeader,
+		BrowserProxyPath:     valueOrDefault(settings.BrowserProxyPath, browserProxyPath),
+		ApplianceImage:       settings.ApplianceImage,
+		StackName:            settings.StackName,
+		PortainerInstanceID:  settings.PortainerInstanceID,
+		ServiceKeyPrefix:     settings.ServiceKeyPrefix,
+		ServiceKeyCreatedAt:  settings.ServiceKeyCreatedAt,
+		ServiceKeyLastUsedAt: settings.ServiceKeyLastUsedAt,
+		ServiceKeyRotatedAt:  settings.ServiceKeyRotatedAt,
+		ManagedAuthReady:     settings.ServiceKey != "",
+		Health:               handler.checkHealth(r.Context(), settings),
+		Access:               access,
+	}
+
+	if settings.ApplianceStackID != 0 {
+		if stack, err := handler.DataStore.Stack().Read(settings.ApplianceStackID); err == nil {
+			status.Stack = &stackSummary{
+				ID:         stack.ID,
+				Name:       stack.Name,
+				EndpointID: stack.EndpointID,
+				Status:     stack.Status,
+			}
+		}
+	}
+
+	return status
+}
+
+func (handler *Handler) checkHealth(ctx context.Context, settings *portainer.LogForgeSettings) healthStatus {
+	checkedAt := time.Now().Unix()
+	if !settings.Enabled || strings.TrimSpace(settings.ApplianceURL) == "" {
+		return healthStatus{Status: "not_configured", CheckedAt: checkedAt}
+	}
+
+	healthURL, err := appendUnicronPath(settings.ApplianceURL, "/api/health")
+	if err != nil {
+		return healthStatus{Status: "unhealthy", Message: err.Error(), CheckedAt: checkedAt}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		return healthStatus{Status: "unhealthy", Message: err.Error(), CheckedAt: checkedAt}
+	}
+	if settings.ServiceKey != "" {
+		req.Header.Set(serviceKeyHeader, settings.ServiceKey)
+	}
+	if settings.ApplianceHostHeader != "" {
+		req.Host = settings.ApplianceHostHeader
+	}
+
+	resp, err := handler.httpClient.Do(req)
+	if err != nil {
+		return healthStatus{Status: "unhealthy", Message: err.Error(), CheckedAt: checkedAt}
+	}
+	defer logs.CloseAndLogErr(resp.Body)
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return healthStatus{
+			Status:     "unhealthy",
+			Message:    strings.TrimSpace(string(body)),
+			StatusCode: resp.StatusCode,
+			CheckedAt:  checkedAt,
+		}
+	}
+
+	message := strings.TrimSpace(string(body))
+	health := healthStatus{
+		Status:     "healthy",
+		Message:    message,
+		StatusCode: resp.StatusCode,
+		CheckedAt:  checkedAt,
+	}
+	if strings.Contains(message, `"version"`) {
+		health.Version = extractJSONValue(message, "version")
+	}
+	return health
+}
+
+func (handler *Handler) stackNameExists(endpointID portainer.EndpointID, stackName string) (bool, error) {
+	stacks, err := handler.DataStore.Stack().ReadAll()
+	if err != nil {
+		return false, err
+	}
+
+	for _, stack := range stacks {
+		if stack.EndpointID == endpointID && strings.EqualFold(stack.Name, stackName) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func renderManagedCompose(payload *installPayload, instanceID string, serviceKeyVerifier string) string {
+	image := valueOrDefault(payload.Image, defaultImage)
+	httpsPort := valueOrDefaultInt(payload.HTTPSPort, defaultHTTPSPort)
+	mtlsPort := valueOrDefaultInt(payload.MTLSPort, defaultMTLSPort)
+	centralFQDN := valueOrDefault(payload.CentralFQDN, defaultCentralFQDN)
+	remoteAgentImage := valueOrDefault(payload.RemoteAgentImage, defaultRemoteAgentImage)
+	portainerInstanceID := valueOrDefault(instanceID, "portainer")
+
+	return fmt.Sprintf(`services:
+  unicron:
+    image: %s
+    container_name: %s
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,mode=1777,size=256m
+      - /run:rw,nosuid,nodev,mode=755,size=64m
+      - /run/pyinstaller:rw,nosuid,nodev,exec,mode=1777,size=256m
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - KILL
+      - SETGID
+      - SETUID
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    extra_hosts:
+      - unicron-stepca:127.0.0.1
+      - unicron-stepca-ra:127.0.0.1
+      - unicron.central:127.0.0.1
+      - %s:127.0.0.1
+    ports:
+      - "%d:443"
+      - "%d:8443"
+    environment:
+      UNICRON_MANAGED_BY: portainer
+      UNICRON_SELF_UPDATE_ENABLED: "false"
+      UNICRON_MANAGED_EXTERNAL_AUTH_ENABLED: "true"
+      UNICRON_MANAGED_EXTERNAL_AUTH_PROVIDER: portainer
+      UNICRON_MANAGED_IDENTITY_HEADER: %s
+      UNICRON_MANAGED_IDENTITY_SIGNATURE_HEADER: %s
+      UNICRON_MANAGED_SERVICE_KEY_HEADER: %s
+      UNICRON_MANAGED_SERVICE_KEY_SHA256: %s
+      UNICRON_CENTRAL_FQDN: %s
+      UNICRON_PUBLIC_CENTRAL_PORT: "%d"
+      UNICRON_PUBLIC_CENTRAL_MTLS_PORT: "%d"
+      UNICRON_APPLIANCE_CONTAINER_NAME: %s
+      PORTAINER_INSTANCE_ID: %s
+      TMPDIR: /run/pyinstaller
+      CENTRAL_ADMIN_RECOVERY_OVERRIDE: "false"
+      REMOTE_AGENT_IMAGE: %s
+    volumes:
+      - %s:/var/lib/unicron
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/unicron-appliance-manager", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+
+volumes:
+  %s:
+    name: %s
+`, image, defaultContainerName, centralFQDN, httpsPort, mtlsPort, managedIdentityHeader, managedSignatureHeader, serviceKeyHeader, serviceKeyVerifier, centralFQDN, httpsPort, mtlsPort, defaultContainerName, portainerInstanceID, remoteAgentImage, defaultVolumeName, defaultVolumeName, defaultVolumeName)
+}
+
+func serviceKeySHA256(serviceKey string) string {
+	sum := sha256.Sum256([]byte(serviceKey))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func generateServiceKey() (string, string, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return "", "", err
+	}
+
+	encoded := "lfp_" + base64.RawURLEncoding.EncodeToString(key)
+	prefixLen := 12
+	if len(encoded) < prefixLen {
+		prefixLen = len(encoded)
+	}
+	return encoded, encoded[:prefixLen], nil
+}
+
+func normalizedApplianceURL(raw string, httpsPort int) string {
+	if normalized := normalizeURL(raw); normalized != "" {
+		return normalized
+	}
+	return fmt.Sprintf("https://127.0.0.1:%d", valueOrDefaultInt(httpsPort, defaultHTTPSPort))
+}
+
+func normalizeURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func applianceHostHeader(payload *installPayload) string {
+	if normalized := normalizeHostHeader(payload.ApplianceHostHeader); normalized != "" {
+		return normalized
+	}
+	if payload.EndpointID != 0 {
+		return normalizeHostHeader(payload.CentralFQDN)
+	}
+	return ""
+}
+
+func normalizeHostHeader(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	if strings.Contains(raw, "://") {
+		if u, err := url.Parse(raw); err == nil {
+			return u.Host
+		}
+	}
+
+	return strings.TrimRight(raw, "/")
+}
+
+func validateHostHeader(value string) error {
+	value = normalizeHostHeader(value)
+	if value == "" {
+		return nil
+	}
+
+	if strings.ContainsAny(value, " \\/") {
+		return errors.New("host header must not contain whitespace or path separators")
+	}
+
+	return nil
+}
+
+func appendUnicronPath(raw string, suffix string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+
+	basePath := strings.TrimRight(u.Path, "/")
+	if !strings.HasSuffix(basePath, "/unicron") {
+		basePath += "/unicron"
+	}
+	u.Path = singleJoiningSlash(basePath, suffix)
+	u.RawQuery = ""
+	return u.String(), nil
+}
+
+func buildUpstreamPath(targetPath string, requestPath string) string {
+	basePath := strings.TrimRight(targetPath, "/")
+	if !strings.HasSuffix(basePath, "/unicron") {
+		basePath += "/unicron"
+	}
+
+	rest := strings.TrimPrefix(requestPath, "/logforge/ui")
+	if rest == "" {
+		rest = "/"
+	}
+
+	return singleJoiningSlash(basePath, rest)
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+func valueOrDefault(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func valueOrDefaultInt(value int, fallback int) int {
+	if value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func isValidPort(value int) bool {
+	return value == 0 || (value >= 1 && value <= 65535)
+}
+
+func validateNoControlChars(value string) error {
+	for _, r := range value {
+		if r == '\n' || r == '\r' || r == '\t' {
+			return errors.New("control characters are not allowed")
+		}
+	}
+	return nil
+}
+
+func extractJSONValue(body string, key string) string {
+	token := `"` + key + `":`
+	idx := strings.Index(body, token)
+	if idx == -1 {
+		return ""
+	}
+	rest := strings.TrimSpace(body[idx+len(token):])
+	if !strings.HasPrefix(rest, `"`) {
+		return ""
+	}
+	rest = rest[1:]
+	end := strings.Index(rest, `"`)
+	if end == -1 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -934,6 +934,7 @@ func renderManagedCompose(payload *installPayload, stackName string, instanceID 
 	httpsPort := valueOrDefaultInt(payload.HTTPSPort, defaultHTTPSPort)
 	mtlsPort := valueOrDefaultInt(payload.MTLSPort, defaultMTLSPort)
 	centralFQDN := valueOrDefault(payload.CentralFQDN, defaultCentralFQDN)
+	extraHosts := renderManagedExtraHosts(centralFQDN)
 	remoteAgentImage := valueOrDefault(payload.RemoteAgentImage, defaultRemoteAgentImage)
 	portainerInstanceID := valueOrDefault(instanceID, "portainer")
 
@@ -961,10 +962,7 @@ func renderManagedCompose(payload *installPayload, stackName string, instanceID 
     security_opt:
       - no-new-privileges:true
     extra_hosts:
-      - unicron-stepca:127.0.0.1
-      - unicron-stepca-ra:127.0.0.1
-      - unicron.central:127.0.0.1
-      - %s:127.0.0.1
+%s
     ports:
       - "%d:443"
       - "%d:8443"
@@ -1002,7 +1000,27 @@ func renderManagedCompose(payload *installPayload, stackName string, instanceID 
 volumes:
   %s:
     name: %s
-`, image, defaultContainerName, centralFQDN, httpsPort, mtlsPort, managedIdentityHeader, managedSignatureHeader, serviceKeyHeader, serviceKeyVerifier, centralFQDN, httpsPort, mtlsPort, stackName, defaultContainerName, portainerInstanceID, remoteAgentImage, defaultVolumeName, defaultVolumeName, defaultVolumeName)
+`, image, defaultContainerName, extraHosts, httpsPort, mtlsPort, managedIdentityHeader, managedSignatureHeader, serviceKeyHeader, serviceKeyVerifier, centralFQDN, httpsPort, mtlsPort, stackName, defaultContainerName, portainerInstanceID, remoteAgentImage, defaultVolumeName, defaultVolumeName, defaultVolumeName)
+}
+
+func renderManagedExtraHosts(centralFQDN string) string {
+	hosts := []string{"unicron-stepca", "unicron-stepca-ra", "unicron.central"}
+	for _, host := range hosts {
+		if strings.EqualFold(host, centralFQDN) {
+			centralFQDN = ""
+			break
+		}
+	}
+	if centralFQDN != "" {
+		hosts = append(hosts, centralFQDN)
+	}
+
+	var result strings.Builder
+	for _, host := range hosts {
+		fmt.Fprintf(&result, "      %q: %q\n", host, "127.0.0.1")
+	}
+
+	return strings.TrimSuffix(result.String(), "\n")
 }
 
 func serviceKeySHA256(serviceKey string) string {

--- a/api/http/handler/logforge/handler.go
+++ b/api/http/handler/logforge/handler.go
@@ -595,14 +595,16 @@ func (handler *Handler) logForgeAccessForRequest(r *http.Request) (logForgeAcces
 			continue
 		}
 
-		roleID := endpointAccessRoleID(tokenData.ID, securityContext.UserMemberships, &endpoint, &endpointGroup)
+		roleID := readOnlyRoleID
+		role := "read_only"
 		if securityContext.IsAdmin {
 			roleID = endpointAdminRoleID
+			role = "admin"
 		}
 		access.Endpoints = append(access.Endpoints, logForgeEndpointScope{
 			ID:     endpoint.ID,
 			Name:   endpoint.Name,
-			Role:   logForgeRole(roleID),
+			Role:   role,
 			RoleID: roleID,
 		})
 	}
@@ -630,60 +632,6 @@ func teamIDs(memberships []portainer.TeamMembership) []portainer.TeamID {
 	})
 
 	return ids
-}
-
-func endpointAccessRoleID(userID portainer.UserID, memberships []portainer.TeamMembership, endpoint *portainer.Endpoint, group *portainer.EndpointGroup) portainer.RoleID {
-	roleID := portainer.RoleID(0)
-	apply := func(candidate portainer.RoleID) {
-		if rankRoleID(candidate) > rankRoleID(roleID) {
-			roleID = candidate
-		}
-	}
-
-	if policy, ok := endpoint.UserAccessPolicies[userID]; ok {
-		apply(policy.RoleID)
-	}
-	for _, membership := range memberships {
-		if policy, ok := endpoint.TeamAccessPolicies[membership.TeamID]; ok {
-			apply(policy.RoleID)
-		}
-	}
-	if policy, ok := group.UserAccessPolicies[userID]; ok {
-		apply(policy.RoleID)
-	}
-	for _, membership := range memberships {
-		if policy, ok := group.TeamAccessPolicies[membership.TeamID]; ok {
-			apply(policy.RoleID)
-		}
-	}
-
-	return roleID
-}
-
-func rankRoleID(roleID portainer.RoleID) int {
-	switch roleID {
-	case endpointAdminRoleID:
-		return 4
-	case standardRoleID, operatorRoleID:
-		return 3
-	case helpdeskRoleID, readOnlyRoleID:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func logForgeRole(roleID portainer.RoleID) string {
-	switch roleID {
-	case endpointAdminRoleID:
-		return "admin"
-	case standardRoleID, operatorRoleID:
-		return "write"
-	case helpdeskRoleID, readOnlyRoleID:
-		return "read_only"
-	default:
-		return "read_only"
-	}
 }
 
 type managedIdentityClaims struct {

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -2,18 +2,21 @@ package logforge
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/datastore"
 	"github.com/portainer/portainer/api/http/security"
 	"github.com/portainer/portainer/api/internal/testhelpers"
+	"github.com/portainer/portainer/pkg/fips"
 
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +56,7 @@ func TestInstallRegistersExternalAppliance(t *testing.T) {
 	handler := newTestHandler(t)
 	handler.httpClient = healthServer.Client()
 
-	payload := []byte(`{"ApplianceUrl":"` + healthServer.URL + `/unicron/","ApplianceHostHeader":"logforge.example.test"}`)
+	payload := []byte(`{"ApplianceUrl":"` + healthServer.URL + `/unicron/","ApplianceHostHeader":"logforge.example.test","TLSSkipVerify":true}`)
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "/logforge/install", bytes.NewReader(payload))
 	request.Header.Set("Content-Type", "application/json")
@@ -71,6 +74,7 @@ func TestInstallRegistersExternalAppliance(t *testing.T) {
 	require.Equal(t, "healthy", status.Health.Status)
 	require.Equal(t, "0.1.0", status.Health.Version)
 	require.Equal(t, "logforge.example.test", status.ApplianceHostHeader)
+	require.True(t, status.TLSSkipVerify)
 	require.True(t, status.ManagedAuthReady)
 	require.NotEmpty(t, status.ServiceKeyPrefix)
 	require.NotContains(t, recorder.Body.String(), `"ServiceKey":`)
@@ -81,6 +85,52 @@ func TestInstallRegistersExternalAppliance(t *testing.T) {
 	require.Equal(t, settings.ServiceKey, healthServiceKey)
 	require.Equal(t, "logforge.example.test", healthHost)
 	require.Equal(t, status.ServiceKeyPrefix, settings.ServiceKeyPrefix)
+	require.True(t, settings.TLSSkipVerify)
+}
+
+func TestHealthChecksVerifyTLSUnlessExplicitlySkipped(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/unicron/api/health", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newTestHandler(t)
+	settings := &portainer.LogForgeSettings{
+		Enabled:      true,
+		ApplianceURL: upstream.URL,
+	}
+
+	health := handler.checkHealth(context.Background(), settings)
+	require.Equal(t, "unhealthy", health.Status)
+
+	settings.TLSSkipVerify = true
+	health = handler.checkHealth(context.Background(), settings)
+	require.Equal(t, "healthy", health.Status)
+}
+
+func TestUIProxyVerifiesTLSUnlessExplicitlySkipped(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	handler := newTestHandler(t)
+	access := logForgeAccess{Allowed: true}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/ui/", nil)
+	handler.newUIProxy(target, "service-key", "", false, access).ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+
+	recorder = httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/logforge/ui/", nil)
+	handler.newUIProxy(target, "service-key", "", true, access).ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code)
 }
 
 func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
@@ -344,6 +394,36 @@ func TestStatusIncludesAdminScopeForPortainerAdministrators(t *testing.T) {
 	require.Equal(t, endpointAdminRoleID, status.Access.Endpoints[0].RoleID)
 }
 
+func TestLogForgeAccessIsCachedPerAuthenticatedToken(t *testing.T) {
+	handler := newTestHandler(t)
+	endpoint := createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), readOnlyRoleID)
+
+	requestForToken := func(token string) *http.Request {
+		request := httptest.NewRequest(http.MethodGet, "/logforge/ui/", nil)
+		return withLogForgeUser(request, &portainer.TokenData{
+			ID:       2,
+			Username: "alice",
+			Role:     portainer.StandardUserRole,
+			Token:    token,
+		}, &security.RestrictedRequestContext{UserID: 2})
+	}
+
+	access, err := handler.logForgeAccessForRequest(requestForToken("token-1"))
+	require.NoError(t, err)
+	require.Equal(t, "local-docker", access.Endpoints[0].Name)
+
+	endpoint.Name = "renamed-docker"
+	require.NoError(t, handler.DataStore.Endpoint().UpdateEndpoint(endpoint.ID, &endpoint))
+
+	access, err = handler.logForgeAccessForRequest(requestForToken("token-1"))
+	require.NoError(t, err)
+	require.Equal(t, "local-docker", access.Endpoints[0].Name)
+
+	access, err = handler.logForgeAccessForRequest(requestForToken("token-2"))
+	require.NoError(t, err)
+	require.Equal(t, "renamed-docker", access.Endpoints[0].Name)
+}
+
 func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
 	compose := renderManagedCompose(
 		&installPayload{
@@ -394,8 +474,15 @@ func TestManagedInstallDerivesHostHeaderFromCentralFQDN(t *testing.T) {
 	require.Equal(t, "localhost", hostHeader)
 }
 
+func TestManagedInstallUsesTrustedSelfSignedTLS(t *testing.T) {
+	require.True(t, tlsSkipVerifyForPayload(&installPayload{EndpointID: 1}))
+	require.False(t, tlsSkipVerifyForPayload(&installPayload{}))
+	require.True(t, tlsSkipVerifyForPayload(&installPayload{TLSSkipVerify: true}))
+}
+
 func newTestHandler(t *testing.T) *Handler {
 	t.Helper()
+	fips.InitFIPS(false)
 
 	_, store := datastore.MustNewTestStore(t, true, true)
 	require.NoError(t, store.Version().UpdateInstanceID("instance-1"))

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"testing"
 
+	composeloader "github.com/compose-spec/compose-go/v2/loader"
+	composetypes "github.com/compose-spec/compose-go/v2/types"
 	portainer "github.com/portainer/portainer/api"
 	"github.com/portainer/portainer/api/datastore"
 	"github.com/portainer/portainer/api/http/security"
@@ -494,6 +496,7 @@ func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
 	require.Contains(t, compose, "PORTAINER_INSTANCE_ID: instance-1")
 	require.Contains(t, compose, "REMOTE_AGENT_IMAGE: example/unicron-agent:test")
 	require.Contains(t, compose, "LOCAL_AGENT_DOCKER_NETWORK: custom-logforge_default")
+	require.Contains(t, compose, `"logs.example.test": "127.0.0.1"`)
 	require.Contains(t, compose, "- unicron.central")
 	require.Contains(t, compose, `"9449:443"`)
 	require.Contains(t, compose, `"8450:8443"`)
@@ -505,6 +508,35 @@ func TestManagedComposeUsesPortainerIntegrationImagesByDefault(t *testing.T) {
 
 	require.Contains(t, compose, "image: logforge/unicron:portainer-integration")
 	require.Contains(t, compose, "REMOTE_AGENT_IMAGE: logforge/unicron-agent:portainer-integration")
+}
+
+func TestManagedComposeUsesValidDeduplicatedExtraHostsMapping(t *testing.T) {
+	compose := renderManagedCompose(
+		&installPayload{CentralFQDN: "unicron.central"},
+		"logforge",
+		"instance-1",
+		"abcdef",
+	)
+
+	require.Contains(t, compose, "    extra_hosts:\n      \"unicron-stepca\": \"127.0.0.1\"")
+	require.NotContains(t, compose, "    extra_hosts:\n      - ")
+
+	project, err := composeloader.LoadWithContext(t.Context(), composetypes.ConfigDetails{
+		WorkingDir: t.TempDir(),
+		ConfigFiles: []composetypes.ConfigFile{{
+			Filename: "compose.yaml",
+			Content:  []byte(compose),
+		}},
+		Environment: map[string]string{},
+	}, func(options *composeloader.Options) {
+		options.SetProjectName("logforge", true)
+	})
+	require.NoError(t, err)
+	require.Equal(t, composetypes.HostsList{
+		"unicron-stepca":    []string{"127.0.0.1"},
+		"unicron-stepca-ra": []string{"127.0.0.1"},
+		"unicron.central":   []string{"127.0.0.1"},
+	}, project.Services["unicron"].ExtraHosts)
 }
 
 func TestManagedInstallDerivesHostHeaderFromCentralFQDN(t *testing.T) {

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -87,20 +87,30 @@ func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
 	var upstreamServiceKey string
 	var upstreamAuthorization string
 	var upstreamCookie string
+	var upstreamAcceptEncoding string
 	var upstreamHost string
 	var upstreamManagedBy string
 	var upstreamManagedIdentity string
 	var upstreamManagedSignature string
+	var upstreamOrigin string
+	var upstreamReferer string
+	var upstreamForwardedProto string
+	var upstreamForwardedHost string
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/unicron/assets/app.js", r.URL.Path)
 		upstreamServiceKey = r.Header.Get(serviceKeyHeader)
 		upstreamAuthorization = r.Header.Get("Authorization")
 		upstreamCookie = r.Header.Get("Cookie")
+		upstreamAcceptEncoding = r.Header.Get("Accept-Encoding")
 		upstreamHost = r.Host
 		upstreamManagedBy = r.Header.Get(managedByHeader)
 		upstreamManagedIdentity = r.Header.Get(managedIdentityHeader)
 		upstreamManagedSignature = r.Header.Get(managedSignatureHeader)
+		upstreamOrigin = r.Header.Get("Origin")
+		upstreamReferer = r.Header.Get("Referer")
+		upstreamForwardedProto = r.Header.Get("X-Forwarded-Proto")
+		upstreamForwardedHost = r.Header.Get("X-Forwarded-Host")
 
 		w.Header().Set("Content-Type", "application/javascript")
 		_, _ = w.Write([]byte(`window.fetch("/unicron/api/logs");`))
@@ -121,6 +131,9 @@ func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "/logforge/ui/assets/app.js", nil)
 	request.Header.Set("Authorization", "Bearer browser-token")
 	request.Header.Set("Cookie", "portainer=browser-cookie")
+	request.Header.Set("Accept-Encoding", "gzip, br")
+	request.Header.Set("Origin", "http://localhost:19001")
+	request.Header.Set("Referer", "http://localhost:19001/#!/logforge")
 	request.Header.Set(serviceKeyHeader, "browser-supplied-key")
 	request.Header.Set(managedByHeader, "browser")
 	request.Header.Set(managedIdentityHeader, "browser-identity")
@@ -138,9 +151,14 @@ func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
 	require.Equal(t, "logforge.example.test", upstreamHost)
 	require.Empty(t, upstreamAuthorization)
 	require.Empty(t, upstreamCookie)
+	require.Equal(t, "identity", upstreamAcceptEncoding)
 	require.Equal(t, "portainer", upstreamManagedBy)
 	require.NotEmpty(t, upstreamManagedIdentity)
 	require.NotEmpty(t, upstreamManagedSignature)
+	require.Equal(t, "http://logforge.example.test", upstreamOrigin)
+	require.Equal(t, "http://logforge.example.test/", upstreamReferer)
+	require.Equal(t, "http", upstreamForwardedProto)
+	require.Equal(t, "logforge.example.test", upstreamForwardedHost)
 	require.Contains(t, recorder.Body.String(), `"/logforge/ui/api/logs"`)
 	require.NotContains(t, recorder.Body.String(), `"/unicron/api/logs"`)
 
@@ -165,6 +183,10 @@ func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
 	require.Equal(t, "read_only", claims.Endpoints[0].Role)
 	require.Equal(t, readOnlyRoleID, claims.Endpoints[0].RoleID)
 	require.Greater(t, claims.ExpiresAt, claims.IssuedAt)
+	require.Contains(t, string(payload), `"id":`)
+	require.Contains(t, string(payload), `"role_id":`)
+	require.NotContains(t, string(payload), `"Id":`)
+	require.NotContains(t, string(payload), `"RoleId":`)
 }
 
 func TestUIProxyRejectsUsersWithoutDockerEndpointAccess(t *testing.T) {
@@ -190,6 +212,44 @@ func TestUIProxyRejectsUsersWithoutDockerEndpointAccess(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+func TestUIProxyRewritesManifestDiscoveryPaths(t *testing.T) {
+	var upstreamPaths string
+	var upstreamVersion string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/unicron/__manifest", r.URL.Path)
+		upstreamPaths = r.URL.Query().Get("paths")
+		upstreamVersion = r.URL.Query().Get("version")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"routes/alerting/_layout":{"path":"alerting"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newTestHandler(t)
+	require.NoError(t, handler.DataStore.LogForge().UpdateSettings(&portainer.LogForgeSettings{
+		Enabled:          true,
+		ApplianceURL:     upstream.URL,
+		BrowserProxyPath: browserProxyPath,
+		ServiceKey:       "secret-service-key",
+	}))
+	createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), readOnlyRoleID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/ui/__manifest?paths=%2Flogforge%2Fui%2Falerting%2C%2Flogforge%2Fui%2Fnotifications&version=route-version", nil)
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       2,
+		Username: "alice",
+		Role:     portainer.StandardUserRole,
+	}, &security.RestrictedRequestContext{UserID: 2})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "/unicron/alerting,/unicron/notifications", upstreamPaths)
+	require.Equal(t, "route-version", upstreamVersion)
+	require.Contains(t, recorder.Body.String(), `"path":"alerting"`)
 }
 
 func TestStatusIncludesLogForgeAccessScopes(t *testing.T) {
@@ -293,6 +353,7 @@ func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
 			MTLSPort:         8450,
 			RemoteAgentImage: "example/unicron-agent:test",
 		},
+		"custom-logforge",
 		"instance-1",
 		"abcdef",
 	)
@@ -308,9 +369,18 @@ func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
 	require.Contains(t, compose, "UNICRON_MANAGED_SERVICE_KEY_SHA256: abcdef")
 	require.Contains(t, compose, "PORTAINER_INSTANCE_ID: instance-1")
 	require.Contains(t, compose, "REMOTE_AGENT_IMAGE: example/unicron-agent:test")
+	require.Contains(t, compose, "LOCAL_AGENT_DOCKER_NETWORK: custom-logforge_default")
+	require.Contains(t, compose, "- unicron.central")
 	require.Contains(t, compose, `"9449:443"`)
 	require.Contains(t, compose, `"8450:8443"`)
 	require.NotContains(t, compose, "/var/run/docker.sock")
+}
+
+func TestManagedComposeUsesPortainerIntegrationImagesByDefault(t *testing.T) {
+	compose := renderManagedCompose(&installPayload{}, "logforge", "instance-1", "abcdef")
+
+	require.Contains(t, compose, "image: logforge/unicron:portainer-integration")
+	require.Contains(t, compose, "REMOTE_AGENT_IMAGE: logforge/unicron-agent:portainer-integration")
 }
 
 func TestManagedInstallDerivesHostHeaderFromCentralFQDN(t *testing.T) {

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -359,6 +359,7 @@ func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
 	)
 
 	require.Contains(t, compose, "image: example/unicron:test")
+	require.Contains(t, compose, "pull_policy: always")
 	require.Contains(t, compose, "UNICRON_MANAGED_BY: portainer")
 	require.Contains(t, compose, `UNICRON_SELF_UPDATE_ENABLED: "false"`)
 	require.Contains(t, compose, `UNICRON_MANAGED_EXTERNAL_AUTH_ENABLED: "true"`)

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -264,6 +264,48 @@ func TestUIProxyRejectsUsersWithoutDockerEndpointAccess(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, recorder.Code)
 }
 
+func TestUIProxyPreservesAgentEnrollmentResponse(t *testing.T) {
+	const enrollmentResponse = `{
+		"agent_name":"portainer-local",
+		"central_url":"https://unicron.central/unicron",
+		"docker_run_command":"docker run -e CENTRAL_WS_URL=wss://unicron.central:8443/unicron/api/agent/ws logforge/unicron-agent:portainer-integration"
+	}`
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/unicron/api/agent/enroll", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(enrollmentResponse))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newTestHandler(t)
+	require.NoError(t, handler.DataStore.LogForge().UpdateSettings(&portainer.LogForgeSettings{
+		Enabled:          true,
+		ApplianceURL:     upstream.URL,
+		BrowserProxyPath: browserProxyPath,
+		ServiceKey:       "secret-service-key",
+	}))
+	createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), readOnlyRoleID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/logforge/ui/api/agent/enroll", bytes.NewReader([]byte(`{"agent_name":"portainer-local"}`)))
+	request.Header.Set("Content-Type", "application/json")
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       2,
+		Username: "alice",
+		Role:     portainer.StandardUserRole,
+	}, &security.RestrictedRequestContext{UserID: 2})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, enrollmentResponse, recorder.Body.String())
+	require.Contains(t, recorder.Body.String(), "wss://unicron.central:8443/unicron/api/agent/ws")
+	require.NotContains(t, recorder.Body.String(), "/logforge/ui/api/agent/ws")
+}
+
 func TestUIProxyRewritesManifestDiscoveryPaths(t *testing.T) {
 	var upstreamPaths string
 	var upstreamVersion string
@@ -273,7 +315,7 @@ func TestUIProxyRewritesManifestDiscoveryPaths(t *testing.T) {
 		upstreamVersion = r.URL.Query().Get("version")
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"routes/alerting/_layout":{"path":"alerting"}}`))
+		_, _ = w.Write([]byte(`{"basename":"/unicron/","routes/alerting/_layout":{"path":"alerting"}}`))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -299,6 +341,7 @@ func TestUIProxyRewritesManifestDiscoveryPaths(t *testing.T) {
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, "/unicron/alerting,/unicron/notifications", upstreamPaths)
 	require.Equal(t, "route-version", upstreamVersion)
+	require.Contains(t, recorder.Body.String(), `"basename":"/logforge/ui/"`)
 	require.Contains(t, recorder.Body.String(), `"path":"alerting"`)
 }
 

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -1,0 +1,302 @@
+package logforge
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	portainer "github.com/portainer/portainer/api"
+	"github.com/portainer/portainer/api/datastore"
+	"github.com/portainer/portainer/api/http/security"
+	"github.com/portainer/portainer/api/internal/testhelpers"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusWithoutSettings(t *testing.T) {
+	handler := newTestHandler(t)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/status", nil)
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var status statusResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	require.False(t, status.Enabled)
+	require.Equal(t, browserProxyPath, status.BrowserProxyPath)
+	require.Equal(t, "not_configured", status.Health.Status)
+	require.False(t, status.Access.Allowed)
+	require.NotContains(t, recorder.Body.String(), `"ServiceKey":`)
+}
+
+func TestInstallRegistersExternalAppliance(t *testing.T) {
+	var healthServiceKey string
+	var healthHost string
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/unicron/api/health", r.URL.Path)
+		healthServiceKey = r.Header.Get(serviceKeyHeader)
+		healthHost = r.Host
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","version":"0.1.0"}`))
+	}))
+	t.Cleanup(healthServer.Close)
+
+	handler := newTestHandler(t)
+	handler.httpClient = healthServer.Client()
+
+	payload := []byte(`{"ApplianceUrl":"` + healthServer.URL + `/unicron/","ApplianceHostHeader":"logforge.example.test"}`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/logforge/install", bytes.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusCreated, recorder.Code)
+
+	var status statusResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	require.True(t, status.Enabled)
+	require.False(t, status.Managed)
+	require.Equal(t, healthServer.URL+"/unicron", status.ApplianceURL)
+	require.Equal(t, "instance-1", status.PortainerInstanceID)
+	require.Equal(t, "healthy", status.Health.Status)
+	require.Equal(t, "0.1.0", status.Health.Version)
+	require.Equal(t, "logforge.example.test", status.ApplianceHostHeader)
+	require.True(t, status.ManagedAuthReady)
+	require.NotEmpty(t, status.ServiceKeyPrefix)
+	require.NotContains(t, recorder.Body.String(), `"ServiceKey":`)
+
+	settings, err := handler.DataStore.LogForge().Settings()
+	require.NoError(t, err)
+	require.NotEmpty(t, settings.ServiceKey)
+	require.Equal(t, settings.ServiceKey, healthServiceKey)
+	require.Equal(t, "logforge.example.test", healthHost)
+	require.Equal(t, status.ServiceKeyPrefix, settings.ServiceKeyPrefix)
+}
+
+func TestUIProxyInjectsServiceKeyAndRewritesUnicronPaths(t *testing.T) {
+	var upstreamServiceKey string
+	var upstreamAuthorization string
+	var upstreamCookie string
+	var upstreamHost string
+	var upstreamManagedBy string
+	var upstreamManagedIdentity string
+	var upstreamManagedSignature string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/unicron/assets/app.js", r.URL.Path)
+		upstreamServiceKey = r.Header.Get(serviceKeyHeader)
+		upstreamAuthorization = r.Header.Get("Authorization")
+		upstreamCookie = r.Header.Get("Cookie")
+		upstreamHost = r.Host
+		upstreamManagedBy = r.Header.Get(managedByHeader)
+		upstreamManagedIdentity = r.Header.Get(managedIdentityHeader)
+		upstreamManagedSignature = r.Header.Get(managedSignatureHeader)
+
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = w.Write([]byte(`window.fetch("/unicron/api/logs");`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler := newTestHandler(t)
+	require.NoError(t, handler.DataStore.LogForge().UpdateSettings(&portainer.LogForgeSettings{
+		Enabled:             true,
+		ApplianceURL:        upstream.URL,
+		ApplianceHostHeader: "logforge.example.test",
+		BrowserProxyPath:    browserProxyPath,
+		ServiceKey:          "secret-service-key",
+	}))
+	endpoint := createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), readOnlyRoleID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/ui/assets/app.js", nil)
+	request.Header.Set("Authorization", "Bearer browser-token")
+	request.Header.Set("Cookie", "portainer=browser-cookie")
+	request.Header.Set(serviceKeyHeader, "browser-supplied-key")
+	request.Header.Set(managedByHeader, "browser")
+	request.Header.Set(managedIdentityHeader, "browser-identity")
+	request.Header.Set(managedSignatureHeader, "browser-signature")
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       2,
+		Username: "alice",
+		Role:     portainer.StandardUserRole,
+	}, &security.RestrictedRequestContext{UserID: 2})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "secret-service-key", upstreamServiceKey)
+	require.Equal(t, "logforge.example.test", upstreamHost)
+	require.Empty(t, upstreamAuthorization)
+	require.Empty(t, upstreamCookie)
+	require.Equal(t, "portainer", upstreamManagedBy)
+	require.NotEmpty(t, upstreamManagedIdentity)
+	require.NotEmpty(t, upstreamManagedSignature)
+	require.Contains(t, recorder.Body.String(), `"/logforge/ui/api/logs"`)
+	require.NotContains(t, recorder.Body.String(), `"/unicron/api/logs"`)
+
+	payload, err := base64.RawURLEncoding.DecodeString(upstreamManagedIdentity)
+	require.NoError(t, err)
+	signature, err := base64.RawURLEncoding.DecodeString(upstreamManagedSignature)
+	require.NoError(t, err)
+	mac := hmac.New(sha256.New, []byte("secret-service-key"))
+	_, _ = mac.Write([]byte(upstreamManagedIdentity))
+	require.True(t, hmac.Equal(mac.Sum(nil), signature))
+
+	var claims managedIdentityClaims
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	require.Equal(t, "portainer", claims.Issuer)
+	require.Equal(t, "portainer:user:2", claims.Subject)
+	require.Equal(t, portainer.UserID(2), claims.UserID)
+	require.Equal(t, "alice", claims.Username)
+	require.False(t, claims.IsAdmin)
+	require.Len(t, claims.Endpoints, 1)
+	require.Equal(t, endpoint.ID, claims.Endpoints[0].ID)
+	require.Equal(t, endpoint.Name, claims.Endpoints[0].Name)
+	require.Equal(t, "read_only", claims.Endpoints[0].Role)
+	require.Equal(t, readOnlyRoleID, claims.Endpoints[0].RoleID)
+	require.Greater(t, claims.ExpiresAt, claims.IssuedAt)
+}
+
+func TestUIProxyRejectsUsersWithoutDockerEndpointAccess(t *testing.T) {
+	upstream := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(upstream.Close)
+
+	handler := newTestHandler(t)
+	require.NoError(t, handler.DataStore.LogForge().UpdateSettings(&portainer.LogForgeSettings{
+		Enabled:          true,
+		ApplianceURL:     upstream.URL,
+		BrowserProxyPath: browserProxyPath,
+		ServiceKey:       "secret-service-key",
+	}))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/ui/", nil)
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       2,
+		Username: "alice",
+		Role:     portainer.StandardUserRole,
+	}, &security.RestrictedRequestContext{UserID: 2})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+func TestStatusIncludesLogForgeAccessScopes(t *testing.T) {
+	handler := newTestHandler(t)
+	endpoint := createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), operatorRoleID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/status", nil)
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       2,
+		Username: "alice",
+		Role:     portainer.StandardUserRole,
+	}, &security.RestrictedRequestContext{UserID: 2})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var status statusResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	require.True(t, status.Access.Allowed)
+	require.False(t, status.Access.IsAdmin)
+	require.Equal(t, portainer.UserID(2), status.Access.UserID)
+	require.Equal(t, "alice", status.Access.Username)
+	require.Len(t, status.Access.Endpoints, 1)
+	require.Equal(t, endpoint.ID, status.Access.Endpoints[0].ID)
+	require.Equal(t, "write", status.Access.Endpoints[0].Role)
+	require.Equal(t, operatorRoleID, status.Access.Endpoints[0].RoleID)
+}
+
+func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {
+	compose := renderManagedCompose(
+		&installPayload{
+			Image:            "example/unicron:test",
+			CentralFQDN:      "logs.example.test",
+			HTTPSPort:        9449,
+			MTLSPort:         8450,
+			RemoteAgentImage: "example/unicron-agent:test",
+		},
+		"instance-1",
+		"abcdef",
+	)
+
+	require.Contains(t, compose, "image: example/unicron:test")
+	require.Contains(t, compose, "UNICRON_MANAGED_BY: portainer")
+	require.Contains(t, compose, `UNICRON_SELF_UPDATE_ENABLED: "false"`)
+	require.Contains(t, compose, `UNICRON_MANAGED_EXTERNAL_AUTH_ENABLED: "true"`)
+	require.Contains(t, compose, "UNICRON_MANAGED_EXTERNAL_AUTH_PROVIDER: portainer")
+	require.Contains(t, compose, "UNICRON_MANAGED_IDENTITY_HEADER: X-LogForge-Managed-Identity")
+	require.Contains(t, compose, "UNICRON_MANAGED_IDENTITY_SIGNATURE_HEADER: X-LogForge-Managed-Identity-Signature")
+	require.Contains(t, compose, "UNICRON_MANAGED_SERVICE_KEY_HEADER: X-LogForge-Service-Key")
+	require.Contains(t, compose, "UNICRON_MANAGED_SERVICE_KEY_SHA256: abcdef")
+	require.Contains(t, compose, "PORTAINER_INSTANCE_ID: instance-1")
+	require.Contains(t, compose, "REMOTE_AGENT_IMAGE: example/unicron-agent:test")
+	require.Contains(t, compose, `"9449:443"`)
+	require.Contains(t, compose, `"8450:8443"`)
+	require.NotContains(t, compose, "/var/run/docker.sock")
+}
+
+func TestManagedInstallDerivesHostHeaderFromCentralFQDN(t *testing.T) {
+	hostHeader := applianceHostHeader(&installPayload{
+		EndpointID:   1,
+		ApplianceURL: "https://172.17.0.1:19444",
+		CentralFQDN:  "localhost",
+	})
+
+	require.Equal(t, "localhost", hostHeader)
+}
+
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
+
+	_, store := datastore.MustNewTestStore(t, true, true)
+	require.NoError(t, store.Version().UpdateInstanceID("instance-1"))
+
+	handler := NewHandler(testhelpers.NewTestRequestBouncer())
+	handler.DataStore = store
+	return handler
+}
+
+func createDockerEndpointWithUserAccess(t *testing.T, handler *Handler, userID portainer.UserID, roleID portainer.RoleID) portainer.Endpoint {
+	t.Helper()
+
+	group := &portainer.EndpointGroup{
+		Name: "docker-group",
+	}
+	require.NoError(t, handler.DataStore.EndpointGroup().Create(group))
+
+	endpoint := &portainer.Endpoint{
+		ID:      portainer.EndpointID(handler.DataStore.Endpoint().GetNextIdentifier()),
+		Name:    "local-docker",
+		Type:    portainer.DockerEnvironment,
+		GroupID: group.ID,
+		UserAccessPolicies: portainer.UserAccessPolicies{
+			userID: {RoleID: roleID},
+		},
+	}
+	require.NoError(t, handler.DataStore.Endpoint().Create(endpoint))
+
+	return *endpoint
+}
+
+func withLogForgeUser(request *http.Request, tokenData *portainer.TokenData, requestContext *security.RestrictedRequestContext) *http.Request {
+	request = request.WithContext(security.StoreTokenData(request, tokenData))
+	if requestContext != nil {
+		request = request.WithContext(security.StoreRestrictedRequestContext(request, requestContext))
+	}
+
+	return request
+}

--- a/api/http/handler/logforge/handler_test.go
+++ b/api/http/handler/logforge/handler_test.go
@@ -216,8 +216,72 @@ func TestStatusIncludesLogForgeAccessScopes(t *testing.T) {
 	require.Equal(t, "alice", status.Access.Username)
 	require.Len(t, status.Access.Endpoints, 1)
 	require.Equal(t, endpoint.ID, status.Access.Endpoints[0].ID)
-	require.Equal(t, "write", status.Access.Endpoints[0].Role)
-	require.Equal(t, operatorRoleID, status.Access.Endpoints[0].RoleID)
+	require.Equal(t, "read_only", status.Access.Endpoints[0].Role)
+	require.Equal(t, readOnlyRoleID, status.Access.Endpoints[0].RoleID)
+}
+
+func TestStatusSanitizesNonAdminEndpointRolesToReadOnly(t *testing.T) {
+	testCases := []struct {
+		name   string
+		roleID portainer.RoleID
+	}{
+		{name: "standard", roleID: standardRoleID},
+		{name: "endpoint-admin", roleID: endpointAdminRoleID},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newTestHandler(t)
+			endpoint := createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), tc.roleID)
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/logforge/status", nil)
+			request = withLogForgeUser(request, &portainer.TokenData{
+				ID:       2,
+				Username: "alice",
+				Role:     portainer.StandardUserRole,
+			}, &security.RestrictedRequestContext{UserID: 2})
+
+			handler.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			var status statusResponse
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+			require.True(t, status.Access.Allowed)
+			require.False(t, status.Access.IsAdmin)
+			require.Len(t, status.Access.Endpoints, 1)
+			require.Equal(t, endpoint.ID, status.Access.Endpoints[0].ID)
+			require.Equal(t, "read_only", status.Access.Endpoints[0].Role)
+			require.Equal(t, readOnlyRoleID, status.Access.Endpoints[0].RoleID)
+		})
+	}
+}
+
+func TestStatusIncludesAdminScopeForPortainerAdministrators(t *testing.T) {
+	handler := newTestHandler(t)
+	endpoint := createDockerEndpointWithUserAccess(t, handler, portainer.UserID(2), readOnlyRoleID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/logforge/status", nil)
+	request = withLogForgeUser(request, &portainer.TokenData{
+		ID:       1,
+		Username: "admin",
+		Role:     portainer.AdministratorRole,
+	}, &security.RestrictedRequestContext{UserID: 1, IsAdmin: true})
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var status statusResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	require.True(t, status.Access.Allowed)
+	require.True(t, status.Access.IsAdmin)
+	require.Len(t, status.Access.Endpoints, 1)
+	require.Equal(t, endpoint.ID, status.Access.Endpoints[0].ID)
+	require.Equal(t, "admin", status.Access.Endpoints[0].Role)
+	require.Equal(t, endpointAdminRoleID, status.Access.Endpoints[0].RoleID)
 }
 
 func TestManagedComposeUsesPortainerManagedMode(t *testing.T) {

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/portainer/portainer/api/http/handler/helm"
 	kubehandler "github.com/portainer/portainer/api/http/handler/kubernetes"
 	"github.com/portainer/portainer/api/http/handler/ldap"
+	"github.com/portainer/portainer/api/http/handler/logforge"
 	"github.com/portainer/portainer/api/http/handler/motd"
 	"github.com/portainer/portainer/api/http/handler/registries"
 	"github.com/portainer/portainer/api/http/handler/resourcecontrols"
@@ -218,6 +219,12 @@ func (server *Server) Start(ctx context.Context) error {
 	ldapHandler.FileService = server.FileService
 	ldapHandler.LDAPService = server.LDAPService
 
+	var logForgeHandler = logforge.NewHandler(requestBouncer)
+	logForgeHandler.DataStore = server.DataStore
+	logForgeHandler.FileService = server.FileService
+	logForgeHandler.ComposeStackManager = server.ComposeStackManager
+	logForgeHandler.StackDeployer = server.StackDeployer
+
 	motdSvc := motdservice.NewService(portainer.MessageOfTheDayURL)
 	motdSvc.Start(ctx)
 
@@ -319,6 +326,7 @@ func (server *Server) Start(ctx context.Context) error {
 		GitOperationHandler:    gitOperationHandler,
 		FileHandler:            fileHandler,
 		LDAPHandler:            ldapHandler,
+		LogForgeHandler:        logForgeHandler,
 		HelmTemplatesHandler:   helmTemplatesHandler,
 		KubernetesHandler:      kubernetesHandler,
 		MOTDHandler:            motdHandler,

--- a/api/internal/testhelpers/datastore.go
+++ b/api/internal/testhelpers/datastore.go
@@ -23,6 +23,7 @@ type testDatastore struct {
 	endpointGroup           dataservices.EndpointGroupService
 	endpointRelation        dataservices.EndpointRelationService
 	helmUserRepository      dataservices.HelmUserRepositoryService
+	logForge                dataservices.LogForgeService
 	registry                dataservices.RegistryService
 	resourceControl         dataservices.ResourceControlService
 	source                  dataservices.SourceService
@@ -72,6 +73,7 @@ func (d *testDatastore) EndpointRelation() dataservices.EndpointRelationService 
 func (d *testDatastore) HelmUserRepository() dataservices.HelmUserRepositoryService {
 	return d.helmUserRepository
 }
+func (d *testDatastore) LogForge() dataservices.LogForgeService { return d.logForge }
 func (d *testDatastore) Registry() dataservices.RegistryService { return d.registry }
 func (d *testDatastore) ResourceControl() dataservices.ResourceControlService {
 	return d.resourceControl

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1245,6 +1245,7 @@ type (
 		ApplianceEndpointID EndpointID `json:"ApplianceEndpointId,omitempty"`
 		ApplianceURL        string     `json:"ApplianceUrl,omitempty"`
 		ApplianceHostHeader string     `json:"ApplianceHostHeader,omitempty"`
+		TLSSkipVerify       bool       `json:"TLSSkipVerify"`
 		BrowserProxyPath    string     `json:"BrowserProxyPath,omitempty"`
 		ApplianceImage      string     `json:"ApplianceImage,omitempty"`
 		StackName           string     `json:"StackName,omitempty"`

--- a/api/portainer.go
+++ b/api/portainer.go
@@ -1236,6 +1236,27 @@ type (
 		ForceSecureCookies bool `json:"ForceSecureCookies" example:"false"`
 	}
 
+	// LogForgeSettings represents the persisted Portainer-side LogForge integration settings.
+	LogForgeSettings struct {
+		Enabled bool `json:"Enabled"`
+
+		Managed             bool       `json:"Managed"`
+		ApplianceStackID    StackID    `json:"ApplianceStackId,omitempty"`
+		ApplianceEndpointID EndpointID `json:"ApplianceEndpointId,omitempty"`
+		ApplianceURL        string     `json:"ApplianceUrl,omitempty"`
+		ApplianceHostHeader string     `json:"ApplianceHostHeader,omitempty"`
+		BrowserProxyPath    string     `json:"BrowserProxyPath,omitempty"`
+		ApplianceImage      string     `json:"ApplianceImage,omitempty"`
+		StackName           string     `json:"StackName,omitempty"`
+
+		PortainerInstanceID  string `json:"PortainerInstanceId,omitempty"`
+		ServiceKey           string `json:"ServiceKey,omitempty"`
+		ServiceKeyPrefix     string `json:"ServiceKeyPrefix,omitempty"`
+		ServiceKeyCreatedAt  int64  `json:"ServiceKeyCreatedAt,omitempty"`
+		ServiceKeyLastUsedAt int64  `json:"ServiceKeyLastUsedAt,omitempty"`
+		ServiceKeyRotatedAt  int64  `json:"ServiceKeyRotatedAt,omitempty"`
+	}
+
 	// SnapshotJob represents a scheduled job that can create environment(endpoint) snapshots
 	SnapshotJob struct{}
 

--- a/app/portainer/__module.js
+++ b/app/portainer/__module.js
@@ -294,6 +294,19 @@ angular
         abstract: true,
       };
 
+      var logforge = {
+        name: 'portainer.logforge',
+        url: '/logforge',
+        views: {
+          'content@': {
+            component: 'logforgeView',
+          },
+        },
+        data: {
+          access: AccessHeaders.Restricted,
+        },
+      };
+
       var workflows = {
         name: 'portainer.gitops.workflows',
         url: '/workflows?search&sort&order&page&pageSize&status&type&platform&groupBy&groupFilter',
@@ -488,6 +501,7 @@ angular
       $stateRegistryProvider.register(group);
       $stateRegistryProvider.register(groupCreation);
       $stateRegistryProvider.register(home);
+      $stateRegistryProvider.register(logforge);
       $stateRegistryProvider.register(gitopsBase);
       $stateRegistryProvider.register(workflows);
       $stateRegistryProvider.register(gitopsWorkflowDetail);

--- a/app/portainer/react/views/index.ts
+++ b/app/portainer/react/views/index.ts
@@ -9,6 +9,7 @@ import { CreateUserAccessToken } from '@/react/portainer/account/CreateAccessTok
 import { EdgeComputeSettingsView } from '@/react/portainer/settings/EdgeComputeView/EdgeComputeSettingsView';
 import { SettingsView } from '@/react/portainer/settings/SettingsView/SettingsView';
 import { CreateHelmRepositoriesView } from '@/react/portainer/account/helm-repositories/CreateHelmRepositoryView';
+import { LogForgeView } from '@/react/portainer/logforge';
 
 import { wizardModule } from './wizard';
 import { teamsModule } from './teams';
@@ -55,6 +56,10 @@ export const viewsModule = angular
   .component(
     'settingsView',
     r2a(withUIRouter(withReactQuery(withCurrentUser(SettingsView))), [])
+  )
+  .component(
+    'logforgeView',
+    r2a(withUIRouter(withReactQuery(withCurrentUser(LogForgeView))), [])
   )
   .component(
     'createHelmRepositoryView',

--- a/app/react/portainer/logforge/LogForgeView.test.tsx
+++ b/app/react/portainer/logforge/LogForgeView.test.tsx
@@ -1,0 +1,315 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { UserViewModel } from '@/portainer/models/user';
+import { withTestQueryProvider } from '@/react/test-utils/withTestQuery';
+import { withTestRouter } from '@/react/test-utils/withRouter';
+import { withUserProvider } from '@/react/test-utils/withUserProvider';
+
+import { LogForgeView } from './LogForgeView';
+import { LogForgeStatus } from './types';
+
+const mocks = vi.hoisted(() => ({
+  useLogForgeStatus: vi.fn(),
+  useInstallOrRegisterLogForgeMutation: vi.fn(),
+  useUninstallOrClearLogForgeMutation: vi.fn(),
+  useEnvironmentList: vi.fn(),
+  notifySuccess: vi.fn(),
+  confirmDelete: vi.fn(),
+}));
+
+vi.mock('./queries', () => ({
+  useLogForgeStatus: () => mocks.useLogForgeStatus(),
+  useInstallOrRegisterLogForgeMutation: () =>
+    mocks.useInstallOrRegisterLogForgeMutation(),
+  useUninstallOrClearLogForgeMutation: () =>
+    mocks.useUninstallOrClearLogForgeMutation(),
+}));
+
+vi.mock('@/react/portainer/environments/queries/useEnvironmentList', () => ({
+  useEnvironmentList: () => mocks.useEnvironmentList(),
+}));
+
+vi.mock('@/portainer/services/notifications', () => ({
+  notifySuccess: mocks.notifySuccess,
+}));
+
+vi.mock('@@/modals/confirm', () => ({
+  confirmDelete: mocks.confirmDelete,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setStatus(createStatus());
+  setEnvironmentList();
+  setMutations();
+  mocks.confirmDelete.mockResolvedValue(true);
+});
+
+test('submits an external appliance registration payload', async () => {
+  const user = userEvent.setup();
+  const installMutate = vi.fn();
+  setMutations({ installMutate });
+
+  const { container } = renderComponent();
+
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-appliance-url'),
+    {
+      target: { value: ' https://logforge.example.com ' },
+    }
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Register LogForge' }));
+
+  expect(installMutate).toHaveBeenCalledWith(
+    { ApplianceUrl: 'https://logforge.example.com' },
+    expect.objectContaining({ onSuccess: expect.any(Function) })
+  );
+});
+
+test('submits a managed install payload for a Docker environment', async () => {
+  const user = userEvent.setup();
+  const installMutate = vi.fn();
+  setEnvironmentList([{ Id: 1, Name: 'local-docker' }]);
+  setMutations({ installMutate });
+
+  const { container } = renderComponent();
+
+  await user.click(screen.getByRole('button', { name: 'Install' }));
+  fireEvent.change(
+    getByDataCy<HTMLSelectElement>(container, 'logforge-environment-select'),
+    { target: { value: '1' } }
+  );
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-stack-name'),
+    {
+      target: { value: 'logforge-hardening' },
+    }
+  );
+  fireEvent.change(getByDataCy<HTMLInputElement>(container, 'logforge-image'), {
+    target: { value: 'logforge/unicron:latest' },
+  });
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-central-fqdn'),
+    {
+      target: { value: 'localhost' },
+    }
+  );
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-https-port'),
+    {
+      target: { value: '19444' },
+    }
+  );
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-mtls-port'),
+    {
+      target: { value: '18443' },
+    }
+  );
+  fireEvent.change(
+    getByDataCy<HTMLInputElement>(container, 'logforge-appliance-url'),
+    {
+      target: { value: 'https://172.17.0.1:19444' },
+    }
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Install LogForge' }));
+
+  expect(installMutate).toHaveBeenCalledWith(
+    {
+      EndpointId: 1,
+      ApplianceUrl: 'https://172.17.0.1:19444',
+      Image: 'logforge/unicron:latest',
+      StackName: 'logforge-hardening',
+      CentralFQDN: 'localhost',
+      HTTPSPort: 19444,
+      MTLSPort: 18443,
+    },
+    expect.objectContaining({ onSuccess: expect.any(Function) })
+  );
+});
+
+test('opens the embedded UI and clears or removes a managed appliance', async () => {
+  const user = userEvent.setup();
+  const uninstallMutate = vi.fn();
+  setStatus(
+    createStatus({
+      Enabled: true,
+      Managed: true,
+      ApplianceUrl: 'https://172.17.0.1:19444',
+      StackName: 'logforge-hardening',
+      Stack: {
+        Id: 2,
+        Name: 'logforge-hardening',
+        EndpointId: 1,
+        Status: 1,
+      },
+      Health: { Status: 'healthy', Message: '{"status":"ok"}' },
+    })
+  );
+  setMutations({ uninstallMutate });
+
+  renderComponent();
+
+  await user.click(screen.getByRole('button', { name: 'Open embedded UI' }));
+
+  expect(screen.getByTitle('LogForge')).toHaveAttribute('src', '/logforge/ui/');
+  expect(
+    screen.getByRole('button', { name: 'Back to status' })
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Back to status' }));
+
+  await user.click(screen.getByRole('button', { name: 'Clear registration' }));
+
+  await waitFor(() => {
+    expect(uninstallMutate).toHaveBeenCalledWith(
+      { RemoveManagedStack: false },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  await user.click(
+    screen.getByRole('button', { name: 'Remove managed appliance' })
+  );
+
+  await waitFor(() => {
+    expect(uninstallMutate).toHaveBeenLastCalledWith(
+      { RemoveManagedStack: true },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+});
+
+test('shows status but blocks the embedded UI for users without Docker endpoint access', () => {
+  setStatus(
+    createStatus({
+      Enabled: true,
+      Managed: false,
+      ApplianceUrl: 'https://logforge.example.test',
+      Access: {
+        Allowed: false,
+        IsAdmin: false,
+        UserId: 2,
+        Username: 'standard',
+        Endpoints: [],
+      },
+    })
+  );
+
+  renderComponent(2);
+
+  expect(screen.getByText('Appliance status')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Open embedded UI' })).toBeNull();
+  expect(
+    screen.queryByRole('button', { name: 'Clear registration' })
+  ).toBeNull();
+  expect(screen.getByText('Access limited')).toBeInTheDocument();
+});
+
+test('does not show setup controls to non-admin users before LogForge is configured', () => {
+  setStatus(
+    createStatus({
+      Access: {
+        Allowed: false,
+        IsAdmin: false,
+        UserId: 2,
+        Username: 'standard',
+        Endpoints: [],
+      },
+    })
+  );
+
+  renderComponent(2);
+
+  expect(screen.getByText('Not configured')).toBeInTheDocument();
+  expect(screen.queryByText('Setup')).toBeNull();
+  expect(
+    screen.queryByRole('button', { name: 'Register LogForge' })
+  ).toBeNull();
+  expect(
+    screen.getByText(
+      'LogForge is not configured. Ask a Portainer administrator to configure a central appliance.'
+    )
+  ).toBeInTheDocument();
+});
+
+function renderComponent(role = 1) {
+  const user = new UserViewModel({ Username: 'admin', Role: role });
+  const Routed = withTestRouter(LogForgeView);
+  const Wrapped = withTestQueryProvider(withUserProvider(Routed, user));
+
+  return render(<Wrapped />);
+}
+
+function createStatus(overrides: Partial<LogForgeStatus> = {}): LogForgeStatus {
+  const { Health, Access, ...rest } = overrides;
+
+  return {
+    Enabled: false,
+    Managed: false,
+    BrowserProxyPath: '/logforge/ui/',
+    ManagedAuthReady: true,
+    Access: {
+      Allowed: true,
+      IsAdmin: true,
+      UserId: 1,
+      Username: 'admin',
+      Endpoints: [{ Id: 1, Name: 'local-docker', Role: 'admin', RoleId: 1 }],
+      ...Access,
+    },
+    ...rest,
+    Health: {
+      Status: 'not_configured',
+      ...Health,
+    },
+  };
+}
+
+function setStatus(status: LogForgeStatus) {
+  mocks.useLogForgeStatus.mockReturnValue({
+    data: status,
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue(status),
+  });
+}
+
+function setEnvironmentList(
+  environments: Array<{ Id: number; Name: string }> = []
+) {
+  mocks.useEnvironmentList.mockReturnValue({
+    environments,
+    isLoading: false,
+  });
+}
+
+function setMutations({
+  installMutate = vi.fn(),
+  uninstallMutate = vi.fn(),
+}: {
+  installMutate?: ReturnType<typeof vi.fn>;
+  uninstallMutate?: ReturnType<typeof vi.fn>;
+} = {}) {
+  mocks.useInstallOrRegisterLogForgeMutation.mockReturnValue({
+    mutate: installMutate,
+    isLoading: false,
+  });
+  mocks.useUninstallOrClearLogForgeMutation.mockReturnValue({
+    mutate: uninstallMutate,
+    isLoading: false,
+  });
+}
+
+function getByDataCy<T extends HTMLElement>(
+  container: HTMLElement,
+  dataCy: string
+) {
+  const element = container.querySelector(`[data-cy="${dataCy}"]`);
+  expect(element).toBeInTheDocument();
+
+  return element as T;
+}

--- a/app/react/portainer/logforge/LogForgeView.test.tsx
+++ b/app/react/portainer/logforge/LogForgeView.test.tsx
@@ -89,7 +89,7 @@ test('submits a managed install payload for a Docker environment', async () => {
     }
   );
   fireEvent.change(getByDataCy<HTMLInputElement>(container, 'logforge-image'), {
-    target: { value: 'logforge/unicron:latest' },
+    target: { value: 'logforge/unicron:portainer-integration' },
   });
   fireEvent.change(
     getByDataCy<HTMLInputElement>(container, 'logforge-central-fqdn'),
@@ -122,7 +122,7 @@ test('submits a managed install payload for a Docker environment', async () => {
     {
       EndpointId: 1,
       ApplianceUrl: 'https://172.17.0.1:19444',
-      Image: 'logforge/unicron:latest',
+      Image: 'logforge/unicron:portainer-integration',
       StackName: 'logforge-hardening',
       CentralFQDN: 'localhost',
       HTTPSPort: 19444,

--- a/app/react/portainer/logforge/LogForgeView.test.tsx
+++ b/app/react/portainer/logforge/LogForgeView.test.tsx
@@ -61,10 +61,17 @@ test('submits an external appliance registration payload', async () => {
     }
   );
 
+  await user.click(
+    screen.getByRole('checkbox', { name: 'Skip TLS verification' })
+  );
+
   await user.click(screen.getByRole('button', { name: 'Register LogForge' }));
 
   expect(installMutate).toHaveBeenCalledWith(
-    { ApplianceUrl: 'https://logforge.example.com' },
+    {
+      ApplianceUrl: 'https://logforge.example.com',
+      TLSSkipVerify: true,
+    },
     expect.objectContaining({ onSuccess: expect.any(Function) })
   );
 });
@@ -237,6 +244,18 @@ test('does not show setup controls to non-admin users before LogForge is configu
   ).toBeInTheDocument();
 });
 
+test('formats multi-part health statuses for display', () => {
+  setStatus(
+    createStatus({
+      Health: { Status: 'waiting_for_agent' },
+    })
+  );
+
+  renderComponent();
+
+  expect(screen.getByText('waiting for agent')).toBeInTheDocument();
+});
+
 function renderComponent(role = 1) {
   const user = new UserViewModel({ Username: 'admin', Role: role });
   const Routed = withTestRouter(LogForgeView);
@@ -251,6 +270,7 @@ function createStatus(overrides: Partial<LogForgeStatus> = {}): LogForgeStatus {
   return {
     Enabled: false,
     Managed: false,
+    TLSSkipVerify: false,
     BrowserProxyPath: '/logforge/ui/',
     ManagedAuthReady: true,
     Access: {

--- a/app/react/portainer/logforge/LogForgeView.tsx
+++ b/app/react/portainer/logforge/LogForgeView.tsx
@@ -50,7 +50,7 @@ const embeddedUIFrameStyle = {
 export function LogForgeView() {
   const [mode, setMode] = useState<SetupMode>('register');
   const [applianceUrl, setApplianceUrl] = useState('');
-  const [image, setImage] = useState('logforge/unicron:latest');
+  const [image, setImage] = useState('logforge/unicron:portainer-integration');
   const [stackName, setStackName] = useState('logforge-unicron');
   const [centralFQDN, setCentralFQDN] = useState('logforge.local');
   const [httpsPort, setHTTPSPort] = useState(9444);

--- a/app/react/portainer/logforge/LogForgeView.tsx
+++ b/app/react/portainer/logforge/LogForgeView.tsx
@@ -1,0 +1,625 @@
+import { FormEvent, ReactNode, useMemo, useState } from 'react';
+import {
+  Activity,
+  ArrowLeft,
+  ExternalLink,
+  PlugZap,
+  RefreshCw,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react';
+
+import { notifySuccess } from '@/portainer/services/notifications';
+import {
+  EnvironmentType,
+  PlatformType,
+} from '@/react/portainer/environments/types';
+import { useEnvironmentList } from '@/react/portainer/environments/queries/useEnvironmentList';
+import { useIsPureAdmin } from '@/react/hooks/useUser';
+
+import { Alert } from '@@/Alert';
+import { Badge, BadgeType } from '@@/Badge';
+import { Button, LoadingButton } from '@@/buttons';
+import { confirmDelete } from '@@/modals/confirm';
+import { PageHeader } from '@@/PageHeader';
+import { Widget, WidgetBody, WidgetTitle } from '@@/Widget';
+
+import {
+  useInstallOrRegisterLogForgeMutation,
+  useLogForgeStatus,
+  useUninstallOrClearLogForgeMutation,
+} from './queries';
+import { LogForgeStatus } from './types';
+
+type SetupMode = 'register' | 'install';
+
+const dockerEnvironmentTypes = [
+  EnvironmentType.Docker,
+  EnvironmentType.AgentOnDocker,
+  EnvironmentType.EdgeAgentOnDocker,
+] as const;
+
+const embeddedUIFrameScale = 0.78;
+const embeddedUIFrameStyle = {
+  width: `${100 / embeddedUIFrameScale}%`,
+  height: `${100 / embeddedUIFrameScale}%`,
+  transform: `scale(${embeddedUIFrameScale})`,
+  transformOrigin: 'top left',
+};
+
+export function LogForgeView() {
+  const [mode, setMode] = useState<SetupMode>('register');
+  const [applianceUrl, setApplianceUrl] = useState('');
+  const [image, setImage] = useState('logforge/unicron:latest');
+  const [stackName, setStackName] = useState('logforge-unicron');
+  const [centralFQDN, setCentralFQDN] = useState('logforge.local');
+  const [httpsPort, setHTTPSPort] = useState(9444);
+  const [mtlsPort, setMTLSPort] = useState(8443);
+  const [selectedEndpointId, setSelectedEndpointId] = useState('');
+  const [showEmbeddedUI, setShowEmbeddedUI] = useState(false);
+
+  const isAdmin = useIsPureAdmin();
+  const statusQuery = useLogForgeStatus();
+  const installMutation = useInstallOrRegisterLogForgeMutation();
+  const uninstallMutation = useUninstallOrClearLogForgeMutation();
+  const environmentList = useEnvironmentList(
+    {
+      pageLimit: 0,
+      types: dockerEnvironmentTypes,
+      platformTypes: [PlatformType.Docker],
+      excludeSnapshots: true,
+      sort: 'Name',
+    },
+    { enabled: isAdmin }
+  );
+
+  const status = statusQuery.data;
+  const dockerEnvironments = environmentList.environments;
+  const canOpenEmbeddedUI = Boolean(status?.Enabled && status.Access?.Allowed);
+
+  const canSubmit =
+    mode === 'register'
+      ? applianceUrl.trim().length > 0
+      : selectedEndpointId.length > 0;
+
+  const iframeSrc = useMemo(() => {
+    if (!status?.BrowserProxyPath) {
+      return '/logforge/ui/';
+    }
+    return status.BrowserProxyPath;
+  }, [status?.BrowserProxyPath]);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      {!showEmbeddedUI && (
+        <PageHeader
+          title="LogForge"
+          breadcrumbs={[{ label: 'Observability' }, 'LogForge']}
+          reload
+          loading={statusQuery.isFetching}
+          onReload={() => statusQuery.refetch().then(() => undefined)}
+        />
+      )}
+
+      <div
+        className={
+          showEmbeddedUI
+            ? 'mx-5 mt-5 flex flex-col gap-4'
+            : 'mx-5 flex flex-col gap-4'
+        }
+      >
+        {status?.Enabled && showEmbeddedUI && canOpenEmbeddedUI ? (
+          <EmbeddedLogForgeUI
+            status={status}
+            iframeSrc={iframeSrc}
+            onBack={() => setShowEmbeddedUI(false)}
+          />
+        ) : (
+          <>
+            <StatusWidget
+              status={status}
+              isLoading={statusQuery.isLoading}
+              onOpen={() => setShowEmbeddedUI(true)}
+              onClear={() => handleClear(false)}
+              onRemove={() => handleClear(true)}
+              isClearing={uninstallMutation.isLoading}
+              isAdmin={isAdmin}
+            />
+
+            {!status?.Enabled && isAdmin && (
+              <SetupWidget
+                mode={mode}
+                setMode={setMode}
+                applianceUrl={applianceUrl}
+                setApplianceUrl={setApplianceUrl}
+                image={image}
+                setImage={setImage}
+                stackName={stackName}
+                setStackName={setStackName}
+                centralFQDN={centralFQDN}
+                setCentralFQDN={setCentralFQDN}
+                httpsPort={httpsPort}
+                setHTTPSPort={setHTTPSPort}
+                mtlsPort={mtlsPort}
+                setMTLSPort={setMTLSPort}
+                selectedEndpointId={selectedEndpointId}
+                setSelectedEndpointId={setSelectedEndpointId}
+                dockerEnvironments={dockerEnvironments}
+                isEnvironmentLoading={environmentList.isLoading}
+                isSubmitting={installMutation.isLoading}
+                canSubmit={canSubmit}
+                onSubmit={handleSubmit}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    installMutation.mutate(
+      mode === 'register'
+        ? {
+            ApplianceUrl: applianceUrl.trim(),
+          }
+        : {
+            EndpointId: Number(selectedEndpointId),
+            ApplianceUrl: applianceUrl.trim() || undefined,
+            Image: image.trim(),
+            StackName: stackName.trim(),
+            CentralFQDN: centralFQDN.trim(),
+            HTTPSPort: httpsPort,
+            MTLSPort: mtlsPort,
+          },
+      {
+        onSuccess(data) {
+          notifySuccess('Success', 'LogForge configured successfully');
+          setShowEmbeddedUI(data.Enabled);
+        },
+      }
+    );
+  }
+
+  async function handleClear(removeManagedStack: boolean) {
+    const confirmed = await confirmDelete(
+      removeManagedStack
+        ? 'Remove the managed LogForge appliance stack and clear this registration?'
+        : 'Clear the LogForge registration from Portainer?'
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    uninstallMutation.mutate(
+      { RemoveManagedStack: removeManagedStack },
+      {
+        onSuccess() {
+          notifySuccess('Success', 'LogForge configuration cleared');
+          setShowEmbeddedUI(false);
+        },
+      }
+    );
+  }
+}
+
+interface StatusWidgetProps {
+  status?: LogForgeStatus;
+  isLoading: boolean;
+  isClearing: boolean;
+  isAdmin: boolean;
+  onOpen(): void;
+  onClear(): void;
+  onRemove(): void;
+}
+
+function StatusWidget({
+  status,
+  isLoading,
+  isClearing,
+  isAdmin,
+  onOpen,
+  onClear,
+  onRemove,
+}: StatusWidgetProps) {
+  const visibleEnvironments = status?.Access?.Endpoints?.length ?? 0;
+  const canOpen = Boolean(status?.Access?.Allowed);
+
+  return (
+    <Widget>
+      <WidgetTitle icon={ShieldCheck} title="Appliance status">
+        {status && <HealthBadge status={status.Health.Status} />}
+      </WidgetTitle>
+      <WidgetBody loading={isLoading}>
+        {status?.Enabled ? (
+          <div className="flex flex-col gap-4">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <StatusField
+                label="Mode"
+                value={status.Managed ? 'Managed' : 'Registered'}
+              />
+              <StatusField
+                label="Appliance URL"
+                value={status.ApplianceUrl || '-'}
+              />
+              <StatusField label="Proxy path" value={status.BrowserProxyPath} />
+              <StatusField
+                label="Service key"
+                value={
+                  status.ServiceKeyPrefix
+                    ? `${status.ServiceKeyPrefix}...`
+                    : '-'
+                }
+              />
+              <StatusField
+                label="Managed auth"
+                value={status.ManagedAuthReady ? 'Ready' : 'Not ready'}
+              />
+              <StatusField
+                label="Stack"
+                value={status.Stack?.Name || status.StackName || '-'}
+              />
+              <StatusField
+                label="Stack status"
+                value={status.Stack ? String(status.Stack.Status) : '-'}
+              />
+              <StatusField label="Image" value={status.ApplianceImage || '-'} />
+              <StatusField
+                label="Visible Docker environments"
+                value={String(visibleEnvironments)}
+              />
+              <StatusField
+                label="Health checked"
+                value={
+                  status.Health.CheckedAt
+                    ? new Date(status.Health.CheckedAt * 1000).toLocaleString()
+                    : '-'
+                }
+              />
+            </div>
+
+            {status.Health.Message && status.Health.Status !== 'healthy' && (
+              <Alert color="warn" title="Health check">
+                {status.Health.Message}
+              </Alert>
+            )}
+
+            {!canOpen && (
+              <Alert color="warn" title="Access limited">
+                Your Portainer account does not have access to any Docker
+                environment monitored by LogForge.
+              </Alert>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              {canOpen && (
+                <Button
+                  icon={ExternalLink}
+                  onClick={onOpen}
+                  data-cy="logforge-open-ui"
+                >
+                  Open embedded UI
+                </Button>
+              )}
+              {isAdmin && (
+                <LoadingButton
+                  color="default"
+                  icon={RefreshCw}
+                  isLoading={isClearing}
+                  loadingText="Clearing..."
+                  onClick={onClear}
+                  type="button"
+                  data-cy="logforge-clear-registration"
+                >
+                  Clear registration
+                </LoadingButton>
+              )}
+              {isAdmin && status.Managed && (
+                <LoadingButton
+                  color="dangerlight"
+                  icon={Trash2}
+                  isLoading={isClearing}
+                  loadingText="Removing..."
+                  onClick={onRemove}
+                  type="button"
+                  data-cy="logforge-remove-appliance"
+                >
+                  Remove managed appliance
+                </LoadingButton>
+              )}
+            </div>
+          </div>
+        ) : (
+          <Alert color="info" title="Not configured">
+            {isAdmin
+              ? 'LogForge is not registered with this Portainer instance.'
+              : 'LogForge is not configured. Ask a Portainer administrator to configure a central appliance.'}
+          </Alert>
+        )}
+      </WidgetBody>
+    </Widget>
+  );
+}
+
+interface EmbeddedLogForgeUIProps {
+  status: LogForgeStatus;
+  iframeSrc: string;
+  onBack(): void;
+}
+
+function EmbeddedLogForgeUI({
+  status,
+  iframeSrc,
+  onBack,
+}: EmbeddedLogForgeUIProps) {
+  return (
+    <Widget aria-label="Embedded LogForge UI">
+      <WidgetTitle icon={Activity} title="LogForge UI">
+        <HealthBadge status={status.Health.Status} />
+      </WidgetTitle>
+      <WidgetBody className="no-padding">
+        <div className="flex min-h-0 flex-col">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-solid border-gray-4 px-5 py-3">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-7">
+              <InlineStatus
+                label="Mode"
+                value={status.Managed ? 'Managed' : 'Registered'}
+              />
+              <InlineStatus
+                label="Stack"
+                value={status.Stack?.Name || status.StackName || '-'}
+              />
+              <InlineStatus label="Proxy" value={status.BrowserProxyPath} />
+            </div>
+            <Button
+              color="default"
+              icon={ArrowLeft}
+              onClick={onBack}
+              data-cy="logforge-back-to-status"
+            >
+              Back to status
+            </Button>
+          </div>
+          <div className="h-[calc(100vh-145px)] min-h-[520px] overflow-hidden bg-white">
+            <iframe
+              title="LogForge"
+              src={iframeSrc}
+              className="border-0 bg-white"
+              style={embeddedUIFrameStyle}
+            />
+          </div>
+        </div>
+      </WidgetBody>
+    </Widget>
+  );
+}
+
+function InlineStatus({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="min-w-0">
+      <span className="font-medium text-gray-9">{label}:</span>{' '}
+      <span className="break-all">{value}</span>
+    </span>
+  );
+}
+
+interface SetupWidgetProps {
+  mode: SetupMode;
+  setMode(mode: SetupMode): void;
+  applianceUrl: string;
+  setApplianceUrl(value: string): void;
+  image: string;
+  setImage(value: string): void;
+  stackName: string;
+  setStackName(value: string): void;
+  centralFQDN: string;
+  setCentralFQDN(value: string): void;
+  httpsPort: number;
+  setHTTPSPort(value: number): void;
+  mtlsPort: number;
+  setMTLSPort(value: number): void;
+  selectedEndpointId: string;
+  setSelectedEndpointId(value: string): void;
+  dockerEnvironments: Array<{ Id: number; Name: string }>;
+  isEnvironmentLoading: boolean;
+  isSubmitting: boolean;
+  canSubmit: boolean;
+  onSubmit(event: FormEvent<HTMLFormElement>): void;
+}
+
+function SetupWidget({
+  mode,
+  setMode,
+  applianceUrl,
+  setApplianceUrl,
+  image,
+  setImage,
+  stackName,
+  setStackName,
+  centralFQDN,
+  setCentralFQDN,
+  httpsPort,
+  setHTTPSPort,
+  mtlsPort,
+  setMTLSPort,
+  selectedEndpointId,
+  setSelectedEndpointId,
+  dockerEnvironments,
+  isEnvironmentLoading,
+  isSubmitting,
+  canSubmit,
+  onSubmit,
+}: SetupWidgetProps) {
+  return (
+    <Widget>
+      <WidgetTitle icon={PlugZap} title="Setup" />
+      <WidgetBody>
+        <form className="form-horizontal" onSubmit={onSubmit}>
+          <div className="form-group">
+            <div className="col-sm-12">
+              <div className="btn-group" role="group" aria-label="Setup mode">
+                <Button
+                  color={mode === 'register' ? 'primary' : 'default'}
+                  onClick={() => setMode('register')}
+                  type="button"
+                  data-cy="logforge-register-mode"
+                >
+                  Register
+                </Button>
+                <Button
+                  color={mode === 'install' ? 'primary' : 'default'}
+                  onClick={() => setMode('install')}
+                  type="button"
+                  data-cy="logforge-install-mode"
+                >
+                  Install
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {mode === 'install' && (
+            <>
+              <FormRow label="Environment">
+                <select
+                  className="form-control"
+                  value={selectedEndpointId}
+                  onChange={(event) =>
+                    setSelectedEndpointId(event.target.value)
+                  }
+                  disabled={isEnvironmentLoading}
+                  data-cy="logforge-environment-select"
+                >
+                  <option value="">Select a Docker environment</option>
+                  {dockerEnvironments.map((environment) => (
+                    <option key={environment.Id} value={environment.Id}>
+                      {environment.Name}
+                    </option>
+                  ))}
+                </select>
+              </FormRow>
+              <FormRow label="Stack name">
+                <input
+                  className="form-control"
+                  value={stackName}
+                  onChange={(event) => setStackName(event.target.value)}
+                  data-cy="logforge-stack-name"
+                />
+              </FormRow>
+              <FormRow label="Image">
+                <input
+                  className="form-control"
+                  value={image}
+                  onChange={(event) => setImage(event.target.value)}
+                  data-cy="logforge-image"
+                />
+              </FormRow>
+              <FormRow label="Central FQDN">
+                <input
+                  className="form-control"
+                  value={centralFQDN}
+                  onChange={(event) => setCentralFQDN(event.target.value)}
+                  data-cy="logforge-central-fqdn"
+                />
+              </FormRow>
+              <FormRow label="HTTPS port">
+                <input
+                  className="form-control"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={httpsPort}
+                  onChange={(event) => setHTTPSPort(Number(event.target.value))}
+                  data-cy="logforge-https-port"
+                />
+              </FormRow>
+              <FormRow label="mTLS port">
+                <input
+                  className="form-control"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={mtlsPort}
+                  onChange={(event) => setMTLSPort(Number(event.target.value))}
+                  data-cy="logforge-mtls-port"
+                />
+              </FormRow>
+            </>
+          )}
+
+          <FormRow label="Appliance URL">
+            <input
+              className="form-control"
+              value={applianceUrl}
+              onChange={(event) => setApplianceUrl(event.target.value)}
+              placeholder={
+                mode === 'install'
+                  ? 'https://127.0.0.1:9444'
+                  : 'https://logforge.example.com'
+              }
+              data-cy="logforge-appliance-url"
+            />
+          </FormRow>
+
+          <div className="form-group">
+            <div className="col-sm-12">
+              <LoadingButton
+                isLoading={isSubmitting}
+                loadingText="Configuring..."
+                disabled={!canSubmit}
+                data-cy="logforge-submit"
+              >
+                {mode === 'install' ? 'Install LogForge' : 'Register LogForge'}
+              </LoadingButton>
+            </div>
+          </div>
+        </form>
+      </WidgetBody>
+    </Widget>
+  );
+}
+
+function StatusField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded border border-solid border-gray-4 p-3">
+      <div className="text-xs font-medium uppercase text-gray-6">{label}</div>
+      <div
+        className="mt-1 truncate text-sm font-medium text-gray-9"
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function FormRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="form-group">
+      <label className="col-sm-3 col-lg-2 control-label text-left">
+        {label}
+      </label>
+      <div className="col-sm-9 col-lg-6">{children}</div>
+    </div>
+  );
+}
+
+function HealthBadge({ status }: { status: string }) {
+  const type: BadgeType =
+    status === 'healthy'
+      ? 'success'
+      : status === 'unhealthy'
+        ? 'danger'
+        : status === 'not_configured'
+          ? 'muted'
+          : 'warn';
+
+  return (
+    <Badge type={type} data-cy="logforge-health-badge">
+      {status.replace('_', ' ')}
+    </Badge>
+  );
+}

--- a/app/react/portainer/logforge/LogForgeView.tsx
+++ b/app/react/portainer/logforge/LogForgeView.tsx
@@ -22,6 +22,7 @@ import { Badge, BadgeType } from '@@/Badge';
 import { Button, LoadingButton } from '@@/buttons';
 import { confirmDelete } from '@@/modals/confirm';
 import { PageHeader } from '@@/PageHeader';
+import { SwitchField } from '@@/form-components/SwitchField';
 import { Widget, WidgetBody, WidgetTitle } from '@@/Widget';
 
 import {
@@ -56,6 +57,7 @@ export function LogForgeView() {
   const [httpsPort, setHTTPSPort] = useState(9444);
   const [mtlsPort, setMTLSPort] = useState(8443);
   const [selectedEndpointId, setSelectedEndpointId] = useState('');
+  const [tlsSkipVerify, setTLSSkipVerify] = useState(false);
   const [showEmbeddedUI, setShowEmbeddedUI] = useState(false);
 
   const isAdmin = useIsPureAdmin();
@@ -144,6 +146,8 @@ export function LogForgeView() {
                 setMTLSPort={setMTLSPort}
                 selectedEndpointId={selectedEndpointId}
                 setSelectedEndpointId={setSelectedEndpointId}
+                tlsSkipVerify={tlsSkipVerify}
+                setTLSSkipVerify={setTLSSkipVerify}
                 dockerEnvironments={dockerEnvironments}
                 isEnvironmentLoading={environmentList.isLoading}
                 isSubmitting={installMutation.isLoading}
@@ -164,6 +168,7 @@ export function LogForgeView() {
       mode === 'register'
         ? {
             ApplianceUrl: applianceUrl.trim(),
+            TLSSkipVerify: tlsSkipVerify,
           }
         : {
             EndpointId: Number(selectedEndpointId),
@@ -257,6 +262,10 @@ function StatusWidget({
               <StatusField
                 label="Managed auth"
                 value={status.ManagedAuthReady ? 'Ready' : 'Not ready'}
+              />
+              <StatusField
+                label="TLS verification"
+                value={status.TLSSkipVerify ? 'Skipped' : 'Enabled'}
               />
               <StatusField
                 label="Stack"
@@ -423,6 +432,8 @@ interface SetupWidgetProps {
   setMTLSPort(value: number): void;
   selectedEndpointId: string;
   setSelectedEndpointId(value: string): void;
+  tlsSkipVerify: boolean;
+  setTLSSkipVerify(value: boolean): void;
   dockerEnvironments: Array<{ Id: number; Name: string }>;
   isEnvironmentLoading: boolean;
   isSubmitting: boolean;
@@ -447,6 +458,8 @@ function SetupWidget({
   setMTLSPort,
   selectedEndpointId,
   setSelectedEndpointId,
+  tlsSkipVerify,
+  setTLSSkipVerify,
   dockerEnvironments,
   isEnvironmentLoading,
   isSubmitting,
@@ -564,6 +577,18 @@ function SetupWidget({
             />
           </FormRow>
 
+          {mode === 'register' && (
+            <SwitchField
+              label="Skip TLS verification"
+              labelClass="col-sm-3 col-lg-2"
+              name="logforge-tls-skip-verify"
+              checked={tlsSkipVerify}
+              onChange={setTLSSkipVerify}
+              tooltip="Enable only for an explicitly trusted appliance that uses a self-signed certificate."
+              data-cy="logforge-tls-skip-verify"
+            />
+          )}
+
           <div className="form-group">
             <div className="col-sm-12">
               <LoadingButton
@@ -619,7 +644,7 @@ function HealthBadge({ status }: { status: string }) {
 
   return (
     <Badge type={type} data-cy="logforge-health-badge">
-      {status.replace('_', ' ')}
+      {status.replaceAll('_', ' ')}
     </Badge>
   );
 }

--- a/app/react/portainer/logforge/index.ts
+++ b/app/react/portainer/logforge/index.ts
@@ -1,0 +1,1 @@
+export { LogForgeView } from './LogForgeView';

--- a/app/react/portainer/logforge/logforge.service.ts
+++ b/app/react/portainer/logforge/logforge.service.ts
@@ -1,0 +1,48 @@
+import axios, { parseAxiosError } from '@/portainer/services/axios/axios';
+
+import {
+  LogForgeInstallPayload,
+  LogForgeStatus,
+  LogForgeUninstallPayload,
+} from './types';
+
+export async function getLogForgeStatus() {
+  try {
+    const { data } = await axios.get<LogForgeStatus>(buildUrl('status'));
+    return data;
+  } catch (e) {
+    throw parseAxiosError(e as Error, 'Unable to retrieve LogForge status');
+  }
+}
+
+export async function installOrRegisterLogForge(
+  payload: LogForgeInstallPayload
+) {
+  try {
+    const { data } = await axios.post<LogForgeStatus>(
+      buildUrl('install'),
+      payload
+    );
+    return data;
+  } catch (e) {
+    throw parseAxiosError(e as Error, 'Unable to configure LogForge');
+  }
+}
+
+export async function uninstallOrClearLogForge(
+  payload: LogForgeUninstallPayload
+) {
+  try {
+    const { data } = await axios.post<LogForgeStatus>(
+      buildUrl('uninstall'),
+      payload
+    );
+    return data;
+  } catch (e) {
+    throw parseAxiosError(e as Error, 'Unable to clear LogForge configuration');
+  }
+}
+
+export function buildUrl(action: string) {
+  return `logforge/${action}`;
+}

--- a/app/react/portainer/logforge/queries.ts
+++ b/app/react/portainer/logforge/queries.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  mutationOptions,
+  withError,
+  withInvalidate,
+} from '@/react-tools/react-query';
+
+import {
+  getLogForgeStatus,
+  installOrRegisterLogForge,
+  uninstallOrClearLogForge,
+} from './logforge.service';
+
+export const logForgeQueryKeys = {
+  base: () => ['logforge'] as const,
+  status: () => [...logForgeQueryKeys.base(), 'status'] as const,
+};
+
+export function useLogForgeStatus() {
+  return useQuery(logForgeQueryKeys.status(), getLogForgeStatus, {
+    staleTime: 5000,
+    refetchInterval: 30000,
+    ...withError('Unable to retrieve LogForge status'),
+  });
+}
+
+export function useInstallOrRegisterLogForgeMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    installOrRegisterLogForge,
+    mutationOptions(
+      withInvalidate(queryClient, [logForgeQueryKeys.status()]),
+      withError('Unable to configure LogForge')
+    )
+  );
+}
+
+export function useUninstallOrClearLogForgeMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    uninstallOrClearLogForge,
+    mutationOptions(
+      withInvalidate(queryClient, [logForgeQueryKeys.status()]),
+      withError('Unable to clear LogForge configuration')
+    )
+  );
+}

--- a/app/react/portainer/logforge/types.ts
+++ b/app/react/portainer/logforge/types.ts
@@ -1,0 +1,69 @@
+import { EnvironmentId } from '../environments/types';
+
+export interface LogForgeHealth {
+  Status: 'not_configured' | 'healthy' | 'unhealthy' | string;
+  Message?: string;
+  StatusCode?: number;
+  Version?: string;
+  CheckedAt?: number;
+}
+
+export interface LogForgeStackSummary {
+  Id: number;
+  Name: string;
+  EndpointId: EnvironmentId;
+  Status: number;
+}
+
+export interface LogForgeEndpointScope {
+  Id: EnvironmentId;
+  Name: string;
+  Role: 'admin' | 'write' | 'read_only' | string;
+  RoleId?: number;
+}
+
+export interface LogForgeAccess {
+  Allowed: boolean;
+  IsAdmin: boolean;
+  UserId?: number;
+  Username?: string;
+  TeamIds?: number[];
+  Endpoints?: LogForgeEndpointScope[];
+}
+
+export interface LogForgeStatus {
+  Enabled: boolean;
+  Managed: boolean;
+  ApplianceStackId?: number;
+  ApplianceEndpointId?: EnvironmentId;
+  ApplianceUrl?: string;
+  ApplianceHostHeader?: string;
+  BrowserProxyPath: string;
+  ApplianceImage?: string;
+  StackName?: string;
+  PortainerInstanceId?: string;
+  ServiceKeyPrefix?: string;
+  ServiceKeyCreatedAt?: number;
+  ServiceKeyLastUsedAt?: number;
+  ServiceKeyRotatedAt?: number;
+  ManagedAuthReady: boolean;
+  Stack?: LogForgeStackSummary;
+  Health: LogForgeHealth;
+  Access: LogForgeAccess;
+}
+
+export interface LogForgeInstallPayload {
+  EndpointId?: EnvironmentId;
+  ApplianceUrl?: string;
+  ApplianceHostHeader?: string;
+  Image?: string;
+  StackName?: string;
+  CentralFQDN?: string;
+  HTTPSPort?: number;
+  MTLSPort?: number;
+  RemoteAgentImage?: string;
+}
+
+export interface LogForgeUninstallPayload {
+  RemoveManagedStack: boolean;
+}

--- a/app/react/portainer/logforge/types.ts
+++ b/app/react/portainer/logforge/types.ts
@@ -38,6 +38,7 @@ export interface LogForgeStatus {
   ApplianceEndpointId?: EnvironmentId;
   ApplianceUrl?: string;
   ApplianceHostHeader?: string;
+  TLSSkipVerify: boolean;
   BrowserProxyPath: string;
   ApplianceImage?: string;
   StackName?: string;
@@ -56,6 +57,7 @@ export interface LogForgeInstallPayload {
   EndpointId?: EnvironmentId;
   ApplianceUrl?: string;
   ApplianceHostHeader?: string;
+  TLSSkipVerify?: boolean;
   Image?: string;
   StackName?: string;
   CentralFQDN?: string;

--- a/app/react/sidebar/ObservabilitySidebar.test.tsx
+++ b/app/react/sidebar/ObservabilitySidebar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+
+import { UserViewModel } from '@/portainer/models/user';
+import { withUserProvider } from '@/react/test-utils/withUserProvider';
+import { withTestRouter } from '@/react/test-utils/withRouter';
+
+import { TestSidebarProvider } from './useSidebarState';
+import { ObservabilitySidebar } from './ObservabilitySidebar';
+
+test('renders LogForge for authenticated users', () => {
+  renderComponent();
+
+  expect(screen.getByText('Observability')).toBeInTheDocument();
+  expect(screen.getByText('LogForge')).toBeInTheDocument();
+});
+
+function renderComponent() {
+  const user = new UserViewModel({ Username: 'user' });
+  const Wrapped = withUserProvider(withTestRouter(ObservabilitySidebar), user);
+
+  return render(
+    <TestSidebarProvider>
+      <Wrapped />
+    </TestSidebarProvider>
+  );
+}

--- a/app/react/sidebar/ObservabilitySidebar.tsx
+++ b/app/react/sidebar/ObservabilitySidebar.tsx
@@ -1,0 +1,17 @@
+import { Activity } from 'lucide-react';
+
+import { SidebarItem } from './SidebarItem';
+import { SidebarSection } from './SidebarSection';
+
+export function ObservabilitySidebar() {
+  return (
+    <SidebarSection title="Observability">
+      <SidebarItem
+        label="LogForge"
+        to="portainer.logforge"
+        icon={Activity}
+        data-cy="portainerSidebar-logforge"
+      />
+    </SidebarSection>
+  );
+}

--- a/app/react/sidebar/Sidebar.tsx
+++ b/app/react/sidebar/Sidebar.tsx
@@ -15,6 +15,7 @@ import { Header } from './Header';
 import { SidebarProvider, useSidebarState } from './useSidebarState';
 import { UpgradeBEBannerWrapper } from './UpgradeBEBanner';
 import { AppDeliverySidebar } from './AppDeliverySidebar';
+import { ObservabilitySidebar } from './ObservabilitySidebar';
 
 export function Sidebar() {
   return (
@@ -72,6 +73,8 @@ function InnerSidebar() {
             <EnvironmentSidebar />
 
             <AppDeliverySidebar />
+
+            <ObservabilitySidebar />
 
             {isAdmin && <EdgeComputeSidebar />}
 

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -109,7 +109,7 @@ module.exports = {
     port: process.env.PORT || 8999,
     proxy: [
       {
-        context: ['/api'],
+        context: ['/api', '/logforge'],
         target: 'http://localhost:9000',
         ws: true,
       },


### PR DESCRIPTION
## Summary

- add native LogForge settings persistence, API routes, managed installation, external appliance registration, and uninstall handling
- add an embedded LogForge UI with same-origin proxying, managed identity signing, and endpoint-scoped access
- preserve ordinary LogForge JSON API responses while continuing to rewrite embedded browser assets and route manifests, so local-agent enrollment keeps the correct `/unicron/api/agent/ws` WebSocket path
- add the Portainer LogForge view, Observability navigation, client queries, and focused backend/frontend coverage
- default managed deployments to the dedicated `logforge/unicron:portainer-integration` and `logforge/unicron-agent:portainer-integration` image tags
- force managed appliance deployments to pull the configured image tag through Compose `pull_policy: always`

## Why

This gives Portainer administrators a native way to deploy or connect LogForge and lets authorized users open the embedded experience without exposing Portainer browser credentials to the appliance. Non-admin managed access is limited to endpoint-scoped read-only claims. Always pulling the managed appliance prevents an older local copy of the Portainer integration tag from being reused.

## User impact

Portainer gains an Observability > LogForge workflow for managed Docker deployment or external appliance registration. The embedded UI remains same-origin through Portainer, while managed identity and service credentials stay server-side.

## Validation

- `go test ./api/http/handler/logforge`
- `go test ./api/http/handler/logforge -count=1` after merging the local-agent enrollment proxy fix
- `go vet ./api/http/handler/logforge`
- `pnpm test app/react/portainer/logforge/LogForgeView.test.tsx app/react/sidebar/ObservabilitySidebar.test.tsx --run` (6 tests)
- `pnpm typecheck`
- `make build-server`
- `make build-client`
- pulled `logforge/unicron:portainer-integration` (`sha256:1740b967b45efa7faf39bbd2975cc538eb0f524f56471346bfa0b02b9500ce27`)
- pulled `logforge/unicron-agent:portainer-integration` (`sha256:91a702850fd7df62e9b5b71ef210d653fede0a933b21dcdf36fe2ee1b73a7494`)
- completed a live Portainer managed-install browser flow; the generated stack includes `pull_policy: always`, the running healthy appliance matches the published digest, managed authentication is ready, and the embedded UI connects successfully
- verified the generated local-agent enrollment response preserves `wss://unicron.central:8443/unicron/api/agent/ws` and does not rewrite it to `/logforge/ui/api/agent/ws`
- verified the generated agent enrollment command uses `logforge/unicron-agent:portainer-integration`, and smoke-started the published agent binary
- verified a standard Portainer account with no Docker environment access receives `403` from both the LogForge UI proxy and install endpoint; the UI shows the access-limited state and exposes no embedded-UI or install controls

## Publication status

Both dedicated Portainer integration image tags are published and were pulled and tested above.
