### PR TITLE
fix(libstack): prune stale inline registry auths

### DIFF
--- a/pkg/libstack/dockercli.go
+++ b/pkg/libstack/dockercli.go
@@ -65,6 +65,11 @@ func WithCli(
 
 	defer logs.CloseAndLogErr(cli.Client())
 
+	// Inline auths loaded from Docker config may outlive registries deleted from
+	// Portainer. Rebuild them from the current Portainer registry list for each
+	// operation so stale credentials are not used by stack deploys.
+	cli.ConfigFile().AuthConfigs = make(map[string]configtypes.AuthConfig, len(options.Registries))
+
 	for _, r := range options.Registries {
 		if r.ServerAddress == "" || r.ServerAddress == registry.DefaultNamespace {
 			r.ServerAddress = registry.IndexServer

--- a/pkg/libstack/dockercli_test.go
+++ b/pkg/libstack/dockercli_test.go
@@ -2,9 +2,13 @@ package libstack
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +39,68 @@ func TestWithCli_NoHeaders(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+func TestWithCli_PrunesStaleInlineRegistryAuthsWhenNoRegistriesAreProvided(t *testing.T) {
+	configDir := tempDockerConfigDir(t, `{
+	"auths": {
+		"ghcr.io": {
+			"auth": "dXNlcjpwYXNz"
+		}
+	}
+}`)
+
+	config.SetDir(configDir)
+
+	err := WithCli(
+		t.Context(),
+		DockerCliOptions{},
+		func(_ context.Context, cli *command.DockerCli) error {
+			require.Empty(t, cli.ConfigFile().AuthConfigs)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+}
+
+func TestWithCli_PrunesStaleInlineRegistryAuthsBeforeInjectingRegistries(t *testing.T) {
+	configDir := tempDockerConfigDir(t, `{
+	"auths": {
+		"ghcr.io": {
+			"auth": "dXNlcjpwYXNz"
+		}
+	}
+}`)
+
+	config.SetDir(configDir)
+
+	err := WithCli(
+		t.Context(),
+		DockerCliOptions{
+			Registries: []configtypes.AuthConfig{
+				{
+					Username:      "current-user",
+					Password:      "current-password",
+					ServerAddress: "registry.example.com",
+				},
+			},
+		},
+		func(_ context.Context, cli *command.DockerCli) error {
+			require.NotContains(t, cli.ConfigFile().AuthConfigs, "ghcr.io")
+			require.Contains(t, cli.ConfigFile().AuthConfigs, "registry.example.com")
+			require.Equal(t, "current-user", cli.ConfigFile().AuthConfigs["registry.example.com"].Username)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+}
+
+func tempDockerConfigDir(t *testing.T, configJSON string) string {
+	t.Helper()
+
+	configDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0o644)
+	require.NoError(t, err)
+
+	return configDir
 }


### PR DESCRIPTION
## Summary
- Rebuild Docker CLI inline registry auths from the current Portainer registry list on each operation
- Prevent stale auths from an existing Docker config from being reused after registries are deleted
- Add regression coverage for stale auth pruning with and without replacement registries

## Test Plan
- go test -count=1 ./pkg/libstack ./pkg/libstack/compose ./pkg/libstack/swarm